### PR TITLE
Limiting the in memory queue sizes for slower handlers

### DIFF
--- a/src/Transport/Config/ContainerConfiguration.cs
+++ b/src/Transport/Config/ContainerConfiguration.cs
@@ -28,6 +28,7 @@
         void ConfigureReceiveInfrastructure(FeatureConfigurationContext context, AzureServiceBusQueueConfig configSection)
         {
             context.Container.ConfigureComponent<AzureServiceBusDequeueStrategy>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureProperty<AzureServiceBusDequeueStrategy>(t => t.BatchSize, configSection.BatchSize);
 
             context.Container.ConfigureComponent<AzureServiceBusQueueNotifier>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureProperty<AzureServiceBusQueueNotifier>(t => t.ServerWaitTime, configSection.ServerWaitTime);
@@ -64,6 +65,7 @@
 
             context.Container.ConfigureComponent<ManageQueueClientsLifeCycle>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<AzureServicebusQueueClientCreator>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureProperty<AzureServicebusQueueClientCreator>(t => t.BatchSize, configSection.BatchSize);
 
             context.Container.ConfigureComponent<AzureServiceBusTopologyCreator>(DependencyLifecycle.InstancePerCall);
 
@@ -94,7 +96,7 @@
             context.Container.ConfigureProperty<AzureServiceBusTopicCreator>(t => t.EnablePartitioning, configSection.EnablePartitioning);
 
             context.Container.ConfigureComponent<AzureServicebusSubscriptionClientCreator>(DependencyLifecycle.InstancePerCall);
-            
+
             context.Container.ConfigureComponent<AzureServiceBusSubscriptionCreator>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureProperty<AzureServiceBusSubscriptionCreator>(t => t.LockDuration, TimeSpan.FromMilliseconds(configSection.LockDuration));
             context.Container.ConfigureProperty<AzureServiceBusSubscriptionCreator>(t => t.RequiresSession, configSection.RequiresSession);

--- a/src/Transport/Creation/Clients/AzureServicebusQueueClientCreator.cs
+++ b/src/Transport/Creation/Clients/AzureServicebusQueueClientCreator.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         public QueueClient Create(string description, MessagingFactory factory)
         {
             var client = factory.CreateQueueClient(description, ShouldRetry() ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
-            client.PrefetchCount = BatchSize; // todo make configurable
+            client.PrefetchCount = BatchSize;
             return client;
         }
 

--- a/src/Transport/Creation/Clients/AzureServicebusQueueClientCreator.cs
+++ b/src/Transport/Creation/Clients/AzureServicebusQueueClientCreator.cs
@@ -11,6 +11,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             this.config = config;
         }
 
+        public int BatchSize { get; set; }
+
         public QueueClient Create(QueueDescription description, MessagingFactory factory)
         {
             return Create(description.Path, factory);
@@ -19,7 +21,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         public QueueClient Create(string description, MessagingFactory factory)
         {
             var client = factory.CreateQueueClient(description, ShouldRetry() ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
-            client.PrefetchCount = 100; // todo make configurable
+            client.PrefetchCount = BatchSize; // todo make configurable
             return client;
         }
 

--- a/src/Transport/Receiving/AzureServiceBusDequeueStrategy.cs
+++ b/src/Transport/Receiving/AzureServiceBusDequeueStrategy.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
     using System.Collections.Concurrent;
     using System.Transactions;
     using Microsoft.ServiceBus.Messaging;
-    using System.Collections;
     using System.Threading;
     using System.Threading.Tasks;
     using CircuitBreakers;
@@ -24,16 +23,14 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         Func<TransportMessage, bool> tryProcessMessage;
         Action<TransportMessage, Exception> endProcessMessage;
         TransactionOptions transactionOptions;
-        Queue pendingMessages = Queue.Synchronized(new Queue());
+
+        BlockingCollection<BrokeredMessage> pendingMessages;
+
         ConcurrentDictionary<string, INotifyReceivedBrokeredMessages> notifiers = new ConcurrentDictionary<string, INotifyReceivedBrokeredMessages>();
         CancellationTokenSource tokenSource;
         RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
 
         ILog logger = LogManager.GetLogger(typeof(AzureServiceBusDequeueStrategy));
-        
-        const int PeekInterval = 50;
-        const int MaximumWaitTimeWhenIdle = 1000;
-        int timeToDelayNextPeek;
 
         public AzureServiceBusDequeueStrategy(ITopology topology, CriticalError criticalError)
         {
@@ -41,7 +38,9 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             this.criticalError = criticalError;
             circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("AzureStoragePollingDequeueStrategy", TimeSpan.FromSeconds(30), ex => criticalError.Raise("Failed to receive message from Azure ServiceBus.", ex));
         }
-        
+
+        public int BatchSize { get; set; }
+
         /// <summary>
         /// Initializes the <see cref="IDequeueMessages"/>.
         /// </summary>
@@ -65,8 +64,10 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         /// <param name="maximumConcurrencyLevel">Indicates the maximum concurrency level this <see cref="IDequeueMessages"/> is able to support.</param>
         public virtual void Start(int maximumConcurrencyLevel)
         {
+            pendingMessages = new BlockingCollection<BrokeredMessage>(BatchSize * maximumConcurrencyLevel);
+
             CreateAndTrackNotifier();
-            
+
             tokenSource = new CancellationTokenSource();
 
             for (var i = 0; i < maximumConcurrencyLevel; i++)
@@ -82,18 +83,18 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             Task.Factory
                 .StartNew(TryProcessMessage, token, token, TaskCreationOptions.LongRunning, TaskScheduler.Default)
                 .ContinueWith(t =>
+                {
+                    if (t.Exception != null)
                     {
-                        if (t.Exception != null)
+                        t.Exception.Handle(ex =>
                         {
-                            t.Exception.Handle(ex =>
-                                {
-                                    circuitBreaker.Failure(ex);
-                                    return true;
-                                });
-                        }
+                            circuitBreaker.Failure(ex);
+                            return true;
+                        });
+                    }
 
-                        StartThread();
-                    }, TaskContinuationOptions.OnlyOnFaulted);
+                    StartThread();
+                }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
 
@@ -103,25 +104,21 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                 BrokeredMessage brokeredMessage = null;
+                BrokeredMessage brokeredMessage;
 
-                 if (pendingMessages.Count > 0) brokeredMessage = pendingMessages.Dequeue() as BrokeredMessage;
-                
-                 if (brokeredMessage == null)
-                 {
-                     if (timeToDelayNextPeek < MaximumWaitTimeWhenIdle) timeToDelayNextPeek += PeekInterval;
+                while (!pendingMessages.TryTake(out brokeredMessage, 10000, cancellationToken)) ;
 
-                     Thread.Sleep(timeToDelayNextPeek);
-                     continue;
-                 }
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    continue;
+                }
 
-                 timeToDelayNextPeek = 0;
-                 Exception exception = null;
+                Exception exception = null;
 
                 // due to clock drift we may receive messages that aren't due yet according to our clock, let's put this back
-                if (brokeredMessage.ScheduledEnqueueTimeUtc > DateTime.UtcNow) 
+                if (brokeredMessage.ScheduledEnqueueTimeUtc > DateTime.UtcNow)
                 {
-                    pendingMessages.Enqueue(brokeredMessage);
+                    pendingMessages.Add(brokeredMessage);
                     continue;
                 }
 
@@ -203,7 +200,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
                 // sadly enough I can't find a public property that checks who the receiver was or if the locktoken has been set
                 // those are internal to the sdk
             }
-            
+
             return true;
         }
 
@@ -235,8 +232,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
         void NotifierFaulted(object sender, EventArgs e)
         {
-           RemoveNotifier(null, address);
-           CreateAndTrackNotifier();
+            RemoveNotifier(null, address);
+            CreateAndTrackNotifier();
         }
 
         public void TrackNotifier(Type eventType, Address original, INotifyReceivedBrokeredMessages notifier)
@@ -260,7 +257,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         {
             var key = CreateKeyFor(eventType, original);
             if (!notifiers.ContainsKey(key)) return;
-            
+
             INotifyReceivedBrokeredMessages toRemove;
             if (notifiers.TryRemove(key, out toRemove))
             {
@@ -287,8 +284,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
         void EnqueueMessage(BrokeredMessage brokeredMessage)
         {
-           // while (pendingMessages.Count > 2 * maximumConcurrencyLevel){Thread.Sleep(10);}
-
             try
             {
                 if (brokeredMessage.LockedUntilUtc <= DateTime.UtcNow)
@@ -300,15 +295,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             }
             catch (InvalidOperationException)
             {
-               // if the message was received without a peeklock mechanism you're not allowed to call LockedUntilUtc
-               // sadly enough I can't find a public property that checks who the receiver was or if the locktoken has been set
-               // those are internal to the sdk
+                // if the message was received without a peeklock mechanism you're not allowed to call LockedUntilUtc
+                // sadly enough I can't find a public property that checks who the receiver was or if the locktoken has been set
+                // those are internal to the sdk
             }
 
-            pendingMessages.Enqueue(brokeredMessage);
+            pendingMessages.Add(brokeredMessage);
         }
 
-       
+
 
         string CreateKeyFor(Type eventType, Address original)
         {

--- a/src/Transport/Receiving/AzureServiceBusDequeueStrategy.cs
+++ b/src/Transport/Receiving/AzureServiceBusDequeueStrategy.cs
@@ -113,7 +113,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
                     // due to clock drift we may receive messages that aren't due yet according to our clock, let's put this back
                     if (brokeredMessage.ScheduledEnqueueTimeUtc > DateTime.UtcNow)
                     {
-                        pendingMessages.Add(brokeredMessage);
+                        pendingMessages.Add(brokeredMessage, cancellationToken);
                         continue;
                     }
 


### PR DESCRIPTION
Using a BlockingCollection within the AzureServiceBusDequeueStrategy allows for the consumption of messages from the Azure Service Bus to match the rates through the handlers.  The size of the queue is determined by the BatchSize configuration setting.  This is also used to restrict the Azure client libraries own prefetch mechanism.