### PR TITLE
removing CloneWithMessageId extension methods as they are not needed

### DIFF
--- a/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
+++ b/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.AzureServiceBus.Tests
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
     using Azure.WindowsAzureServiceBus.Tests;
-    using NServiceBus.Azure.Transports.WindowsAzureServiceBus;
     using Settings;
     using NUnit.Framework;
 
@@ -119,7 +118,7 @@ namespace NServiceBus.AzureServiceBus.Tests
                     counter++;
                 }
                 var sender = entityLifecycleManager.Get("myqueue", null, AzureServiceBusConnectionString.Value);
-                tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch), s => s.SendBatch(batch.CloneWithMessageId()), TimeSpan.FromSeconds(10), 5));
+                tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch), s => s.SendBatch(batch.Select(x => x.Clone())), TimeSpan.FromSeconds(10), 5));
             }
             await Task.WhenAll(tasks);
 

--- a/src/Transport/Sending/DefaultOutgoingMessageRouter.cs
+++ b/src/Transport/Sending/DefaultOutgoingMessageRouter.cs
@@ -74,7 +74,7 @@ namespace NServiceBus.AzureServiceBus
                     if (chunk.Any())
                     {
                         var currentChunk = chunk;
-                        await messageSender.RetryOnThrottleAsync(s => s.SendBatch(currentChunk), s => s.SendBatch(currentChunk.CloneWithMessageId()), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
+                        await messageSender.RetryOnThrottleAsync(s => s.SendBatch(currentChunk), s => s.SendBatch(currentChunk.Select(x => x.Clone())), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
                     }
 
                     chunk = new List<BrokeredMessage> { message };
@@ -89,7 +89,7 @@ namespace NServiceBus.AzureServiceBus
 
             if (chunk.Any())
             {
-                await messageSender.RetryOnThrottleAsync(s => s.SendBatch(chunk), s => s.SendBatch(chunk.CloneWithMessageId()), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
+                await messageSender.RetryOnThrottleAsync(s => s.SendBatch(chunk), s => s.SendBatch(chunk.Select(x => x.Clone())), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
             }
         }
 

--- a/src/Transport/Utils/BrokeredMessageExtensions.cs
+++ b/src/Transport/Utils/BrokeredMessageExtensions.cs
@@ -2,8 +2,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 {
     using Logging;
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
     using Microsoft.ServiceBus.Messaging;
@@ -80,19 +78,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
                 Log.Warn($"A timeout exception occured while trying to abandon a message, the exception was {ex.Message}", ex);
             }
             return false;
-        }
-
-        public static BrokeredMessage CloneWithMessageId(this BrokeredMessage toSend)
-        {
-            var clone = toSend.Clone();
-            clone.MessageId = toSend.MessageId;
-            toSend = clone;
-            return toSend;
-        }
-
-        public static IEnumerable<BrokeredMessage> CloneWithMessageId(this IEnumerable<BrokeredMessage> toSend)
-        {
-            return toSend.Select(message => message.CloneWithMessageId());
         }
 
         static ILog Log = LogManager.GetLogger(typeof(BrokeredMessageExtensions));


### PR DESCRIPTION
Native `BrokeredMessage.Clone` clones ID as well.