### PR TITLE
Send poisonous message to DLQ natively

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -79,6 +79,7 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -271,6 +272,7 @@
     <Compile Include="OldTests\When_sending_an_oversized_message_without_a_transaction_scope.cs" />
     <Compile Include="OldTests\When_sending_an_oversized_message_from_a_transaction_scope.cs" />
     <Compile Include="SetupAcceptanceTests.cs" />
+    <Compile Include="TransportEncoding\When_receiving_a_message_with_unknown_transport_encoding.cs" />
     <Compile Include="TransportEncoding\When_sending_to_an_endpoint_with_different_transport_encoding.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
+++ b/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
@@ -65,7 +65,7 @@
             {
                 public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
                 {
-                    context.OutgoingHeaders["Transport-Encoding"] = "unknown";
+                    context.OutgoingHeaders["NServiceBus.Transport.Encoding"] = "unknown";
                     return Task.FromResult(0);
                 }
             }

--- a/src/AcceptanceTests/app.config
+++ b/src/AcceptanceTests/app.config
@@ -3,56 +3,55 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="NServiceBus.Core" publicKeyToken="9fc386479f8a226c" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="NServiceBus.Core" publicKeyToken="9fc386479f8a226c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup>
-<system.serviceModel>
-<extensions>
-<!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
-<behaviorExtensions>
-<add name="connectionStatusBehavior"
-type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="transportClientEndpointBehavior"
-type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="serviceRegistrySettings"
-type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-</behaviorExtensions>
-<bindingElementExtensions>
-<add name="netMessagingTransport"
-type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="tcpRelayTransport"
-type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="httpRelayTransport"
-type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="httpsRelayTransport"
-type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="onewayRelayTransport"
-type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-</bindingElementExtensions>
-<bindingExtensions>
-<add name="basicHttpRelayBinding"
-type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="webHttpRelayBinding"
-type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="ws2007HttpRelayBinding"
-type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="netTcpRelayBinding"
-type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="netOnewayRelayBinding"
-type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="netEventRelayBinding"
-type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-<add name="netMessagingBinding"
-type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-</bindingExtensions>
-</extensions>
-</system.serviceModel>
-<appSettings>
-<!-- Service Bus specific app setings for messaging connections -->
-<add key="Microsoft.ServiceBus.ConnectionString"
-value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]"/>
-</appSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+  <system.serviceModel>
+    <extensions>
+      <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
+      <behaviorExtensions>
+        <add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </behaviorExtensions>
+      <bindingElementExtensions>
+        <add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </bindingElementExtensions>
+      <bindingExtensions>
+        <add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </bindingExtensions>
+    </extensions>
+  </system.serviceModel>
+  <appSettings>
+    <!-- Service Bus specific app setings for messaging connections -->
+    <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
+++ b/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
@@ -198,5 +198,21 @@ namespace NServiceBus.AzureServiceBus.Tests
 
             Assert.Throws<ConfigurationErrorsException>(() => converter.Convert(brokeredMessage));
         }
+        [Test]
+
+        public void Should_not_propagate_transport_encoding_header_from_brokered_message()
+        {
+            // default settings
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+
+            var bytes = Encoding.UTF8.GetBytes("Whatever");
+            var brokeredMessage = new BrokeredMessage(bytes);
+            brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding] = "wcf/byte-array";
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings);
+
+            var incomingMessageDetails = converter.Convert(brokeredMessage);
+
+            CollectionAssert.DoesNotContain(incomingMessageDetails.Headers, BrokeredMessageHeaders.TransportEncoding, $"Headers should not contain `{BrokeredMessageHeaders.TransportEncoding}`, but it was found.");
+        }
     }
 }

--- a/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
+++ b/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.AzureServiceBus.Tests
 {
     using System;
-    using System.Configuration;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -182,7 +181,7 @@ namespace NServiceBus.AzureServiceBus.Tests
 
             var brokeredMessage = new BrokeredMessage("non-default-type");
 
-            Assert.Throws<ConfigurationErrorsException>(() => converter.Convert(brokeredMessage));
+            Assert.Throws<UnsupportedBrokeredMessageBodyTypeException>(() => converter.Convert(brokeredMessage));
         }
 
         [Test]
@@ -196,7 +195,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             var brokeredMessage = new BrokeredMessage("non-default-type");
             brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding] = "unknown";
 
-            Assert.Throws<ConfigurationErrorsException>(() => converter.Convert(brokeredMessage));
+            Assert.Throws<UnsupportedBrokeredMessageBodyTypeException>(() => converter.Convert(brokeredMessage));
         }
         [Test]
 

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Connectivity\MessageSenderLifeCycleManager.cs" />
     <Compile Include="Connectivity\TaskWithRetryExtensions.cs" />
     <Compile Include="Creation\AzureServiceBusSubscriptionCreatorV6.cs" />
+    <Compile Include="Receiving\UnsupportedBrokeredMessageBodyTypeException.cs" />
     <Compile Include="Seam\TransportResourcesCreator.cs" />
     <Compile Include="Utils\BrokeredMessageHeaders.cs" />
     <Compile Include="Sending\IHandleOversizedBrokeredMessages.cs" />

--- a/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
+++ b/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
@@ -1,15 +1,16 @@
 namespace NServiceBus.AzureServiceBus
 {
     using System;
-    using System.Configuration;
     using System.Globalization;
     using System.IO;
     using System.Linq;
     using Microsoft.ServiceBus.Messaging;
+    using NServiceBus.Logging;
     using NServiceBus.Settings;
 
     class DefaultBrokeredMessagesToIncomingMessagesConverter : IConvertBrokeredMessagesToIncomingMessages
     {
+        ILog logger = LogManager.GetLogger<DefaultBrokeredMessagesToIncomingMessagesConverter>();
         readonly ReadOnlySettings settings;
 
         public DefaultBrokeredMessagesToIncomingMessagesConverter(ReadOnlySettings settings)
@@ -19,6 +20,11 @@ namespace NServiceBus.AzureServiceBus
 
         public IncomingMessageDetails Convert(BrokeredMessage brokeredMessage)
         {
+            if (!brokeredMessage.Properties.ContainsKey(BrokeredMessageHeaders.TransportEncoding))
+            {
+                logger.Debug($"Incoming BrokeredMessage with id=`{brokeredMessage.MessageId}` had no `{BrokeredMessageHeaders.TransportEncoding}` header.");
+            }
+
             var headers = brokeredMessage.Properties
                 .Where(kvp => kvp.Key != BrokeredMessageHeaders.TransportEncoding)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value as string);
@@ -37,7 +43,7 @@ namespace NServiceBus.AzureServiceBus
                     catch (Exception e)
                     {
                         var errorMessage = transportEncodingWasSpecified ? $"Unsupported brokered message body type `${transportEncodingToUse}` configured" : "No brokered message body type was found. Attempt to process message body as byte array has failed.";
-                        throw new ConfigurationErrorsException(errorMessage, e);
+                        throw new UnsupportedBrokeredMessageBodyTypeException(errorMessage, e);
                     }
                     break;
                 case "application/octect-stream":
@@ -49,9 +55,9 @@ namespace NServiceBus.AzureServiceBus
                     }
                     break;
                 default:
-                    throw new ConfigurationErrorsException("Unsupported brokered message body type configured");
+                    throw new UnsupportedBrokeredMessageBodyTypeException("Unsupported brokered message body type configured");
             }
-            
+
 
             if (!string.IsNullOrWhiteSpace(brokeredMessage.ReplyTo) && !headers.ContainsKey(Headers.ReplyToAddress))
             {

--- a/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
+++ b/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
@@ -19,7 +19,9 @@ namespace NServiceBus.AzureServiceBus
 
         public IncomingMessageDetails Convert(BrokeredMessage brokeredMessage)
         {
-            var headers = brokeredMessage.Properties.ToDictionary(kvp => kvp.Key, kvp => kvp.Value as string);
+            var headers = brokeredMessage.Properties
+                .Where(kvp => kvp.Key != BrokeredMessageHeaders.TransportEncoding)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value as string);
 
             var transportEncodingWasSpecified = brokeredMessage.Properties.ContainsKey(BrokeredMessageHeaders.TransportEncoding);
             var transportEncodingToUse = transportEncodingWasSpecified ? brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding] as string : GetDefaultTransportEncoding();

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AzureServiceBus
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Configuration;
     using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
@@ -114,7 +115,17 @@ namespace NServiceBus.AzureServiceBus
                 return;
             }
 
-            var incomingMessage = brokeredMessageConverter.Convert(message);
+            IncomingMessageDetails incomingMessage;
+            try
+            {
+                incomingMessage = brokeredMessageConverter.Convert(message);
+            }
+            catch (ConfigurationErrorsException exception)
+            {
+                await message.DeadLetterAsync("BrokeredMessage to IncomingMessageDetails conversion failure", exception.ToString());
+                return;
+            }
+
             var context = new BrokeredMessageReceiveContext()
             {
                 IncomingBrokeredMessage = message,

--- a/src/Transport/Receiving/UnsupportedBrokeredMessageBodyTypeException.cs
+++ b/src/Transport/Receiving/UnsupportedBrokeredMessageBodyTypeException.cs
@@ -1,0 +1,25 @@
+﻿namespace NServiceBus.AzureServiceBus
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    public class UnsupportedBrokeredMessageBodyTypeException : Exception
+    {
+        public UnsupportedBrokeredMessageBodyTypeException()
+        {
+        }
+
+        public UnsupportedBrokeredMessageBodyTypeException(string message) : base(message)
+        {
+        }
+
+        public UnsupportedBrokeredMessageBodyTypeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected UnsupportedBrokeredMessageBodyTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Transport/Sending/DefaultOutgoingMessagesToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultOutgoingMessagesToBrokeredMessagesConverter.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.AzureServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Configuration;
     using System.IO;
     using System.Linq;
     using Microsoft.ServiceBus.Messaging;
@@ -136,7 +135,7 @@ namespace NServiceBus.AzureServiceBus
                     brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding] = "application/octect-stream";
                     break;
                 default:
-                    throw new ConfigurationErrorsException("Unsupported brokered message body type configured");
+                    throw new UnsupportedBrokeredMessageBodyTypeException("Unsupported brokered message body type configured");
             }
             return brokeredMessage;
         }

--- a/src/Transport/Utils/BrokeredMessageHeaders.cs
+++ b/src/Transport/Utils/BrokeredMessageHeaders.cs
@@ -2,6 +2,6 @@ namespace NServiceBus.AzureServiceBus
 {
     internal static class BrokeredMessageHeaders
     {
-        public const string TransportEncoding = "Transport-Encoding";
+        public const string TransportEncoding = "NServiceBus.Transport.Encoding";
     }
 }


### PR DESCRIPTION
Sending poisonous message to DLQ natively.

I put together an acceptance test (`When_receiving_a_message_with_unknown_transport_encoding`) that is a hack. Perhaps would be better to test it in a "unit test". Similar to `When_receiving_incomingmessages_from_queues` so that we can control queue name & connection string.

@yvesgoeleven please review. 