### PR TITLE
[DEAD SPIKE] Calculate message size

### DIFF
--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Seam\When_message_pump_is_failing_to_receive_messages.cs" />
     <Compile Include="Seam\When_receiving_messages.cs" />
     <Compile Include="Sending\When_batching_TransportOperations.cs" />
+    <Compile Include="Sending\When_asking_for_brokered_message_total_estimated_size.cs" />
     <Compile Include="Sending\When_retrying_on_throttle.cs" />
     <Compile Include="Sending\When_routing_outgoingmessages_to_endpoints_with_retries.cs" />
     <Compile Include="TestUtils\ConnectionString.cs" />

--- a/src/Tests/Sending/When_asking_for_brokered_message_total_estimated_size.cs
+++ b/src/Tests/Sending/When_asking_for_brokered_message_total_estimated_size.cs
@@ -1,0 +1,89 @@
+namespace NServiceBus.AzureServiceBus.Tests
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Microsoft.ServiceBus.Messaging;
+    using NServiceBus.Azure.Transports.WindowsAzureServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_asking_for_brokered_message_total_estimated_size
+    {
+        [Test]
+        public void Should_report_message_size_zero()
+        {
+            var message = new BrokeredMessage();
+
+            Assert.That(message.Size, Is.EqualTo(0), "BrokeredMessage.Size issue has been fixed and this test fixture needs to be reevaluated");
+        }
+
+        Func<int, int> TenPercentOf = originalValue => (int) (originalValue * 1.1);
+        Func<int, int> FiftennPercentOf = originalValue => (int) (originalValue * 1.15);
+
+        [Test]
+        public void Should_report_empty_message_size()
+        {
+            const int emptyMessageSize = 114;
+
+            var message = new BrokeredMessage();
+            var size = message.TotalEstimatedSize();
+
+            Assert.That(size, Is.AtLeast(TenPercentOf(emptyMessageSize)).And.LessThan(FiftennPercentOf(emptyMessageSize)), "Empty message should still have a size");
+        }
+
+        [Test]
+        public void Should_report_message_size_with_custom_properties()
+        {
+            const int emptyMessageSize = 114;
+            const int propertyNameAndValueSize = 5 + 1024;
+
+            var message = new BrokeredMessage();
+            message.Properties["prop1"] = new string('A', 1024);
+            var size = message.TotalEstimatedSize();
+
+            Assert.That(size, Is.AtLeast(TenPercentOf(emptyMessageSize + propertyNameAndValueSize)).And.LessThan(FiftennPercentOf(emptyMessageSize + propertyNameAndValueSize)));
+        }
+
+        [Test]
+        public void Should_report_message_size_with_body_as_byte_array()
+        {
+            const int emptyMessageSize = 114;
+            const int bodySize = 1024*5;
+
+            var message = new BrokeredMessage(Encoding.UTF8.GetBytes(new string('A', bodySize)));
+            var size = message.TotalEstimatedSize();
+
+            Assert.That(size, Is.AtLeast(TenPercentOf(emptyMessageSize + bodySize)).And.LessThan(FiftennPercentOf(emptyMessageSize + bodySize)));
+        }
+
+        [Test]
+        public void Should_report_message_size_with_body_as_stream_and_custom_property()
+        {
+            const int emptyMessageSize = 114;
+            const int bodySize = 1024*3;
+            const int propertyNameAndValueSize = 4 + 1024;
+            
+            var message = new BrokeredMessage(new MemoryStream(Encoding.UTF8.GetBytes(new string('A', bodySize))));
+            message.Properties["prop"] = new string('A', 1024);
+            var size = message.TotalEstimatedSize();
+
+            Assert.That(size, Is.AtLeast(TenPercentOf(emptyMessageSize + bodySize + propertyNameAndValueSize)).And.LessThan(FiftennPercentOf(emptyMessageSize + bodySize + propertyNameAndValueSize)));
+        }
+
+        [Test]
+        public void Should_report_message_size_with_body_as_byte_array_and_custom_property()
+        {
+            const int emptyMessageSize = 114;
+            const int bodySize = 1024*3;
+            const int propertyNameAndValueSize = 4 + 1024;
+            
+            var message = new BrokeredMessage(Encoding.UTF8.GetBytes(new string('A', bodySize)));
+            message.Properties["prop"] = new string('A', 1024);
+            var size = message.TotalEstimatedSize();
+
+            Assert.That(size, Is.AtLeast(TenPercentOf(emptyMessageSize + bodySize + propertyNameAndValueSize)).And.LessThan(FiftennPercentOf(emptyMessageSize + bodySize + propertyNameAndValueSize)));
+        }
+    }
+}


### PR DESCRIPTION
**WARNING** experimental code for issue #86 (Maximum batch size for brokered messages is not calculated properly)

Adding `TotalEstimatedSize` extension method on `BrokeredMessage` to estimate size of the message.

- For standard properties we grab field size (if not a string). 
- For custom and standard properties that are strings, use byte count of the value that is always assumed to be a string. 
- For custom properties also count bytes for keys. 
- Body of the message is assumed to be returned by the original `Size` property.
- In addition, add 10% of the original size.

@yvesgoeleven what do you think of this so far? I couldn't use `msg.GetBody<T>()` for two reasons:
1. We'd need to clone the message each time we need to calculate the size since accessing body more than once is prohibited. 
2. To know the `T` we'd need to have a header to indicate how body is stored. We _can't_ assume that header (unless we enforce it ourselves). 