### PR TITLE
Use BatchSize to limit message consumption to handler performance

### DIFF
--- a/src/Transport/Config/ContainerConfiguration.cs
+++ b/src/Transport/Config/ContainerConfiguration.cs
@@ -28,6 +28,7 @@
         void ConfigureReceiveInfrastructure(FeatureConfigurationContext context, AzureServiceBusQueueConfig configSection)
         {
             context.Container.ConfigureComponent<AzureServiceBusDequeueStrategy>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureProperty<AzureServiceBusDequeueStrategy>(t => t.BatchSize, configSection.BatchSize);
 
             context.Container.ConfigureComponent<AzureServiceBusQueueNotifier>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureProperty<AzureServiceBusQueueNotifier>(t => t.ServerWaitTime, configSection.ServerWaitTime);
@@ -64,6 +65,7 @@
 
             context.Container.ConfigureComponent<ManageQueueClientsLifeCycle>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<AzureServicebusQueueClientCreator>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureProperty<AzureServicebusQueueClientCreator>(t => t.BatchSize, configSection.BatchSize);
 
             context.Container.ConfigureComponent<AzureServiceBusTopologyCreator>(DependencyLifecycle.InstancePerCall);
 
@@ -94,7 +96,7 @@
             context.Container.ConfigureProperty<AzureServiceBusTopicCreator>(t => t.EnablePartitioning, configSection.EnablePartitioning);
 
             context.Container.ConfigureComponent<AzureServicebusSubscriptionClientCreator>(DependencyLifecycle.InstancePerCall);
-            
+
             context.Container.ConfigureComponent<AzureServiceBusSubscriptionCreator>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureProperty<AzureServiceBusSubscriptionCreator>(t => t.LockDuration, TimeSpan.FromMilliseconds(configSection.LockDuration));
             context.Container.ConfigureProperty<AzureServiceBusSubscriptionCreator>(t => t.RequiresSession, configSection.RequiresSession);

--- a/src/Transport/Creation/Clients/AzureServicebusQueueClientCreator.cs
+++ b/src/Transport/Creation/Clients/AzureServicebusQueueClientCreator.cs
@@ -11,6 +11,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             this.config = config;
         }
 
+        public int BatchSize { get; set; }
+
         public QueueClient Create(QueueDescription description, MessagingFactory factory)
         {
             return Create(description.Path, factory);
@@ -19,7 +21,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         public QueueClient Create(string description, MessagingFactory factory)
         {
             var client = factory.CreateQueueClient(description, ShouldRetry() ? ReceiveMode.PeekLock : ReceiveMode.ReceiveAndDelete);
-            client.PrefetchCount = 100; // todo make configurable
+            client.PrefetchCount = BatchSize;
             return client;
         }
 

--- a/src/Transport/Receiving/AzureServiceBusDequeueStrategy.cs
+++ b/src/Transport/Receiving/AzureServiceBusDequeueStrategy.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
     using System.Collections.Concurrent;
     using System.Transactions;
     using Microsoft.ServiceBus.Messaging;
-    using System.Collections;
     using System.Threading;
     using System.Threading.Tasks;
     using CircuitBreakers;
@@ -24,16 +23,13 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         Func<TransportMessage, bool> tryProcessMessage;
         Action<TransportMessage, Exception> endProcessMessage;
         TransactionOptions transactionOptions;
-        Queue pendingMessages = Queue.Synchronized(new Queue());
+        BlockingCollection<BrokeredMessage> pendingMessages;
+
         ConcurrentDictionary<string, INotifyReceivedBrokeredMessages> notifiers = new ConcurrentDictionary<string, INotifyReceivedBrokeredMessages>();
         CancellationTokenSource tokenSource;
         RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
 
         ILog logger = LogManager.GetLogger(typeof(AzureServiceBusDequeueStrategy));
-        
-        const int PeekInterval = 50;
-        const int MaximumWaitTimeWhenIdle = 1000;
-        int timeToDelayNextPeek;
 
         public AzureServiceBusDequeueStrategy(ITopology topology, CriticalError criticalError)
         {
@@ -41,7 +37,9 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             this.criticalError = criticalError;
             circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("AzureStoragePollingDequeueStrategy", TimeSpan.FromSeconds(30), ex => criticalError.Raise(string.Format("Failed to receive message from Azure ServiceBus."), ex));
         }
-        
+
+        public int BatchSize { get; set; }
+
         /// <summary>
         /// Initializes the <see cref="IDequeueMessages"/>.
         /// </summary>
@@ -65,8 +63,10 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         /// <param name="maximumConcurrencyLevel">Indicates the maximum concurrency level this <see cref="IDequeueMessages"/> is able to support.</param>
         public virtual void Start(int maximumConcurrencyLevel)
         {
+            pendingMessages = new BlockingCollection<BrokeredMessage>(BatchSize * maximumConcurrencyLevel);
+
             CreateAndTrackNotifier();
-            
+
             tokenSource = new CancellationTokenSource();
 
             for (var i = 0; i < maximumConcurrencyLevel; i++)
@@ -82,46 +82,40 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             Task.Factory
                 .StartNew(TryProcessMessage, token, token, TaskCreationOptions.LongRunning, TaskScheduler.Default)
                 .ContinueWith(t =>
+                {
+                    if (t.Exception != null)
                     {
-                        if (t.Exception != null)
+                        t.Exception.Handle(ex =>
                         {
-                            t.Exception.Handle(ex =>
-                                {
-                                    circuitBreaker.Failure(ex);
-                                    return true;
-                                });
-                        }
+                            circuitBreaker.Failure(ex);
+                            return true;
+                        });
+                    }
 
-                        StartThread();
-                    }, TaskContinuationOptions.OnlyOnFaulted);
+                    StartThread();
+                }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
 
         void TryProcessMessage(object obj)
         {
-            var cancellationToken = (CancellationToken)obj;
+            var cancellationToken = (CancellationToken) obj;
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                 BrokeredMessage brokeredMessage = null;
+                BrokeredMessage brokeredMessage = pendingMessages.Take(cancellationToken);
 
-                 if (pendingMessages.Count > 0) brokeredMessage = pendingMessages.Dequeue() as BrokeredMessage;
-                
-                 if (brokeredMessage == null)
-                 {
-                     if (timeToDelayNextPeek < MaximumWaitTimeWhenIdle) timeToDelayNextPeek += PeekInterval;
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
 
-                     Thread.Sleep(timeToDelayNextPeek);
-                     continue;
-                 }
-
-                 timeToDelayNextPeek = 0;
-                 Exception exception = null;
+                Exception exception = null;
 
                 // due to clock drift we may receive messages that aren't due yet according to our clock, let's put this back
-                if (brokeredMessage.ScheduledEnqueueTimeUtc > DateTime.UtcNow) 
+                if (brokeredMessage.ScheduledEnqueueTimeUtc > DateTime.UtcNow)
                 {
-                    pendingMessages.Enqueue(brokeredMessage);
+                    pendingMessages.Add(brokeredMessage, cancellationToken);
                     continue;
                 }
 
@@ -203,7 +197,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
                 // sadly enough I can't find a public property that checks who the receiver was or if the locktoken has been set
                 // those are internal to the sdk
             }
-            
+
             return true;
         }
 
@@ -235,8 +229,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
         void NotifierFaulted(object sender, EventArgs e)
         {
-           RemoveNotifier(null, address);
-           CreateAndTrackNotifier();
+            RemoveNotifier(null, address);
+            CreateAndTrackNotifier();
         }
 
         public void TrackNotifier(Type eventType, Address original, INotifyReceivedBrokeredMessages notifier)
@@ -260,7 +254,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
         {
             var key = CreateKeyFor(eventType, original);
             if (!notifiers.ContainsKey(key)) return;
-            
+
             INotifyReceivedBrokeredMessages toRemove;
             if (notifiers.TryRemove(key, out toRemove))
             {
@@ -287,8 +281,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 
         void EnqueueMessage(BrokeredMessage brokeredMessage)
         {
-           // while (pendingMessages.Count > 2 * maximumConcurrencyLevel){Thread.Sleep(10);}
-
             try
             {
                 if (brokeredMessage.LockedUntilUtc <= DateTime.UtcNow)
@@ -300,15 +292,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
             }
             catch (InvalidOperationException)
             {
-               // if the message was received without a peeklock mechanism you're not allowed to call LockedUntilUtc
-               // sadly enough I can't find a public property that checks who the receiver was or if the locktoken has been set
-               // those are internal to the sdk
+                // if the message was received without a peeklock mechanism you're not allowed to call LockedUntilUtc
+                // sadly enough I can't find a public property that checks who the receiver was or if the locktoken has been set
+                // those are internal to the sdk
             }
 
-            pendingMessages.Enqueue(brokeredMessage);
+            pendingMessages.Add(brokeredMessage, tokenSource.Token);
         }
 
-       
+
 
         string CreateKeyFor(Type eventType, Address original)
         {


### PR DESCRIPTION
PR to address issue #34 when messages are being Dead Lettered due to large number of messages on a queue for a slow handler.

This uses a blocking collection which is sized by the BatchSize configuration setting and the number of handler threads.  

Alan.