### PR TITLE
Batching based on estimated message size

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -1,43 +1,6 @@
 ﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
 {
     
-    public class AzureServicebusDefaults
-    {
-        public const int DefaultBackoffTimeInSeconds = 10;
-        public const int DefaultBatchSize = 1000;
-        public const string DefaultConnectionString = "";
-        public const string DefaultConnectivityMode = "Tcp";
-        public const long DefaultDefaultMessageTimeToLive = 92233720368547;
-        public const int DefaultDuplicateDetectionHistoryTimeWindow = 600000;
-        public const bool DefaultEnableBatchedOperations = true;
-        public const bool DefaultEnableDeadLetteringOnMessageExpiration = false;
-        public const bool DefaultEnablePartitioning = false;
-        public const string DefaultIssuerName = "owner";
-        public const int DefaultLockDuration = 30000;
-        public const int DefaultMaxDeliveryCount = 6;
-        public const long DefaultMaxSizeInMegabytes = 1024;
-        public const bool DefaultQueuePerInstance = false;
-        public const bool DefaultRequiresDuplicateDetection = false;
-        public const bool DefaultRequiresSession = false;
-        public const int DefaultServerWaitTime = 300;
-        public const bool DefaultSupportOrdering = true;
-        public const bool EnableDeadLetteringOnFilterEvaluationExceptions = false;
-        public AzureServicebusDefaults() { }
-    }
-    public class AzureServiceBusTopologyCreator : NServiceBus.Transports.ICreateQueues
-    {
-        public AzureServiceBusTopologyCreator(NServiceBus.Azure.Transports.WindowsAzureServiceBus.ITopology topology) { }
-        public void CreateQueueIfNecessary(NServiceBus.Address address, string account) { }
-    }
-    public class DefaultTopology : NServiceBus.Features.Feature
-    {
-        public DefaultTopology() { }
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
-    }
-    public interface ICreateMessagingFactories
-    {
-        Microsoft.ServiceBus.Messaging.MessagingFactory Create(NServiceBus.Address address);
-    }
     public interface ICreateNamespaceManagers
     {
         Microsoft.ServiceBus.NamespaceManager Create(string serviceBusNamespace);
@@ -51,11 +14,6 @@
     {
         Microsoft.ServiceBus.Messaging.SubscriptionClient Create(Microsoft.ServiceBus.Messaging.SubscriptionDescription description, Microsoft.ServiceBus.Messaging.MessagingFactory factory);
     }
-    public interface ICreateSubscriptions
-    {
-        Microsoft.ServiceBus.Messaging.SubscriptionDescription Create(NServiceBus.Address topic, System.Type eventType, string subscriptionname);
-        void Delete(NServiceBus.Address topic, string subscriptionname);
-    }
     public interface ICreateTopicClients
     {
         Microsoft.ServiceBus.Messaging.TopicClient Create(Microsoft.ServiceBus.Messaging.TopicDescription topic, Microsoft.ServiceBus.Messaging.MessagingFactory factory);
@@ -63,45 +21,19 @@
     }
     public interface IManageMessagingFactoriesLifecycle
     {
-        Microsoft.ServiceBus.Messaging.MessagingFactory Get(NServiceBus.Address address);
+        Microsoft.ServiceBus.Messaging.MessagingFactory Get(string address);
     }
     public interface IManageQueueClientsLifecycle
     {
-        Microsoft.ServiceBus.Messaging.QueueClient Get(NServiceBus.Address address);
+        Microsoft.ServiceBus.Messaging.QueueClient Get(string address);
     }
     public interface IManageSubscriptionClientsLifecycle
     {
-        Microsoft.ServiceBus.Messaging.TopicClient Get(NServiceBus.Address address);
+        Microsoft.ServiceBus.Messaging.TopicClient Get(string address);
     }
     public interface IManageTopicClientsLifecycle
     {
-        Microsoft.ServiceBus.Messaging.TopicClient Get(NServiceBus.Address address);
-    }
-    public interface INotifyReceivedBrokeredMessages
-    {
-        NServiceBus.Address Address { get; set; }
-        System.Type MessageType { get; set; }
-        public event System.EventHandler Faulted;
-        void Start(System.Action<Microsoft.ServiceBus.Messaging.BrokeredMessage> tryProcessMessage, System.Action<System.Exception> errorProcessingMessage);
-        void Stop();
-    }
-    public interface IPublishBrokeredMessages
-    {
-        void Publish(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage);
-    }
-    public interface ISendBrokeredMessages
-    {
-        void Send(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage);
-    }
-    public interface ITopology
-    {
-        void Create(NServiceBus.Address address);
-        NServiceBus.Azure.Transports.WindowsAzureServiceBus.IPublishBrokeredMessages GetPublisher(NServiceBus.Address local);
-        NServiceBus.Azure.Transports.WindowsAzureServiceBus.INotifyReceivedBrokeredMessages GetReceiver(NServiceBus.Address address);
-        NServiceBus.Azure.Transports.WindowsAzureServiceBus.ISendBrokeredMessages GetSender(NServiceBus.Address destination);
-        void Initialize(NServiceBus.Settings.ReadOnlySettings setting);
-        NServiceBus.Azure.Transports.WindowsAzureServiceBus.INotifyReceivedBrokeredMessages Subscribe(System.Type eventType, NServiceBus.Address address);
-        void Unsubscribe(NServiceBus.Azure.Transports.WindowsAzureServiceBus.INotifyReceivedBrokeredMessages notifier);
+        Microsoft.ServiceBus.Messaging.TopicClient Get(string address);
     }
     public class MessageTooLargeException : System.Exception
     {
@@ -109,13 +41,6 @@
         public MessageTooLargeException(string message) { }
         public MessageTooLargeException(string message, System.Exception inner) { }
         protected MessageTooLargeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
-    public class RoleEnvironmentUnavailableException : System.Exception
-    {
-        public RoleEnvironmentUnavailableException() { }
-        public RoleEnvironmentUnavailableException(string message) { }
-        public RoleEnvironmentUnavailableException(string message, System.Exception inner) { }
-        protected RoleEnvironmentUnavailableException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class SubscriptionAlreadyInUseException : System.Exception
     {
@@ -128,79 +53,770 @@
 namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.Transports
 {
     
-    public interface ICreateQueues
-    {
-        Microsoft.ServiceBus.Messaging.QueueDescription Create(NServiceBus.Address address);
-    }
     public interface ICreateTopics
     {
-        Microsoft.ServiceBus.Messaging.TopicDescription Create(NServiceBus.Address address);
+        Microsoft.ServiceBus.Messaging.TopicDescription Create(string address);
+    }
+}
+namespace NServiceBus.AzureServiceBus.Addressing
+{
+    
+    public class AdjustmentSanitizationStrategy : NServiceBus.AzureServiceBus.Addressing.ISanitizationStrategy
+    {
+        public AdjustmentSanitizationStrategy(NServiceBus.AzureServiceBus.Addressing.IValidationStrategy validationStrategy) { }
+        public string Sanitize(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+    public class AdjustmentSanitizationV6Strategy : NServiceBus.AzureServiceBus.Addressing.ISanitizationStrategy
+    {
+        public AdjustmentSanitizationV6Strategy(NServiceBus.AzureServiceBus.Addressing.IValidationStrategy validationStrategy) { }
+        public string Sanitize(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+    public class CoreIndividualizationStrategy : NServiceBus.AzureServiceBus.Addressing.IIndividualizationStrategy
+    {
+        public CoreIndividualizationStrategy() { }
+        public string Individualize(string endpointname) { }
+    }
+    public class DiscriminatorBasedIndividualizationStrategy : NServiceBus.AzureServiceBus.Addressing.IIndividualizationStrategy
+    {
+        public DiscriminatorBasedIndividualizationStrategy() { }
+        public string Individualize(string endpointname) { }
+        public void SetDiscriminatorGenerator(System.Func<string> discriminatorGenerator) { }
+    }
+    public class EndpointValidationException : System.Exception
+    {
+        public EndpointValidationException() { }
+        public EndpointValidationException(string message) { }
+        public EndpointValidationException(string message, System.Exception inner) { }
+        protected EndpointValidationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class EntityNameValidationRules : NServiceBus.AzureServiceBus.Addressing.IValidationStrategy
+    {
+        public EntityNameValidationRules(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public bool IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+    public class EntityNameValidationV6Rules : NServiceBus.AzureServiceBus.Addressing.IValidationStrategy
+    {
+        public EntityNameValidationV6Rules(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public bool IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+    public enum FailOverMode
+    {
+        Primary = 0,
+        Secondary = 1,
+    }
+    public class FailOverNamespacePartitioningStrategy : NServiceBus.AzureServiceBus.Addressing.INamespacePartitioningStrategy
+    {
+        public FailOverNamespacePartitioningStrategy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public NServiceBus.AzureServiceBus.Addressing.FailOverMode Mode { get; set; }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.AzureServiceBus.Addressing.FailOverNamespacePartitioningStrategy.<GetNamespaces>d__6))]
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> GetNamespaces(string endpointName, NServiceBus.AzureServiceBus.Addressing.PartitioningIntent partitioningIntent) { }
+    }
+    public class FlatCompositionStrategy : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy
+    {
+        public FlatCompositionStrategy() { }
+        public string GetEntityPath(string entityname, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+    public class HierarchyCompositionStrategy : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy
+    {
+        public HierarchyCompositionStrategy() { }
+        public string GetEntityPath(string entityname, NServiceBus.AzureServiceBus.EntityType entityType) { }
+        public void SetPathGenerator(System.Func<string, string> pathGenerator) { }
+    }
+    public interface ICompositionStrategy
+    {
+        string GetEntityPath(string entityname, NServiceBus.AzureServiceBus.EntityType entityType);
+    }
+    public interface IIndividualizationStrategy
+    {
+        string Individualize(string endpointname);
+    }
+    public interface INamespacePartitioningStrategy
+    {
+        System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> GetNamespaces(string endpointName, NServiceBus.AzureServiceBus.Addressing.PartitioningIntent partitioningIntent);
+    }
+    public interface ISanitizationStrategy
+    {
+        string Sanitize(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType);
+    }
+    public interface IValidationStrategy
+    {
+        bool IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType);
+    }
+    public enum PartitioningIntent
+    {
+        Receiving = 0,
+        Sending = 1,
+        Creating = 2,
+    }
+    public class ReplicatedNamespacePartitioningStrategy : NServiceBus.AzureServiceBus.Addressing.INamespacePartitioningStrategy
+    {
+        public ReplicatedNamespacePartitioningStrategy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> GetNamespaces(string endpointName, NServiceBus.AzureServiceBus.Addressing.PartitioningIntent partitioningIntent) { }
+    }
+    public class RoundRobinNamespacePartitioningStrategy : NServiceBus.AzureServiceBus.Addressing.INamespacePartitioningStrategy
+    {
+        public RoundRobinNamespacePartitioningStrategy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.AzureServiceBus.Addressing.RoundRobinNamespacePartitioningStrategy.<GetNamespaces>d__2))]
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> GetNamespaces(string endpointName, NServiceBus.AzureServiceBus.Addressing.PartitioningIntent partitioningIntent) { }
+    }
+    public class ShardedNamespacePartitioningStrategy : NServiceBus.AzureServiceBus.Addressing.INamespacePartitioningStrategy
+    {
+        public ShardedNamespacePartitioningStrategy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.AzureServiceBus.Addressing.ShardedNamespacePartitioningStrategy.<GetNamespaces>d__4))]
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> GetNamespaces(string endpointname, NServiceBus.AzureServiceBus.Addressing.PartitioningIntent partitioningIntent) { }
+        public void SetShardingRule(System.Func<int> rule) { }
+    }
+    public class SingleNamespacePartitioningStrategy : NServiceBus.AzureServiceBus.Addressing.INamespacePartitioningStrategy
+    {
+        public SingleNamespacePartitioningStrategy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.AzureServiceBus.Addressing.SingleNamespacePartitioningStrategy.<GetNamespaces>d__2))]
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> GetNamespaces(string endpointName, NServiceBus.AzureServiceBus.Addressing.PartitioningIntent partitioningIntent) { }
+    }
+    public class ThrowOnFailingSanitizationStrategy : NServiceBus.AzureServiceBus.Addressing.ISanitizationStrategy
+    {
+        public ThrowOnFailingSanitizationStrategy(NServiceBus.AzureServiceBus.Addressing.IValidationStrategy validationStrategy) { }
+        public string Sanitize(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+}
+namespace NServiceBus.AzureServiceBus
+{
+    
+    public class Batch
+    {
+        public Batch() { }
+        public NServiceBus.AzureServiceBus.TopologySection Destinations { get; set; }
+        public System.Collections.Generic.IList<NServiceBus.AzureServiceBus.BatchedOperation> Operations { get; set; }
+        public NServiceBus.Transports.DispatchConsistency RequiredDispatchConsistency { get; set; }
+    }
+    public class BatchedOperation
+    {
+        public BatchedOperation() { }
+        public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; set; }
+        public NServiceBus.Transports.OutgoingMessage Message { get; set; }
+        public long GetEstimatedSize() { }
+    }
+    public class BrokeredMessageReceiveContext : NServiceBus.AzureServiceBus.ReceiveContext
+    {
+        public BrokeredMessageReceiveContext() { }
+        public NServiceBus.AzureServiceBus.EntityInfo Entity { get; set; }
+        public Microsoft.ServiceBus.Messaging.BrokeredMessage IncomingBrokeredMessage { get; set; }
+        public Microsoft.ServiceBus.Messaging.ReceiveMode ReceiveMode { get; set; }
+    }
+    public class DefaultBatchedOperationsToBrokeredMessagesConverter : NServiceBus.AzureServiceBus.IConvertOutgoingMessagesToBrokeredMessages
+    {
+        public DefaultBatchedOperationsToBrokeredMessagesConverter(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> Convert(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.BatchedOperation> outgoingMessages, NServiceBus.AzureServiceBus.RoutingOptions routingOptions) { }
+        public Microsoft.ServiceBus.Messaging.BrokeredMessage Convert(NServiceBus.AzureServiceBus.BatchedOperation outgoingOperation, NServiceBus.AzureServiceBus.RoutingOptions routingOptions) { }
+    }
+    public class DefaultConfigurationValues
+    {
+        public DefaultConfigurationValues() { }
+        public NServiceBus.Settings.SettingsHolder Apply(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class DefaultOutgoingBatchRouter : NServiceBus.AzureServiceBus.IRouteOutgoingBatches
+    {
+        public DefaultOutgoingBatchRouter(NServiceBus.AzureServiceBus.IConvertOutgoingMessagesToBrokeredMessages outgoingMessageConverter, NServiceBus.AzureServiceBus.IManageMessageSenderLifeCycle senders, NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.AzureServiceBus.IHandleOversizedBrokeredMessages oversizedMessageHandler) { }
+        public async System.Threading.Tasks.Task RouteBatch(NServiceBus.AzureServiceBus.Batch batch, NServiceBus.AzureServiceBus.ReceiveContext context) { }
+        public async System.Threading.Tasks.Task RouteBatches(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.Batch> outgoingBatches, NServiceBus.AzureServiceBus.ReceiveContext context) { }
+    }
+    public class EntityInfo
+    {
+        public EntityInfo() { }
+        public NServiceBus.AzureServiceBus.NamespaceInfo Namespace { get; set; }
+        public string Path { get; set; }
+        public System.Collections.Generic.IList<NServiceBus.AzureServiceBus.EntityRelationShipInfo> RelationShips { get; }
+        public NServiceBus.AzureServiceBus.EntityType Type { get; set; }
+        protected bool Equals(NServiceBus.AzureServiceBus.EntityInfo other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public class EntityRelationShipInfo
+    {
+        public EntityRelationShipInfo() { }
+        public NServiceBus.AzureServiceBus.EntityInfo Source { get; set; }
+        public NServiceBus.AzureServiceBus.EntityInfo Target { get; set; }
+        public NServiceBus.AzureServiceBus.EntityRelationShipType Type { get; set; }
+    }
+    public enum EntityRelationShipType
+    {
+        Forward = 0,
+        Subscription = 1,
+    }
+    public enum EntityType
+    {
+        Queue = 0,
+        Topic = 1,
+        Subscription = 2,
+        EventHub = 3,
+    }
+    public class ForwardingTopology : NServiceBus.AzureServiceBus.ITopology
+    {
+        public ForwardingTopology() { }
+        public bool HasNativePubSubSupport { get; }
+        public bool HasSupportForCentralizedPubSub { get; }
+        public System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory() { }
+        public System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory() { }
+        public NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy() { }
+        public System.Func<NServiceBus.Transports.ICreateQueues> GetQueueCreatorFactory() { }
+        public NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager() { }
+        public void Initialize(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class ForwardingTopologySectionManager : NServiceBus.AzureServiceBus.ITopologySectionManager
+    {
+        public ForwardingTopologySectionManager(NServiceBus.Settings.SettingsHolder settings, NServiceBus.AzureServiceBus.ITransportPartsContainer container) { }
+        public NServiceBus.AzureServiceBus.TopologySection DeterminePublishDestination(System.Type eventType) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineReceiveResources(string inputQueue) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToCreate() { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToSubscribeTo(System.Type eventType) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToUnsubscribeFrom(System.Type eventtype) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineSendDestination(string destination) { }
+    }
+    public interface IBatcher
+    {
+        System.Collections.Generic.IList<NServiceBus.AzureServiceBus.Batch> ToBatches(NServiceBus.Transports.TransportOperations operations);
+    }
+    public interface IBrokerSideSubscriptionFilter
+    {
+        string Serialize();
+    }
+    public interface IClientEntity
+    {
+        bool IsClosed { get; }
+        Microsoft.ServiceBus.RetryPolicy RetryPolicy { get; set; }
+    }
+    public interface IClientSideSubscriptionFilter
+    {
+        bool Execute(object message);
+    }
+    public interface IConvertBrokeredMessagesToIncomingMessages
+    {
+        NServiceBus.AzureServiceBus.IncomingMessageDetails Convert(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage);
+    }
+    public interface IConvertOutgoingMessagesToBrokeredMessages
+    {
+        Microsoft.ServiceBus.Messaging.BrokeredMessage Convert(NServiceBus.AzureServiceBus.BatchedOperation outgoingOperation, NServiceBus.AzureServiceBus.RoutingOptions routingOptions);
+        System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> Convert(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.BatchedOperation> outgoingOperations, NServiceBus.AzureServiceBus.RoutingOptions routingOptions);
+    }
+    public interface ICreateAzureServiceBusQueues
+    {
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> Create(string queuePath, NServiceBus.AzureServiceBus.INamespaceManager namespaceManager);
+    }
+    public interface ICreateAzureServiceBusSubscriptions
+    {
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> Create(string topicPath, string subscriptionName, NServiceBus.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.AzureServiceBus.INamespaceManager namespaceManager);
+    }
+    public interface ICreateAzureServiceBusTopics
+    {
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> Create(string topicPath, NServiceBus.AzureServiceBus.INamespaceManager namespaceManager);
+    }
+    public interface ICreateMessageReceivers
+    {
+        System.Threading.Tasks.Task<NServiceBus.AzureServiceBus.IMessageReceiver> Create(string entitypath, string connectionstring);
+    }
+    public interface ICreateMessageSenders
+    {
+        System.Threading.Tasks.Task<NServiceBus.AzureServiceBus.IMessageSender> Create(string entitypath, string viaEntityPath, string connectionstring);
+    }
+    public interface ICreateMessagingFactories
+    {
+        NServiceBus.AzureServiceBus.IMessagingFactory Create(string connectionstring);
+    }
+    public interface ICreateNamespaceManagers
+    {
+        NServiceBus.AzureServiceBus.INamespaceManager Create(string connectionstring);
+    }
+    public interface ICreateTopology
+    {
+        System.Threading.Tasks.Task Create(NServiceBus.AzureServiceBus.TopologySection topology);
+    }
+    public interface IHandleOversizedBrokeredMessages
+    {
+        System.Threading.Tasks.Task Handle(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage);
+    }
+    public interface IManageMessageReceiverLifeCycle
+    {
+        NServiceBus.AzureServiceBus.IMessageReceiver Get(string entitypath, string connectionstring);
+    }
+    public interface IManageMessageSenderLifeCycle
+    {
+        NServiceBus.AzureServiceBus.IMessageSender Get(string entitypath, string viaEntityPath, string connectionstring);
+    }
+    public interface IManageMessagingFactoryLifeCycle
+    {
+        System.Threading.Tasks.Task CloseAll();
+        NServiceBus.AzureServiceBus.IMessagingFactory Get(string @namespace);
+    }
+    public interface IManageNamespaceManagerLifeCycle
+    {
+        NServiceBus.AzureServiceBus.INamespaceManager Get(string @namespace);
+    }
+    public interface IMessageReceiver : NServiceBus.AzureServiceBus.IClientEntity
+    {
+        Microsoft.ServiceBus.Messaging.ReceiveMode Mode { get; }
+        int PrefetchCount { get; set; }
+        System.Threading.Tasks.Task CloseAsync();
+        void OnMessage(System.Func<Microsoft.ServiceBus.Messaging.BrokeredMessage, System.Threading.Tasks.Task> callback, Microsoft.ServiceBus.Messaging.OnMessageOptions options);
+    }
+    public interface IMessageSender : NServiceBus.AzureServiceBus.IClientEntity
+    {
+        System.Threading.Tasks.Task Send(Microsoft.ServiceBus.Messaging.BrokeredMessage message);
+        System.Threading.Tasks.Task SendBatch(System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> messages);
+    }
+    public interface IMessagingFactory : NServiceBus.AzureServiceBus.IClientEntity
+    {
+        System.Threading.Tasks.Task CloseAsync();
+        System.Threading.Tasks.Task<NServiceBus.AzureServiceBus.IMessageReceiver> CreateMessageReceiver(string entitypath, Microsoft.ServiceBus.Messaging.ReceiveMode receiveMode);
+        System.Threading.Tasks.Task<NServiceBus.AzureServiceBus.IMessageSender> CreateMessageSender(string entitypath);
+        System.Threading.Tasks.Task<NServiceBus.AzureServiceBus.IMessageSender> CreateMessageSender(string entitypath, string viaEntityPath);
+    }
+    public interface INamespaceManager
+    {
+        System.Uri Address { get; }
+        Microsoft.ServiceBus.NamespaceManagerSettings Settings { get; }
+        System.Threading.Tasks.Task CreateQueue(Microsoft.ServiceBus.Messaging.QueueDescription description);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> CreateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription, string sqlFilter);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> CreateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription);
+        System.Threading.Tasks.Task DeleteQueue(string path);
+        System.Threading.Tasks.Task DeleteTopic(string path);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> GetQueue(string path);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.RuleDescription>> GetRules(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> GetSubscription(string topicPath, string subscriptionName);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> GetTopic(string path);
+        System.Threading.Tasks.Task<bool> QueueExists(string path);
+        System.Threading.Tasks.Task<bool> SubscriptionExists(string topicPath, string subscriptionName);
+        System.Threading.Tasks.Task<bool> TopicExists(string path);
+        System.Threading.Tasks.Task UpdateQueue(Microsoft.ServiceBus.Messaging.QueueDescription description);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> UpdateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
+        System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> UpdateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription);
+    }
+    public class IncomingMessageDetails
+    {
+        public IncomingMessageDetails(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream) { }
+        public System.IO.Stream BodyStream { get; }
+        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        public string MessageId { get; }
+    }
+    public interface INotifyIncomingMessages
+    {
+        bool IsRunning { get; }
+        int RefCount { get; set; }
+        void Initialize(NServiceBus.AzureServiceBus.EntityInfo entity, System.Func<NServiceBus.AzureServiceBus.IncomingMessageDetails, NServiceBus.AzureServiceBus.ReceiveContext, System.Threading.Tasks.Task> callback, System.Func<System.Exception, System.Threading.Tasks.Task> errorCallback, int maximumConcurrency);
+        void Start();
+        System.Threading.Tasks.Task Stop();
+    }
+    public interface IOperateTopology
+    {
+        void OnError(System.Func<System.Exception, System.Threading.Tasks.Task> func);
+        void OnIncomingMessage(System.Func<NServiceBus.AzureServiceBus.IncomingMessageDetails, NServiceBus.AzureServiceBus.ReceiveContext, System.Threading.Tasks.Task> func);
+        void Start(NServiceBus.AzureServiceBus.TopologySection topology, int maximumConcurrency);
+        void Start(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.EntityInfo> subscriptions);
+        System.Threading.Tasks.Task Stop();
+        System.Threading.Tasks.Task Stop(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.EntityInfo> subscriptions);
+    }
+    public interface IRegisterTransportParts
+    {
+        void Register<T>();
+        void Register(System.Type t);
+        void Register<T>(System.Func<object> func);
+        void Register(System.Type t, System.Func<object> func);
+        void RegisterSingleton<T>();
+        void RegisterSingleton(System.Type t);
+    }
+    public interface IResolveTransportParts
+    {
+        object Resolve(System.Type typeToBuild);
+        T Resolve<T>();
+        System.Collections.Generic.IEnumerable<T> ResolveAll<T>();
+        System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type typeToBuild);
+    }
+    public interface IRouteOutgoingBatches
+    {
+        System.Threading.Tasks.Task RouteBatch(NServiceBus.AzureServiceBus.Batch batch, NServiceBus.AzureServiceBus.ReceiveContext receiveContext);
+        System.Threading.Tasks.Task RouteBatches(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.Batch> outgoingBatches, NServiceBus.AzureServiceBus.ReceiveContext receiveContext);
+    }
+    public interface ITopology
+    {
+        bool HasNativePubSubSupport { get; }
+        bool HasSupportForCentralizedPubSub { get; }
+        System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory();
+        System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory();
+        NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy();
+        System.Func<NServiceBus.Transports.ICreateQueues> GetQueueCreatorFactory();
+        NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager();
+        void Initialize(NServiceBus.Settings.SettingsHolder settings);
+    }
+    public interface ITopologySectionManager
+    {
+        NServiceBus.AzureServiceBus.TopologySection DeterminePublishDestination(System.Type eventType);
+        NServiceBus.AzureServiceBus.TopologySection DetermineReceiveResources(string inputQueue);
+        NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToCreate();
+        NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToSubscribeTo(System.Type eventType);
+        NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToUnsubscribeFrom(System.Type eventtype);
+        NServiceBus.AzureServiceBus.TopologySection DetermineSendDestination(string destination);
+    }
+    public interface ITransportPartsContainer : NServiceBus.AzureServiceBus.IRegisterTransportParts, NServiceBus.AzureServiceBus.IResolveTransportParts { }
+    public class MessageReceiverAdapter : NServiceBus.AzureServiceBus.IClientEntity, NServiceBus.AzureServiceBus.IMessageReceiver
+    {
+        public MessageReceiverAdapter(Microsoft.ServiceBus.Messaging.MessageReceiver receiver) { }
+        public bool IsClosed { get; }
+        public Microsoft.ServiceBus.Messaging.ReceiveMode Mode { get; }
+        public int PrefetchCount { get; set; }
+        public Microsoft.ServiceBus.RetryPolicy RetryPolicy { get; set; }
+        public System.Threading.Tasks.Task CloseAsync() { }
+        public void OnMessage(System.Func<Microsoft.ServiceBus.Messaging.BrokeredMessage, System.Threading.Tasks.Task> callback, Microsoft.ServiceBus.Messaging.OnMessageOptions options) { }
+    }
+    public class MessageSenderAdapter : NServiceBus.AzureServiceBus.IClientEntity, NServiceBus.AzureServiceBus.IMessageSender
+    {
+        public MessageSenderAdapter(Microsoft.ServiceBus.Messaging.MessageSender sender) { }
+        public bool IsClosed { get; }
+        public Microsoft.ServiceBus.RetryPolicy RetryPolicy { get; set; }
+        public System.Threading.Tasks.Task CloseAsync() { }
+        public System.Threading.Tasks.Task Send(Microsoft.ServiceBus.Messaging.BrokeredMessage message) { }
+        public System.Threading.Tasks.Task SendBatch(System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> messages) { }
+    }
+    public class NamespaceInfo
+    {
+        public NamespaceInfo(string connectionString, NServiceBus.AzureServiceBus.NamespaceMode mode = 0) { }
+        public string ConnectionString { get; set; }
+        public NServiceBus.AzureServiceBus.NamespaceMode Mode { get; set; }
+        protected bool Equals(NServiceBus.AzureServiceBus.NamespaceInfo other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public class NamespaceManagerAdapter : NServiceBus.AzureServiceBus.INamespaceManager
+    {
+        public NamespaceManagerAdapter(Microsoft.ServiceBus.NamespaceManager manager) { }
+        public System.Uri Address { get; }
+        public Microsoft.ServiceBus.NamespaceManagerSettings Settings { get; }
+        public System.Threading.Tasks.Task CreateQueue(Microsoft.ServiceBus.Messaging.QueueDescription description) { }
+        public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> CreateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription, string sqlFilter) { }
+        public async System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> CreateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription) { }
+        public async System.Threading.Tasks.Task DeleteQueue(string path) { }
+        public System.Threading.Tasks.Task DeleteSubscriptionAsync(string topicPath, string subscriptionName) { }
+        public System.Threading.Tasks.Task DeleteTopic(string path) { }
+        public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> GetQueue(string path) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.RuleDescription>> GetRules(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription) { }
+        public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> GetSubscription(string topicPath, string subscriptionName) { }
+        public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> GetTopic(string path) { }
+        public System.Threading.Tasks.Task<bool> QueueExists(string path) { }
+        public System.Threading.Tasks.Task<bool> SubscriptionExists(string topicPath, string subscriptionName) { }
+        public System.Threading.Tasks.Task<bool> TopicExists(string path) { }
+        public System.Threading.Tasks.Task UpdateQueue(Microsoft.ServiceBus.Messaging.QueueDescription description) { }
+        public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> UpdateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription) { }
+        public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> UpdateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription) { }
+    }
+    public enum NamespaceMode
+    {
+        Active = 0,
+        Passive = 1,
+    }
+    public class NoTransaction : NServiceBus.Transports.TransportTransaction
+    {
+        public NoTransaction() { }
+    }
+    public abstract class ReceiveContext
+    {
+        protected ReceiveContext() { }
+        public System.Threading.CancellationToken CancellationToken { get; set; }
+        public System.Collections.Generic.IList<System.Func<System.Threading.Tasks.Task>> OnComplete { get; set; }
+    }
+    public class RoutingOptions
+    {
+        public RoutingOptions() { }
+        public bool SendVia { get; set; }
+        public string ViaConnectionString { get; set; }
+        public string ViaEntityPath { get; set; }
+        public string ViaPartitionKey { get; set; }
+    }
+    public class StandardTopology : NServiceBus.AzureServiceBus.ITopology
+    {
+        public StandardTopology() { }
+        public bool HasNativePubSubSupport { get; }
+        public bool HasSupportForCentralizedPubSub { get; }
+        public System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory() { }
+        public System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory() { }
+        public NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy() { }
+        public System.Func<NServiceBus.Transports.ICreateQueues> GetQueueCreatorFactory() { }
+        public NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager() { }
+        public void Initialize(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class StandardTopologySectionManager : NServiceBus.AzureServiceBus.ITopologySectionManager
+    {
+        public StandardTopologySectionManager(NServiceBus.Settings.SettingsHolder settings, NServiceBus.AzureServiceBus.ITransportPartsContainer container) { }
+        public NServiceBus.AzureServiceBus.TopologySection DeterminePublishDestination(System.Type eventType) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineReceiveResources(string inputQueue) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToCreate() { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToSubscribeTo(System.Type eventType) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToUnsubscribeFrom(System.Type eventtype) { }
+        public NServiceBus.AzureServiceBus.TopologySection DetermineSendDestination(string destination) { }
+    }
+    public class SubscriptionInfo : NServiceBus.AzureServiceBus.EntityInfo
+    {
+        public SubscriptionInfo() { }
+        public NServiceBus.AzureServiceBus.IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }
+        public NServiceBus.AzureServiceBus.IClientSideSubscriptionFilter ClientSideFilter { get; set; }
+        public NServiceBus.AzureServiceBus.SubscriptionMetadata Metadata { get; set; }
+    }
+    public class SubscriptionMetadata
+    {
+        public SubscriptionMetadata() { }
+        public string Description { get; set; }
+        public string SubscriptionNameBasedOnEventWithNamespace { get; set; }
+    }
+    public enum SupportedBrokeredMessageBodyTypes
+    {
+        ByteArray = 0,
+        Stream = 1,
+    }
+    public class ThrowOnOversizedBrokeredMessages : NServiceBus.AzureServiceBus.IHandleOversizedBrokeredMessages
+    {
+        public ThrowOnOversizedBrokeredMessages() { }
+        public System.Threading.Tasks.Task Handle(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage) { }
+    }
+    public class TopologyOperator : NServiceBus.AzureServiceBus.IOperateTopology
+    {
+        public TopologyOperator(NServiceBus.AzureServiceBus.ITransportPartsContainer container) { }
+        public void OnError(System.Func<System.Exception, System.Threading.Tasks.Task> func) { }
+        public void OnIncomingMessage(System.Func<NServiceBus.AzureServiceBus.IncomingMessageDetails, NServiceBus.AzureServiceBus.ReceiveContext, System.Threading.Tasks.Task> func) { }
+        public void Start(NServiceBus.AzureServiceBus.TopologySection topologySection, int maximumConcurrency) { }
+        public void Start(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.EntityInfo> subscriptions) { }
+        public async System.Threading.Tasks.Task Stop() { }
+        public System.Threading.Tasks.Task Stop(System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.EntityInfo> subscriptions) { }
+    }
+    public class TopologySection
+    {
+        public TopologySection() { }
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.EntityInfo> Entities { get; set; }
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.NamespaceInfo> Namespaces { get; set; }
+        public System.Collections.Generic.IEnumerable<NServiceBus.AzureServiceBus.EntityRelationShipInfo> Relationships { get; set; }
+    }
+    public class TransportPartsContainer : NServiceBus.AzureServiceBus.IRegisterTransportParts, NServiceBus.AzureServiceBus.IResolveTransportParts, NServiceBus.AzureServiceBus.ITransportPartsContainer
+    {
+        public TransportPartsContainer() { }
+        public void Register<T>() { }
+        public void Register(System.Type t) { }
+        public void Register<T>(System.Func<object> func) { }
+        public void Register(System.Type t, System.Func<object> func) { }
+        public void RegisterSingleton<T>() { }
+        public void RegisterSingleton(System.Type t) { }
+        public object Resolve(System.Type typeToBuild) { }
+        public T Resolve<T>() { }
+        public System.Collections.Generic.IEnumerable<T> ResolveAll<T>() { }
+        public System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type typeToBuild) { }
+    }
+    public class UnsupportedBrokeredMessageBodyTypeException : System.Exception
+    {
+        public UnsupportedBrokeredMessageBodyTypeException() { }
+        public UnsupportedBrokeredMessageBodyTypeException(string message) { }
+        public UnsupportedBrokeredMessageBodyTypeException(string message, System.Exception innerException) { }
+        protected UnsupportedBrokeredMessageBodyTypeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 }
 namespace NServiceBus
 {
     
+    public class static AzureServiceBusAddressingExtensions
+    {
+        public static NServiceBus.AzureServiceBusCompositionSettings Composition(this NServiceBus.AzureServiceBusAddressingSettings addressingSettings) { }
+        public static NServiceBus.AzureServiceBusIndividualizationSettings Individualization(this NServiceBus.AzureServiceBusAddressingSettings addressingSettings) { }
+        public static NServiceBus.AzureServiceBusNamespacePartitioningSettings NamespacePartitioning(this NServiceBus.AzureServiceBusAddressingSettings addressingSettings) { }
+        public static NServiceBus.AzureServiceBusSanitizationSettings Sanitization(this NServiceBus.AzureServiceBusAddressingSettings addressingSettings) { }
+        public static NServiceBus.AzureServiceBusValidationSettings Validation(this NServiceBus.AzureServiceBusAddressingSettings addressingSettings) { }
+    }
+    public class AzureServiceBusAddressingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusAddressingSettings(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class AzureServiceBusBatchingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusBatchingSettings(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class AzureServiceBusCompositionSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusCompositionSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusCompositionSettings UseStrategy<T>()
+            where T : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy { }
+    }
+    public class AzureServiceBusConnectivitySettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusConnectivitySettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusConnectivitySettings NumberOfClientsPerEntity(int number) { }
+        public NServiceBus.AzureServiceBusConnectivitySettings SendViaReceiveQueue(bool sendViaReceiveQueue) { }
+    }
+    public class static AzureServiceBusConnectivitySettingsExtensions
+    {
+        public static NServiceBus.AzureServiceBusMessageReceiverSettings MessageReceivers(this NServiceBus.AzureServiceBusConnectivitySettings azureServiceBusConnectivitySettings) { }
+        public static NServiceBus.AzureServiceBusMessageSenderSettings MessageSenders(this NServiceBus.AzureServiceBusConnectivitySettings azureServiceBusConnectivitySettings) { }
+        public static NServiceBus.AzureServiceBusMessagingFactoriesSettings MessagingFactories(this NServiceBus.AzureServiceBusConnectivitySettings azureServiceBusConnectivitySettings) { }
+    }
+    public class AzureServiceBusIndividualizationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusIndividualizationSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusIndividualizationSettings UseStrategy<T>()
+            where T : NServiceBus.AzureServiceBus.Addressing.IIndividualizationStrategy { }
+    }
+    public class AzureServiceBusMessageReceiverSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusMessageReceiverSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusMessageReceiverSettings AutoRenewTimeout(System.TimeSpan autoRenewTimeout) { }
+        public NServiceBus.AzureServiceBusMessageReceiverSettings PrefetchCount(int prefetchCount) { }
+        public NServiceBus.AzureServiceBusMessageReceiverSettings ReceiveMode(Microsoft.ServiceBus.Messaging.ReceiveMode receiveMode) { }
+        public NServiceBus.AzureServiceBusMessageReceiverSettings RetryPolicy(Microsoft.ServiceBus.RetryPolicy retryPolicy) { }
+    }
+    public class AzureServiceBusMessageSenderSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusMessageSenderSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusMessageSenderSettings BackOffTimeOnThrottle(System.TimeSpan backoffTime) { }
+        public NServiceBus.AzureServiceBusMessageSenderSettings MaximuMessageSizeInKilobytes(int sizeInKilobytes) { }
+        public NServiceBus.AzureServiceBusMessageSenderSettings OversizedBrokeredMessageHandler<T>(T instance)
+            where T : NServiceBus.AzureServiceBus.IHandleOversizedBrokeredMessages { }
+        public NServiceBus.AzureServiceBusMessageSenderSettings RetryAttemptsOnThrottle(int count) { }
+        public NServiceBus.AzureServiceBusMessageSenderSettings RetryPolicy(Microsoft.ServiceBus.RetryPolicy retryPolicy) { }
+    }
+    public class AzureServiceBusMessagingFactoriesSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusMessagingFactoriesSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusMessagingFactoriesSettings BatchFlushInterval(System.TimeSpan batchFlushInterval) { }
+        public NServiceBus.AzureServiceBusMessagingFactoriesSettings MessagingFactorySettingsFactory(System.Func<string, Microsoft.ServiceBus.Messaging.MessagingFactorySettings> factory) { }
+        public NServiceBus.AzureServiceBusMessagingFactoriesSettings NumberOfMessagingFactoriesPerNamespace(int number) { }
+        public NServiceBus.AzureServiceBusMessagingFactoriesSettings PrefetchCount(int prefetchCount) { }
+        public NServiceBus.AzureServiceBusMessagingFactoriesSettings RetryPolicy(Microsoft.ServiceBus.RetryPolicy retryPolicy) { }
+    }
+    public class AzureServiceBusNamespacePartitioningSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusNamespacePartitioningSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusNamespacePartitioningSettings AddNamespace(string @namespace) { }
+        public NServiceBus.AzureServiceBusNamespacePartitioningSettings UseStrategy<T>()
+            where T : NServiceBus.AzureServiceBus.Addressing.INamespacePartitioningStrategy { }
+    }
+    public class AzureServiceBusQueueSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusQueueSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusQueueSettings AutoDeleteOnIdle(System.TimeSpan autoDeleteOnIdle) { }
+        public NServiceBus.AzureServiceBusQueueSettings DefaultMessageTimeToLive(System.TimeSpan defaultMessageTimeToLive) { }
+        public NServiceBus.AzureServiceBusQueueSettings DescriptionFactory(System.Func<string, NServiceBus.Settings.ReadOnlySettings, Microsoft.ServiceBus.Messaging.QueueDescription> factory) { }
+        public NServiceBus.AzureServiceBusQueueSettings DuplicateDetectionHistoryTimeWindow(System.TimeSpan duplicateDetectionHistoryTimeWindow) { }
+        public NServiceBus.AzureServiceBusQueueSettings EnableBatchedOperations(bool enableBatchedOperations) { }
+        public NServiceBus.AzureServiceBusQueueSettings EnableDeadLetteringOnMessageExpiration(bool enableDeadLetteringOnMessageExpiration) { }
+        public NServiceBus.AzureServiceBusQueueSettings EnableExpress(bool enableExpress) { }
+        public NServiceBus.AzureServiceBusQueueSettings EnableExpress(System.Func<string, bool> condition, bool enableExpress) { }
+        public NServiceBus.AzureServiceBusQueueSettings EnablePartitioning(bool enablePartitioning) { }
+        public NServiceBus.AzureServiceBusQueueSettings ForwardDeadLetteredMessagesTo(string forwardDeadLetteredMessagesTo) { }
+        public NServiceBus.AzureServiceBusQueueSettings ForwardDeadLetteredMessagesTo(System.Func<string, bool> condition, string forwardDeadLetteredMessagesTo) { }
+        public NServiceBus.AzureServiceBusQueueSettings ForwardTo(string forwardTo) { }
+        public NServiceBus.AzureServiceBusQueueSettings ForwardTo(System.Func<string, bool> condition, string forwardTo) { }
+        public NServiceBus.AzureServiceBusQueueSettings LockDuration(System.TimeSpan duration) { }
+        public NServiceBus.AzureServiceBusQueueSettings MaxDeliveryCount(int maxDeliveryCount) { }
+        public NServiceBus.AzureServiceBusQueueSettings MaxSizeInMegabytes(long maxSizeInMegabytes) { }
+        public NServiceBus.AzureServiceBusQueueSettings RequiresDuplicateDetection(bool requiresDuplicateDetection) { }
+        public NServiceBus.AzureServiceBusQueueSettings RequiresSession(bool requiresSession) { }
+        public NServiceBus.AzureServiceBusQueueSettings SupportOrdering(bool supported) { }
+    }
+    public class static AzureServiceBusResourceExtensions
+    {
+        public static NServiceBus.AzureServiceBusQueueSettings Queues(this NServiceBus.AzureServiceBusResourceSettings resourceSettings) { }
+        public static NServiceBus.AzureServiceBusSubscriptionSettings Subscriptions(this NServiceBus.AzureServiceBusResourceSettings resourceSettings) { }
+        public static NServiceBus.AzureServiceBusTopicSettings Topics(this NServiceBus.AzureServiceBusResourceSettings resourceSettings) { }
+    }
+    public class AzureServiceBusResourceSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusResourceSettings(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class AzureServiceBusSanitizationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusSanitizationSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusSanitizationSettings UseStrategy<T>()
+            where T : NServiceBus.AzureServiceBus.Addressing.ISanitizationStrategy { }
+    }
+    public class AzureServiceBusSerializationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusSerializationSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusSerializationSettings BrokeredMessageBodyType(NServiceBus.AzureServiceBus.SupportedBrokeredMessageBodyTypes type) { }
+    }
+    public class AzureServiceBusSubscriptionSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusSubscriptionSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings AutoDeleteOnIdle(System.TimeSpan autoDeleteOnIdle) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings DefaultMessageTimeToLive(System.TimeSpan expiryTimespan) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings DescriptionFactory(System.Func<string, string, NServiceBus.Settings.ReadOnlySettings, Microsoft.ServiceBus.Messaging.SubscriptionDescription> factory) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings EnableBatchedOperations(bool enableBatchedOperations) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings EnableDeadLetteringOnFilterEvaluationExceptions(bool enableDeadLetteringOnFilterEvaluationExceptions) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings EnableDeadLetteringOnMessageExpiration(bool enableDeadLetteringOnMessageExpiration) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings ForwardDeadLetteredMessagesTo(string forwardDeadLetteredMessagesTo) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings ForwardDeadLetteredMessagesTo(System.Func<string, bool> condition, string forwardDeadLetteredMessagesTo) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings ForwardTo(string forwardTo) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings ForwardTo(System.Func<string, bool> condition, string forwardTo) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings LockDuration(System.TimeSpan lockDuration) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings MaxDeliveryCount(int maxDeliveryCount) { }
+        public NServiceBus.AzureServiceBusSubscriptionSettings RequiresSession(bool requiresSession) { }
+    }
+    public class AzureServiceBusTopicSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusTopicSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusTopicSettings AutoDeleteOnIdle(System.TimeSpan autoDeleteOnIdle) { }
+        public NServiceBus.AzureServiceBusTopicSettings DefaultMessageTimeToLive(System.TimeSpan timeToLive) { }
+        public NServiceBus.AzureServiceBusTopicSettings DescriptionFactory(System.Func<string, NServiceBus.Settings.ReadOnlySettings, Microsoft.ServiceBus.Messaging.TopicDescription> factory) { }
+        public NServiceBus.AzureServiceBusTopicSettings DuplicateDetectionHistoryTimeWindow(System.TimeSpan duplicateDetectionHistoryTimeWindow) { }
+        public NServiceBus.AzureServiceBusTopicSettings EnableBatchedOperations(bool enableBatchedOperations) { }
+        public NServiceBus.AzureServiceBusTopicSettings EnableExpress(bool enableExpress) { }
+        public NServiceBus.AzureServiceBusTopicSettings EnableExpress(System.Func<string, bool> condition, bool enableExpress) { }
+        public NServiceBus.AzureServiceBusTopicSettings EnableFilteringMessagesBeforePublishing(bool enableFilteringMessagesBeforePublishing) { }
+        public NServiceBus.AzureServiceBusTopicSettings EnablePartitioning(bool enablePartitioning) { }
+        public NServiceBus.AzureServiceBusTopicSettings MaxSizeInMegabytes(long maxSizeInMegabytes) { }
+        public NServiceBus.AzureServiceBusTopicSettings RequiresDuplicateDetection(bool requiresDuplicateDetection) { }
+        public NServiceBus.AzureServiceBusTopicSettings SupportOrdering(bool supported) { }
+    }
+    public class static AzureServiceBusTopologyExtensions
+    {
+        public static NServiceBus.AzureServiceBusAddressingSettings Addressing(this NServiceBus.AzureServiceBusTopologySettings topologySettings) { }
+        public static NServiceBus.AzureServiceBusResourceSettings Resources(this NServiceBus.AzureServiceBusTopologySettings topologySettings) { }
+    }
+    public class AzureServiceBusTopologySettings : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport>
+    {
+        public AzureServiceBusTopologySettings(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class AzureServiceBusTransactionSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusTransactionSettings(NServiceBus.Settings.SettingsHolder settings) { }
+    }
     public class AzureServiceBusTransport : NServiceBus.Transports.TransportDefinition
     {
         public AzureServiceBusTransport() { }
-        protected override void Configure(NServiceBus.BusConfiguration config) { }
+        public override string ExampleConnectionStringForErrorMessage { get; }
+        public override NServiceBus.Routing.EndpointInstance BindToLocalEndpoint(NServiceBus.Routing.EndpointInstance instance, NServiceBus.Settings.ReadOnlySettings settings) { }
+        protected override NServiceBus.Transports.TransportReceivingConfigurationResult ConfigureForReceiving(NServiceBus.Transports.TransportReceivingConfigurationContext context) { }
+        protected override NServiceBus.Transports.TransportSendingConfigurationResult ConfigureForSending(NServiceBus.Transports.TransportSendingConfigurationContext context) { }
+        public override NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public override NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager() { }
+        public override System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints() { }
+        public override NServiceBus.TransportTransactionMode GetSupportedTransactionMode() { }
+        public override string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress) { }
     }
-    public class static ConfigureAzureServiceBusMessageQueue
+    public class AzureServiceBusTransportConfigurator : NServiceBus.Features.Feature
     {
-        [System.ObsoleteAttribute("Please use `config.UseTransport<AzureServiceBus>()` instead. Will be removed in v" +
-            "ersion 7.0.0.", true)]
-        public static NServiceBus.Configure AzureServiceBusMessageQueue(this NServiceBus.Configure config) { }
+        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
-}
-namespace NServiceBus.Config
-{
-    
-    public class AzureServiceBusQueueConfig : System.Configuration.ConfigurationSection
+    public class static AzureServiceBusTransportExtensions
     {
-        public AzureServiceBusQueueConfig() { }
-        [System.Configuration.ConfigurationPropertyAttribute("BackoffTimeInSeconds", DefaultValue=10, IsRequired=false)]
-        public int BackoffTimeInSeconds { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("BatchSize", DefaultValue=1000, IsRequired=false)]
-        public int BatchSize { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("ConnectionString", DefaultValue="", IsRequired=false)]
-        public string ConnectionString { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("ConnectivityMode", DefaultValue="Tcp", IsRequired=false)]
-        public string ConnectivityMode { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("DefaultMessageTimeToLive", DefaultValue=92233720368547, IsRequired=false)]
-        public long DefaultMessageTimeToLive { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("DuplicateDetectionHistoryTimeWindow", DefaultValue=600000, IsRequired=false)]
-        public int DuplicateDetectionHistoryTimeWindow { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("EnableBatchedOperations", DefaultValue=true, IsRequired=false)]
-        public bool EnableBatchedOperations { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("EnableDeadLetteringOnFilterEvaluationExceptions", DefaultValue=false, IsRequired=false)]
-        public bool EnableDeadLetteringOnFilterEvaluationExceptions { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("EnableDeadLetteringOnMessageExpiration", DefaultValue=false, IsRequired=false)]
-        public bool EnableDeadLetteringOnMessageExpiration { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("EnablePartitioning", DefaultValue=false, IsRequired=false)]
-        public bool EnablePartitioning { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("IssuerKey", IsRequired=false)]
-        public string IssuerKey { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("IssuerName", DefaultValue="owner", IsRequired=false)]
-        public string IssuerName { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("LockDuration", DefaultValue=30000, IsRequired=false)]
-        public int LockDuration { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("MaxDeliveryCount", DefaultValue=6, IsRequired=false)]
-        public int MaxDeliveryCount { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("MaxSizeInMegabytes", DefaultValue=1024, IsRequired=false)]
-        public long MaxSizeInMegabytes { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("QueueName", DefaultValue=null, IsRequired=false)]
-        public string QueueName { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("QueuePerInstance", DefaultValue=false, IsRequired=false)]
-        public bool QueuePerInstance { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("RequiresDuplicateDetection", DefaultValue=false, IsRequired=false)]
-        public bool RequiresDuplicateDetection { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("RequiresSession", DefaultValue=false, IsRequired=false)]
-        public bool RequiresSession { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("ServerWaitTime", DefaultValue=300, IsRequired=false)]
-        public int ServerWaitTime { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("ServiceNamespace", IsRequired=false)]
-        public string ServiceNamespace { get; set; }
-        [System.Configuration.ConfigurationPropertyAttribute("SupportOrdering", DefaultValue=true, IsRequired=false)]
-        public bool SupportOrdering { get; set; }
+        public static NServiceBus.AzureServiceBusBatchingSettings Batching(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusConnectivitySettings Connectivity(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusSerializationSettings Serialization(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusTransactionSettings Transactions(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusTopologySettings UseDefaultTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusTopologySettings UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
+            where T : NServiceBus.AzureServiceBus.ITopology, new () { }
+        public static NServiceBus.AzureServiceBusTopologySettings UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<T> factory)
+            where T : NServiceBus.AzureServiceBus.ITopology { }
+        public static NServiceBus.AzureServiceBusTopologySettings UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, T topology)
+            where T : NServiceBus.AzureServiceBus.ITopology { }
+    }
+    public class AzureServiceBusValidationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusValidationSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusValidationSettings UseQueuePathMaximumLength(int queuePathMaximumLength) { }
+        public NServiceBus.AzureServiceBusValidationSettings UseStrategy<T>()
+            where T : NServiceBus.AzureServiceBus.Addressing.IValidationStrategy { }
+        public NServiceBus.AzureServiceBusValidationSettings UseSubscriptionPathMaximumLength(int subscriptionPathMaximumLength) { }
+        public NServiceBus.AzureServiceBusValidationSettings UseTopicPathMaximumLength(int topicPathMaximumLength) { }
     }
 }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -190,7 +190,7 @@ namespace NServiceBus.AzureServiceBus
     }
     public class BatchedOperation
     {
-        public BatchedOperation() { }
+        public BatchedOperation(int messageSizePaddingPercentage = 0) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; set; }
         public NServiceBus.Transports.OutgoingMessage Message { get; set; }
         public long GetEstimatedSize() { }
@@ -668,6 +668,7 @@ namespace NServiceBus
         public AzureServiceBusMessageSenderSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusMessageSenderSettings BackOffTimeOnThrottle(System.TimeSpan backoffTime) { }
         public NServiceBus.AzureServiceBusMessageSenderSettings MaximuMessageSizeInKilobytes(int sizeInKilobytes) { }
+        public NServiceBus.AzureServiceBusMessageSenderSettings MessageSizePaddingPercentage(int percentage) { }
         public NServiceBus.AzureServiceBusMessageSenderSettings OversizedBrokeredMessageHandler<T>(T instance)
             where T : NServiceBus.AzureServiceBus.IHandleOversizedBrokeredMessages { }
         public NServiceBus.AzureServiceBusMessageSenderSettings RetryAttemptsOnThrottle(int count) { }

--- a/src/Tests/API/APIApprovals.cs
+++ b/src/Tests/API/APIApprovals.cs
@@ -1,25 +1,25 @@
-﻿// reenable once Transport exists again
+﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.API
+{
+    using System.IO;
+    using System.Runtime.CompilerServices;
+    using ApiApprover;
+    using ApprovalTests;
+    using ApprovalTests.Reporters;
+    using Mono.Cecil;
+    using NUnit.Framework;
 
-//namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.API
-//{
-//    using System.IO;
-//    using System.Runtime.CompilerServices;
-//    using ApiApprover;
-//    using ApprovalTests;
-//    using Mono.Cecil;
-//    using NUnit.Framework;
-
-//    [TestFixture]
-//    public class APIApprovals
-//    {
-//        [Test]
-//        [MethodImpl(MethodImplOptions.NoInlining)]
-//        public void ApproveAzureServiceBusTransport()
-//        {
-//            var assemblyPath = Path.GetFullPath(typeof(AzureServiceBusTransport).Assembly.Location);
-//            var asm = AssemblyDefinition.ReadAssembly(assemblyPath);
-//            var publicApi = PublicApiGenerator.CreatePublicApiForAssembly(asm, definition => true, false);
-//            Approvals.Verify(publicApi);
-//        }
-//    }
-//}
+    [TestFixture]
+    public class APIApprovals
+    {
+        [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
+        public void ApproveAzureServiceBusTransport()
+        {
+            var assemblyPath = Path.GetFullPath(typeof(AzureServiceBusTransport).Assembly.Location);
+            var asm = AssemblyDefinition.ReadAssembly(assemblyPath);
+            var publicApi = PublicApiGenerator.CreatePublicApiForAssembly(asm, definition => true, false);
+            Approvals.Verify(publicApi);
+        }
+    }
+}

--- a/src/Tests/Configuration/When_configuring_message_senders.cs
+++ b/src/Tests/Configuration/When_configuring_message_senders.cs
@@ -35,6 +35,15 @@ namespace NServiceBus.AzureServiceBus.Tests
         }
 
         [Test]
+        public void Should_be_not_able_to_set_invalid_backoff_time_when_throttled()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => extensions.Connectivity().MessageSenders().BackOffTimeOnThrottle(TimeSpan.FromSeconds(-1)));
+        }
+
+        [Test]
         public void Should_be_able_to_set_retry_attempts_when_throttled()
         {
             var settings = new SettingsHolder();
@@ -43,6 +52,15 @@ namespace NServiceBus.AzureServiceBus.Tests
             var connectivitySettings = extensions.Connectivity().MessageSenders().RetryAttemptsOnThrottle(10);
 
             Assert.AreEqual(10, connectivitySettings.GetSettings().Get<int>(WellKnownConfigurationKeys.Connectivity.MessageSenders.RetryAttemptsOnThrottle));
+        }
+
+        [Test]
+        public void Should_be_able_to_set_invalid_retry_attempts_when_throttled()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => extensions.Connectivity().MessageSenders().RetryAttemptsOnThrottle(-1));
         }
 
         [Test]
@@ -57,6 +75,35 @@ namespace NServiceBus.AzureServiceBus.Tests
         }
 
         [Test]
+        public void Should_not_be_able_to_set_invalid_maximum_message_size_in_kilobytes()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => extensions.Connectivity().MessageSenders().MaximuMessageSizeInKilobytes(0));
+        }
+
+        [Test]
+        public void Should_be_able_to_set_message_size_padding_percentage()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            var connectivitySettings = extensions.Connectivity().MessageSenders().MessageSizePaddingPercentage(10);
+
+            Assert.AreEqual(10, connectivitySettings.GetSettings().Get<int>(WellKnownConfigurationKeys.Connectivity.MessageSenders.MessageSizePaddingPercentage));
+        }
+
+        [Test]
+        public void Should_be_not_be_able_to_set_invalid_message_size_padding_percentage()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => extensions.Connectivity().MessageSenders().MessageSizePaddingPercentage(-1));
+        }
+
+        [Test]
         public void Should_be_able_to_set_oversized_brokered_message_handler()
         {
             var settings = new SettingsHolder();
@@ -68,7 +115,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             Assert.AreEqual(myOversizedBrokeredMessageHandler, connectivitySettings.GetSettings().Get<IHandleOversizedBrokeredMessages>(WellKnownConfigurationKeys.Connectivity.MessageSenders.OversizedBrokeredMessageHandlerInstance));
         }
 
-        public class MyOversizedBrokeredMessageHandler : IHandleOversizedBrokeredMessages
+        private class MyOversizedBrokeredMessageHandler : IHandleOversizedBrokeredMessages
         {
             public Task Handle(BrokeredMessage brokeredMessage)
             {

--- a/src/Tests/Seam/When_dispatching_messages.cs
+++ b/src/Tests/Seam/When_dispatching_messages.cs
@@ -27,7 +27,7 @@
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
 
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);
@@ -63,7 +63,7 @@
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
 
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Settings;
     using NServiceBus.Transports;
     using NUnit.Framework;
 
@@ -26,7 +27,9 @@
 
             var transportOperations = new TransportOperations(multicastTransportOperations, unicastTransportOperations);
 
-            var batcher = new Batcher(new FakeTopolySectionManager());
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+
+            var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
 
             Assert.That(batches.Count, Is.EqualTo(2));
@@ -51,7 +54,9 @@
 
             var transportOperations = new TransportOperations(multicastTransportOperations, unicastTransportOperations);
 
-            var batcher = new Batcher(new FakeTopolySectionManager());
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+
+            var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
 
             Assert.That(batches.Count, Is.EqualTo(2));
@@ -76,7 +81,9 @@
 
             var transportOperations = new TransportOperations(multicastTransportOperations, unicastTransportOperations);
 
-            var batcher = new Batcher(new FakeTopolySectionManager());
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+
+            var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
 
             Assert.That(batches.Count, Is.EqualTo(4));
@@ -101,12 +108,14 @@
 
             var transportOperations = new TransportOperations(multicastTransportOperations, unicastTransportOperations);
 
-            var batcher = new Batcher(new FakeTopolySectionManager());
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+
+            var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
 
             Assert.That(batches.Count, Is.EqualTo(2));
-            Assert.That(batches[0].Operations.First().GetEstimatedSize(), Is.EqualTo(2267));
-            Assert.That(batches[1].Operations.First().GetEstimatedSize(), Is.EqualTo(2267));
+            Assert.That(batches[0].Operations.First().GetEstimatedSize(), Is.EqualTo(2164), "For default message size padding of 5% size should be 2,164 bytes");
+            Assert.That(batches[1].Operations.First().GetEstimatedSize(), Is.EqualTo(2164), "For default message size padding of 5% size should be 2,164 bytes");
         }
 
     }

--- a/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
+++ b/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var bytes = Encoding.UTF8.GetBytes("Whatever");
 
@@ -46,7 +46,7 @@ namespace NServiceBus.AzureServiceBus.Tests
 
             extensions.Serialization().BrokeredMessageBodyType(SupportedBrokeredMessageBodyTypes.Stream);
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var bytes = Encoding.UTF8.GetBytes("Whatever");
 
@@ -69,7 +69,7 @@ namespace NServiceBus.AzureServiceBus.Tests
         {
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var batchedOperation = new BatchedOperation
             {
@@ -88,7 +88,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var headers = new Dictionary<string, string>
             {
@@ -113,7 +113,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var now = DateTime.UtcNow;
             Time.UtcNow = () => now;
@@ -139,7 +139,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var now = DateTime.UtcNow;
             Time.UtcNow = () => now;
@@ -163,7 +163,7 @@ namespace NServiceBus.AzureServiceBus.Tests
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var ttl = TimeSpan.FromMinutes(1);
 
@@ -188,7 +188,7 @@ namespace NServiceBus.AzureServiceBus.Tests
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var correlationId = "SomeId";
             var headers = new Dictionary<string, string>
@@ -212,7 +212,7 @@ namespace NServiceBus.AzureServiceBus.Tests
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var headers = new Dictionary<string, string>()
             {
@@ -234,7 +234,7 @@ namespace NServiceBus.AzureServiceBus.Tests
         public void Should_set_ViaPartitionKey_if_partition_key_is_available_and_sending_via_option_is_enabled()
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var routingOptions = new RoutingOptions
             {
@@ -263,7 +263,7 @@ namespace NServiceBus.AzureServiceBus.Tests
 
             extensions.Serialization().BrokeredMessageBodyType(bodyType);
 
-            var converter = new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings);
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
 
             var bytes = Encoding.UTF8.GetBytes("Whatever");
 

--- a/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
+++ b/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
@@ -277,5 +277,26 @@ namespace NServiceBus.AzureServiceBus.Tests
 
             Assert.That(brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding], Is.EqualTo(expectedHeaderValue));
         }
+
+        [Test]
+        public void Should_inject_estimated_message_size_into_headers()
+        {
+            // default settings
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+
+            var converter = new DefaultBatchedOperationsToBrokeredMessagesConverter(settings);
+
+            var body = Encoding.UTF8.GetBytes("Whatever");
+            var headers = new Dictionary<string, string> { { "header", "value" } };
+            var batchedOperation = new BatchedOperation
+            {
+                Message = new OutgoingMessage("SomeId", headers, body),
+                DeliveryConstraints = new List<DeliveryConstraint>()
+            };
+
+            var brokeredMessage = converter.Convert(batchedOperation, new RoutingOptions());
+
+            Assert.That(brokeredMessage.Properties[BrokeredMessageHeaders.EstimatedMessageSize], Is.GreaterThan(0)); 
+        }
     }
 }

--- a/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints.cs
+++ b/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints.cs
@@ -169,7 +169,7 @@ namespace NServiceBus.AzureServiceBus.Tests
 
             // setup the batch
             var @namespace = new NamespaceInfo(AzureServiceBusConnectionString.Value, NamespaceMode.Active);
-            var bytes = Enumerable.Range(0, 250 * 1024).Select(x => (byte)(x % 256)).ToArray();
+            var bytes = Enumerable.Range(0, 220 * 1024).Select(x => (byte)(x % 256)).ToArray();
             var batch = new Batch
             {
                 Destinations = new TopologySection

--- a/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints.cs
+++ b/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints.cs
@@ -29,7 +29,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
 
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);
@@ -92,7 +92,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
 
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);
@@ -160,7 +160,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
 
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);
@@ -228,7 +228,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, new ThrowOnOversizedBrokeredMessages());
             
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);
@@ -289,7 +289,7 @@ namespace NServiceBus.AzureServiceBus.Tests
             var messagingFactoryLifeCycleManager = new MessagingFactoryLifeCycleManager(messagingFactoryCreator, settings);
             var messageSenderCreator = new MessageSenderCreator(messagingFactoryLifeCycleManager, settings);
             var clientLifecycleManager = new MessageSenderLifeCycleManager(messageSenderCreator, settings);
-            var router = new DefaultOutgoingBatchRouter(new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, oversizedHandler);
+            var router = new DefaultOutgoingBatchRouter(new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), clientLifecycleManager, settings, oversizedHandler);
 
             // create the queue
             var creator = new AzureServiceBusQueueCreator(settings);

--- a/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints_with_retries.cs
+++ b/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints_with_retries.cs
@@ -52,7 +52,7 @@
 //
 //            var router = new DefaultOutgoingBatchRouter(
 //                topology,
-//                new DefaultOutgoingMessagesToBrokeredMessagesConverter(settings), 
+//                new DefaultBatchedOperationsToBrokeredMessagesConverter(settings), 
 //                clientLifecycleManager, settings);
 //
 //            var outgoingMessage = new OutgoingMessage("SomeId", new Dictionary<string, string>(), new byte[] {});

--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -9,7 +9,7 @@
     {
         public SettingsHolder Apply(SettingsHolder settings)
         {
-            ApplyDefaultsForConnectivity(settings);
+            ApplyDefaultsForConnectivityAndSending(settings);
             ApplyDefaultValuesForAddressing(settings);
             ApplyDefaultValuesForQueueDescriptions(settings);
             ApplyDefaultValuesForTopics(settings);
@@ -37,7 +37,7 @@
             settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, new List<string>());
         }
 
-        void ApplyDefaultsForConnectivity(SettingsHolder settings)
+        void ApplyDefaultsForConnectivityAndSending(SettingsHolder settings)
         {
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.NumberOfClientsPerEntity, 5);
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.SendViaReceiveQueue, false);
@@ -48,6 +48,7 @@
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.MessageSenders.BackOffTimeOnThrottle, TimeSpan.FromSeconds(10));
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.MessageSenders.RetryAttemptsOnThrottle, 5);
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.MessageSenders.MaximumMessageSizeInKilobytes, 256);
+            settings.SetDefault(WellKnownConfigurationKeys.Connectivity.MessageSenders.MessageSizePaddingPercentage, 5);
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.MessageSenders.OversizedBrokeredMessageHandlerInstance, new ThrowOnOversizedBrokeredMessages());
         }
 

--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -9,7 +9,7 @@
     {
         public SettingsHolder Apply(SettingsHolder settings)
         {
-            ApplyDefaultsForConnectivityAndSending(settings);
+            ApplyDefaultsForConnectivity(settings);
             ApplyDefaultValuesForAddressing(settings);
             ApplyDefaultValuesForQueueDescriptions(settings);
             ApplyDefaultValuesForTopics(settings);
@@ -37,7 +37,7 @@
             settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, new List<string>());
         }
 
-        void ApplyDefaultsForConnectivityAndSending(SettingsHolder settings)
+        void ApplyDefaultsForConnectivity(SettingsHolder settings)
         {
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.NumberOfClientsPerEntity, 5);
             settings.SetDefault(WellKnownConfigurationKeys.Connectivity.SendViaReceiveQueue, false);

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageSenderSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageSenderSettings.cs
@@ -25,6 +25,7 @@ namespace NServiceBus
 
         public AzureServiceBusMessageSenderSettings BackOffTimeOnThrottle(TimeSpan backoffTime)
         {
+            Guard.AgainstNegative(nameof(backoffTime), backoffTime);
             _settings.Set(WellKnownConfigurationKeys.Connectivity.MessageSenders.BackOffTimeOnThrottle, backoffTime);
 
             return this;
@@ -32,6 +33,7 @@ namespace NServiceBus
 
         public AzureServiceBusMessageSenderSettings RetryAttemptsOnThrottle(int count)
         {
+            Guard.AgainstNegative(nameof(count), count);
             _settings.Set(WellKnownConfigurationKeys.Connectivity.MessageSenders.RetryAttemptsOnThrottle, count);
 
             return this;
@@ -39,8 +41,16 @@ namespace NServiceBus
 
         public AzureServiceBusMessageSenderSettings MaximuMessageSizeInKilobytes(int sizeInKilobytes)
         {
+            Guard.AgainstNegativeAndZero(nameof(sizeInKilobytes), sizeInKilobytes);
             _settings.Set(WellKnownConfigurationKeys.Connectivity.MessageSenders.MaximumMessageSizeInKilobytes, sizeInKilobytes);
 
+            return this;
+        }
+
+        public AzureServiceBusMessageSenderSettings MessageSizePaddingPercentage(int percentage)
+        {
+            Guard.AgainstNegative(nameof(percentage), percentage);
+            _settings.Set(WellKnownConfigurationKeys.Connectivity.MessageSenders.MessageSizePaddingPercentage, percentage);
             return this;
         }
 

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -133,6 +133,7 @@ namespace NServiceBus.AzureServiceBus
                 public const string BackOffTimeOnThrottle = "AzureServiceBus.Connectivity.MessageSenders.BackOffTimeOnThrottle";
                 public const string RetryAttemptsOnThrottle = "AzureServiceBus.Connectivity.MessageSenders.RetryAttemptsOnThrottle";
                 public const string MaximumMessageSizeInKilobytes = "AzureServiceBus.Connectivity.MessageSenders.MaximumMessageSizeInKilobytes";
+                public const string MessageSizePaddingPercentage = "AzureServiceBus.Connectivity.MessageSenders.MessageSizePaddingPercentage";
                 public const string OversizedBrokeredMessageHandlerInstance = "AzureServiceBus.Connectivity.MessageSenders.OversizedBrokeredMessageHandlerInstance";
             }
 

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Connectivity\MessageSenderLifeCycleManager.cs" />
     <Compile Include="Connectivity\TaskWithRetryExtensions.cs" />
     <Compile Include="Creation\AzureServiceBusSubscriptionCreatorV6.cs" />
+    <Compile Include="Properties\Resharper.Annotations.g.cs" />
     <Compile Include="Receiving\UnsupportedBrokeredMessageBodyTypeException.cs" />
     <Compile Include="Seam\TransportResourcesCreator.cs" />
     <Compile Include="Utils\BrokeredMessageHeaders.cs" />
@@ -103,6 +104,7 @@
     <Compile Include="Topology\ITopology.cs" />
     <Compile Include="Topology\Topologies\ForwardingTopology.cs" />
     <Compile Include="Topology\Topologies\StandardTopology.cs" />
+    <Compile Include="Utils\Guard.cs" />
     <Compile Include="Utils\IRegisterTransportParts.cs" />
     <Compile Include="Receiving\IncomingMessageDetails.cs" />
     <Compile Include="Receiving\SupportedBrokeredMessageBodyTypes.cs" />

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -150,7 +150,7 @@
     <Compile Include="Receiving\DefaultBrokeredMessagesToIncomingMessagesConverter.cs" />
     <Compile Include="Receiving\IConvertBrokeredMessagesToIncomingMessages.cs" />
     <Compile Include="Sending\DefaultOutgoingBatchRouter.cs" />
-    <Compile Include="Sending\DefaultOutgoingMessagesToBrokeredMessagesConverter.cs" />
+    <Compile Include="Sending\DefaultBatchedOperationsToBrokeredMessagesConverter.cs" />
     <Compile Include="Sending\IRouteOutgoingBatches.cs" />
     <Compile Include="Sending\IConvertOutgoingMessagesToBrokeredMessages.cs" />
     <Compile Include="Receiving\INotifyIncomingMessages.cs" />

--- a/src/Transport/Properties/Resharper.Annotations.g.cs
+++ b/src/Transport/Properties/Resharper.Annotations.g.cs
@@ -1,0 +1,933 @@
+﻿using System;
+using System.Diagnostics;
+// ReSharper disable CommentTypo
+// ReSharper disable IdentifierTypo
+
+#pragma warning disable 1591
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable IntroduceOptionalParameters.Global
+// ReSharper disable MemberCanBeProtected.Global
+// ReSharper disable InconsistentNaming
+
+namespace JetBrains.Annotations
+{
+    /// <summary>
+    /// Indicates that the value of the marked element could be <c>null</c> sometimes,
+    /// so the check for <c>null</c> is necessary before its usage
+    /// </summary>
+    /// <example><code>
+    /// [CanBeNull] public object Test() { return null; }
+    /// public void UseTest() {
+    ///   var p = Test();
+    ///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
+    /// }
+    /// </code></example>
+    [AttributeUsage(
+      AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+      AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class CanBeNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that the value of the marked element could never be <c>null</c>
+    /// </summary>
+    /// <example><code>
+    /// [NotNull] public object Foo() {
+    ///   return null; // Warning: Possible 'null' assignment
+    /// }
+    /// </code></example>
+    [AttributeUsage(
+      AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+      AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that collection or enumerable value does not contain null elements
+    /// </summary>
+    [AttributeUsage(
+      AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+      AttributeTargets.Delegate | AttributeTargets.Field)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class ItemNotNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that collection or enumerable value can contain null elements
+    /// </summary>
+    [AttributeUsage(
+      AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+      AttributeTargets.Delegate | AttributeTargets.Field)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class ItemCanBeNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that the marked method builds string by format pattern and (optional) arguments.
+    /// Parameter, which contains format string, should be given in constructor. The format string
+    /// should be in <see cref="string.Format(IFormatProvider,string,object[])"/>-like form
+    /// </summary>
+    /// <example><code>
+    /// [StringFormatMethod("message")]
+    /// public void ShowError(string message, params object[] args) { /* do something */ }
+    /// public void Foo() {
+    ///   ShowError("Failed: {0}"); // Warning: Non-existing argument in format string
+    /// }
+    /// </code></example>
+    [AttributeUsage(
+      AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Delegate)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class StringFormatMethodAttribute : Attribute
+    {
+        /// <param name="formatParameterName">
+        /// Specifies which parameter of an annotated method should be treated as format-string
+        /// </param>
+        public StringFormatMethodAttribute(string formatParameterName)
+        {
+            FormatParameterName = formatParameterName;
+        }
+
+        public string FormatParameterName { get; private set; }
+    }
+
+    /// <summary>
+    /// For a parameter that is expected to be one of the limited set of values.
+    /// Specify fields of which type should be used as values for this parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class ValueProviderAttribute : Attribute
+    {
+        public ValueProviderAttribute(string name)
+        {
+            Name = name;
+        }
+
+        [NotNull]
+        public string Name { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the function argument should be string literal and match one
+    /// of the parameters of the caller function. For example, ReSharper annotates
+    /// the parameter of <see cref="System.ArgumentNullException"/>
+    /// </summary>
+    /// <example><code>
+    /// public void Foo(string param) {
+    ///   if (param == null)
+    ///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
+    /// }
+    /// </code></example>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class InvokerParameterNameAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that the method is contained in a type that implements
+    /// <c>System.ComponentModel.INotifyPropertyChanged</c> interface and this method
+    /// is used to notify that some property value changed
+    /// </summary>
+    /// <remarks>
+    /// The method should be non-static and conform to one of the supported signatures:
+    /// <list>
+    /// <item><c>NotifyChanged(string)</c></item>
+    /// <item><c>NotifyChanged(params string[])</c></item>
+    /// <item><c>NotifyChanged{T}(Expression{Func{T}})</c></item>
+    /// <item><c>NotifyChanged{T,U}(Expression{Func{T,U}})</c></item>
+    /// <item><c>SetProperty{T}(ref T, T, string)</c></item>
+    /// </list>
+    /// </remarks>
+    /// <example><code>
+    /// public class Foo : INotifyPropertyChanged {
+    ///   public event PropertyChangedEventHandler PropertyChanged;
+    ///   [NotifyPropertyChangedInvocator]
+    ///   protected virtual void NotifyChanged(string propertyName) { ... }
+    ///
+    ///   private string _name;
+    ///   public string Name {
+    ///     get { return _name; }
+    ///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
+    ///   }
+    /// }
+    /// </code>
+    /// Examples of generated notifications:
+    /// <list>
+    /// <item><c>NotifyChanged("Property")</c></item>
+    /// <item><c>NotifyChanged(() =&gt; Property)</c></item>
+    /// <item><c>NotifyChanged((VM x) =&gt; x.Property)</c></item>
+    /// <item><c>SetProperty(ref myField, value, "Property")</c></item>
+    /// </list>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
+    {
+        public NotifyPropertyChangedInvocatorAttribute() { }
+        public NotifyPropertyChangedInvocatorAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; private set; }
+    }
+
+    /// <summary>
+    /// Describes dependency between method input and output
+    /// </summary>
+    /// <syntax>
+    /// <p>Function Definition Table syntax:</p>
+    /// <list>
+    /// <item>FDT      ::= FDTRow [;FDTRow]*</item>
+    /// <item>FDTRow   ::= Input =&gt; Output | Output &lt;= Input</item>
+    /// <item>Input    ::= ParameterName: Value [, Input]*</item>
+    /// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
+    /// <item>Value    ::= true | false | null | notnull | canbenull</item>
+    /// </list>
+    /// If method has single input parameter, it's name could be omitted.<br/>
+    /// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same)
+    /// for method output means that the methos doesn't return normally.<br/>
+    /// <c>canbenull</c> annotation is only applicable for output parameters.<br/>
+    /// You can use multiple <c>[ContractAnnotation]</c> for each FDT row,
+    /// or use single attribute with rows separated by semicolon.<br/>
+    /// </syntax>
+    /// <examples><list>
+    /// <item><code>
+    /// [ContractAnnotation("=> halt")]
+    /// public void TerminationMethod()
+    /// </code></item>
+    /// <item><code>
+    /// [ContractAnnotation("halt &lt;= condition: false")]
+    /// public void Assert(bool condition, string text) // regular assertion method
+    /// </code></item>
+    /// <item><code>
+    /// [ContractAnnotation("s:null => true")]
+    /// public bool IsNullOrEmpty(string s) // string.IsNullOrEmpty()
+    /// </code></item>
+    /// <item><code>
+    /// // A method that returns null if the parameter is null,
+    /// // and not null if the parameter is not null
+    /// [ContractAnnotation("null => null; notnull => notnull")]
+    /// public object Transform(object data) 
+    /// </code></item>
+    /// <item><code>
+    /// [ContractAnnotation("s:null=>false; =>true,result:notnull; =>false, result:null")]
+    /// public bool TryParse(string s, out Person result)
+    /// </code></item>
+    /// </list></examples>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class ContractAnnotationAttribute : Attribute
+    {
+        public ContractAnnotationAttribute([NotNull] string contract)
+          : this(contract, false)
+        { }
+
+        public ContractAnnotationAttribute([NotNull] string contract, bool forceFullStates)
+        {
+            Contract = contract;
+            ForceFullStates = forceFullStates;
+        }
+
+        public string Contract { get; private set; }
+        public bool ForceFullStates { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that marked element should be localized or not
+    /// </summary>
+    /// <example><code>
+    /// [LocalizationRequiredAttribute(true)]
+    /// public class Foo {
+    ///   private string str = "my string"; // Warning: Localizable string
+    /// }
+    /// </code></example>
+    [AttributeUsage(AttributeTargets.All)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class LocalizationRequiredAttribute : Attribute
+    {
+        public LocalizationRequiredAttribute() : this(true) { }
+        public LocalizationRequiredAttribute(bool required)
+        {
+            Required = required;
+        }
+
+        public bool Required { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the value of the marked type (or its derivatives)
+    /// cannot be compared using '==' or '!=' operators and <c>Equals()</c>
+    /// should be used instead. However, using '==' or '!=' for comparison
+    /// with <c>null</c> is always permitted.
+    /// </summary>
+    /// <example><code>
+    /// [CannotApplyEqualityOperator]
+    /// class NoEquality { }
+    /// class UsesNoEquality {
+    ///   public void Test() {
+    ///     var ca1 = new NoEquality();
+    ///     var ca2 = new NoEquality();
+    ///     if (ca1 != null) { // OK
+    ///       bool condition = ca1 == ca2; // Warning
+    ///     }
+    ///   }
+    /// }
+    /// </code></example>
+    [AttributeUsage(
+      AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class CannotApplyEqualityOperatorAttribute : Attribute { }
+
+    /// <summary>
+    /// When applied to a target attribute, specifies a requirement for any type marked
+    /// with the target attribute to implement or inherit specific type or types.
+    /// </summary>
+    /// <example><code>
+    /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
+    /// public class ComponentAttribute : Attribute { }
+    /// [Component] // ComponentAttribute requires implementing IComponent interface
+    /// public class MyComponent : IComponent { }
+    /// </code></example>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [BaseTypeRequired(typeof(Attribute))]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class BaseTypeRequiredAttribute : Attribute
+    {
+        public BaseTypeRequiredAttribute([NotNull] Type baseType)
+        {
+            BaseType = baseType;
+        }
+
+        [NotNull]
+        public Type BaseType { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the marked symbol is used implicitly
+    /// (e.g. via reflection, in external library), so this symbol
+    /// will not be marked as unused (as well as by other usage inspections)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class UsedImplicitlyAttribute : Attribute
+    {
+        public UsedImplicitlyAttribute()
+          : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default)
+        { }
+
+        public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags)
+          : this(useKindFlags, ImplicitUseTargetFlags.Default)
+        { }
+
+        public UsedImplicitlyAttribute(ImplicitUseTargetFlags targetFlags)
+          : this(ImplicitUseKindFlags.Default, targetFlags)
+        { }
+
+        public UsedImplicitlyAttribute(
+          ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+        {
+            UseKindFlags = useKindFlags;
+            TargetFlags = targetFlags;
+        }
+
+        public ImplicitUseKindFlags UseKindFlags { get; private set; }
+        public ImplicitUseTargetFlags TargetFlags { get; private set; }
+    }
+
+    /// <summary>
+    /// Should be used on attributes and causes ReSharper
+    /// to not mark symbols marked with such attributes as unused
+    /// (as well as by other usage inspections)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.GenericParameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class MeansImplicitUseAttribute : Attribute
+    {
+        public MeansImplicitUseAttribute()
+          : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default)
+        { }
+
+        public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
+          : this(useKindFlags, ImplicitUseTargetFlags.Default)
+        { }
+
+        public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
+          : this(ImplicitUseKindFlags.Default, targetFlags)
+        { }
+
+        public MeansImplicitUseAttribute(
+          ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+        {
+            UseKindFlags = useKindFlags;
+            TargetFlags = targetFlags;
+        }
+
+        [UsedImplicitly]
+        public ImplicitUseKindFlags UseKindFlags { get; private set; }
+        [UsedImplicitly]
+        public ImplicitUseTargetFlags TargetFlags { get; private set; }
+    }
+
+    [Flags]
+    internal enum ImplicitUseKindFlags
+    {
+        Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
+        /// <summary>Only entity marked with attribute considered used</summary>
+        Access = 1,
+        /// <summary>Indicates implicit assignment to a member</summary>
+        Assign = 2,
+        /// <summary>
+        /// Indicates implicit instantiation of a type with fixed constructor signature.
+        /// That means any unused constructor parameters won't be reported as such.
+        /// </summary>
+        InstantiatedWithFixedConstructorSignature = 4,
+        /// <summary>Indicates implicit instantiation of a type</summary>
+        InstantiatedNoFixedConstructorSignature = 8,
+    }
+
+    /// <summary>
+    /// Specify what is considered used implicitly when marked
+    /// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>
+    /// </summary>
+    [Flags]
+    internal enum ImplicitUseTargetFlags
+    {
+        Default = Itself,
+        Itself = 1,
+        /// <summary>Members of entity marked with attribute are considered used</summary>
+        Members = 2,
+        /// <summary>Entity marked with attribute and all its members considered used</summary>
+        WithMembers = Itself | Members
+    }
+
+    /// <summary>
+    /// This attribute is intended to mark publicly available API
+    /// which should not be removed and so is treated as used
+    /// </summary>
+    [MeansImplicitUse]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class PublicAPIAttribute : Attribute
+    {
+        public PublicAPIAttribute() { }
+        public PublicAPIAttribute([NotNull] string comment)
+        {
+            Comment = comment;
+        }
+
+        public string Comment { get; private set; }
+    }
+
+    /// <summary>
+    /// Tells code analysis engine if the parameter is completely handled
+    /// when the invoked method is on stack. If the parameter is a delegate,
+    /// indicates that delegate is executed while the method is executed.
+    /// If the parameter is an enumerable, indicates that it is enumerated
+    /// while the method is executed
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class InstantHandleAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that a method does not make any observable state changes.
+    /// The same as <c>System.Diagnostics.Contracts.PureAttribute</c>
+    /// </summary>
+    /// <example><code>
+    /// [Pure] private int Multiply(int x, int y) { return x * y; }
+    /// public void Foo() {
+    ///   const int a = 2, b = 2;
+    ///   Multiply(a, b); // Waring: Return value of pure method is not used
+    /// }
+    /// </code></example>
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class PureAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that a parameter is a path to a file or a folder within a web project.
+    /// Path can be relative or absolute, starting from web root (~)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal class PathReferenceAttribute : Attribute
+    {
+        public PathReferenceAttribute() { }
+        public PathReferenceAttribute([PathReference] string basePath)
+        {
+            BasePath = basePath;
+        }
+
+        public string BasePath { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcAreaMasterLocationFormatAttribute : Attribute
+    {
+        public AspMvcAreaMasterLocationFormatAttribute(string format)
+        {
+            Format = format;
+        }
+
+        public string Format { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcAreaPartialViewLocationFormatAttribute : Attribute
+    {
+        public AspMvcAreaPartialViewLocationFormatAttribute(string format)
+        {
+            Format = format;
+        }
+
+        public string Format { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcAreaViewLocationFormatAttribute : Attribute
+    {
+        public AspMvcAreaViewLocationFormatAttribute(string format)
+        {
+            Format = format;
+        }
+
+        public string Format { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcMasterLocationFormatAttribute : Attribute
+    {
+        public AspMvcMasterLocationFormatAttribute(string format)
+        {
+            Format = format;
+        }
+
+        public string Format { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcPartialViewLocationFormatAttribute : Attribute
+    {
+        public AspMvcPartialViewLocationFormatAttribute(string format)
+        {
+            Format = format;
+        }
+
+        public string Format { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcViewLocationFormatAttribute : Attribute
+    {
+        public AspMvcViewLocationFormatAttribute(string format)
+        {
+            Format = format;
+        }
+
+        public string Format { get; private set; }
+    }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+    /// is an MVC action. If applied to a method, the MVC action name is calculated
+    /// implicitly from the context. Use this attribute for custom wrappers similar to
+    /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcActionAttribute : Attribute
+    {
+        public AspMvcActionAttribute() { }
+        public AspMvcActionAttribute(string anonymousProperty)
+        {
+            AnonymousProperty = anonymousProperty;
+        }
+
+        public string AnonymousProperty { get; private set; }
+    }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Indicates that a parameter is an MVC area.
+    /// Use this attribute for custom wrappers similar to
+    /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcAreaAttribute : PathReferenceAttribute
+    {
+        public AspMvcAreaAttribute() { }
+        public AspMvcAreaAttribute(string anonymousProperty)
+        {
+            AnonymousProperty = anonymousProperty;
+        }
+
+        public string AnonymousProperty { get; private set; }
+    }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter is
+    /// an MVC controller. If applied to a method, the MVC controller name is calculated
+    /// implicitly from the context. Use this attribute for custom wrappers similar to
+    /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcControllerAttribute : Attribute
+    {
+        public AspMvcControllerAttribute() { }
+        public AspMvcControllerAttribute(string anonymousProperty)
+        {
+            AnonymousProperty = anonymousProperty;
+        }
+
+        public string AnonymousProperty { get; private set; }
+    }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Indicates that a parameter is an MVC Master. Use this attribute
+    /// for custom wrappers similar to <c>System.Web.Mvc.Controller.View(String, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcMasterAttribute : Attribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Indicates that a parameter is an MVC model type. Use this attribute
+    /// for custom wrappers similar to <c>System.Web.Mvc.Controller.View(String, Object)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcModelTypeAttribute : Attribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter is an MVC
+    /// partial view. If applied to a method, the MVC partial view name is calculated implicitly
+    /// from the context. Use this attribute for custom wrappers similar to
+    /// <c>System.Web.Mvc.Html.RenderPartialExtensions.RenderPartial(HtmlHelper, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcPartialViewAttribute : PathReferenceAttribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Allows disabling inspections for MVC views within a class or a method
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcSupressViewErrorAttribute : Attribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Indicates that a parameter is an MVC display template.
+    /// Use this attribute for custom wrappers similar to 
+    /// <c>System.Web.Mvc.Html.DisplayExtensions.DisplayForModel(HtmlHelper, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcDisplayTemplateAttribute : Attribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Indicates that a parameter is an MVC editor template.
+    /// Use this attribute for custom wrappers similar to
+    /// <c>System.Web.Mvc.Html.EditorExtensions.EditorForModel(HtmlHelper, String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcEditorTemplateAttribute : Attribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. Indicates that a parameter is an MVC template.
+    /// Use this attribute for custom wrappers similar to
+    /// <c>System.ComponentModel.DataAnnotations.UIHintAttribute(System.String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcTemplateAttribute : Attribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+    /// is an MVC view. If applied to a method, the MVC view name is calculated implicitly
+    /// from the context. Use this attribute for custom wrappers similar to
+    /// <c>System.Web.Mvc.Controller.View(Object)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcViewAttribute : PathReferenceAttribute { }
+
+    /// <summary>
+    /// ASP.NET MVC attribute. When applied to a parameter of an attribute,
+    /// indicates that this parameter is an MVC action name
+    /// </summary>
+    /// <example><code>
+    /// [ActionName("Foo")]
+    /// public ActionResult Login(string returnUrl) {
+    ///   ViewBag.ReturnUrl = Url.Action("Foo"); // OK
+    ///   return RedirectToAction("Bar"); // Error: Cannot resolve action
+    /// }
+    /// </code></example>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMvcActionSelectorAttribute : Attribute { }
+
+    [AttributeUsage(
+      AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class HtmlElementAttributesAttribute : Attribute
+    {
+        public HtmlElementAttributesAttribute() { }
+        public HtmlElementAttributesAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; private set; }
+    }
+
+    [AttributeUsage(
+      AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class HtmlAttributeValueAttribute : Attribute
+    {
+        public HtmlAttributeValueAttribute([NotNull] string name)
+        {
+            Name = name;
+        }
+
+        [NotNull]
+        public string Name { get; private set; }
+    }
+
+    /// <summary>
+    /// Razor attribute. Indicates that a parameter or a method is a Razor section.
+    /// Use this attribute for custom wrappers similar to 
+    /// <c>System.Web.WebPages.WebPageBase.RenderSection(String)</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorSectionAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates how method invocation affects content of the collection
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class CollectionAccessAttribute : Attribute
+    {
+        public CollectionAccessAttribute(CollectionAccessType collectionAccessType)
+        {
+            CollectionAccessType = collectionAccessType;
+        }
+
+        public CollectionAccessType CollectionAccessType { get; private set; }
+    }
+
+    [Flags]
+    internal enum CollectionAccessType
+    {
+        /// <summary>Method does not use or modify content of the collection</summary>
+        None = 0,
+        /// <summary>Method only reads content of the collection but does not modify it</summary>
+        Read = 1,
+        /// <summary>Method can change content of the collection but does not add new elements</summary>
+        ModifyExistingContent = 2,
+        /// <summary>Method can add new elements to the collection</summary>
+        UpdatedContent = ModifyExistingContent | 4
+    }
+
+    /// <summary>
+    /// Indicates that the marked method is assertion method, i.e. it halts control flow if
+    /// one of the conditions is satisfied. To set the condition, mark one of the parameters with 
+    /// <see cref="AssertionConditionAttribute"/> attribute
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AssertionMethodAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates the condition parameter of the assertion method. The method itself should be
+    /// marked by <see cref="AssertionMethodAttribute"/> attribute. The mandatory argument of
+    /// the attribute is the assertion type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AssertionConditionAttribute : Attribute
+    {
+        public AssertionConditionAttribute(AssertionConditionType conditionType)
+        {
+            ConditionType = conditionType;
+        }
+
+        public AssertionConditionType ConditionType { get; private set; }
+    }
+
+    /// <summary>
+    /// Specifies assertion type. If the assertion method argument satisfies the condition,
+    /// then the execution continues. Otherwise, execution is assumed to be halted
+    /// </summary>
+    internal enum AssertionConditionType
+    {
+        /// <summary>Marked parameter should be evaluated to true</summary>
+        IS_TRUE = 0,
+        /// <summary>Marked parameter should be evaluated to false</summary>
+        IS_FALSE = 1,
+        /// <summary>Marked parameter should be evaluated to null value</summary>
+        IS_NULL = 2,
+        /// <summary>Marked parameter should be evaluated to not null value</summary>
+        IS_NOT_NULL = 3,
+    }
+
+    /// <summary>
+    /// Indicates that method is pure LINQ method, with postponed enumeration (like Enumerable.Select,
+    /// .Where). This annotation allows inference of [InstantHandle] annotation for parameters
+    /// of delegate type by analyzing LINQ method chains.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class LinqTunnelAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that IEnumerable, passed as parameter, is not enumerated.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class NoEnumerationAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that parameter is regular expression pattern.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RegexPatternAttribute : Attribute { }
+
+    /// <summary>
+    /// XAML attribute. Indicates the type that has <c>ItemsSource</c> property and should be
+    /// treated as <c>ItemsControl</c>-derived type, to enable inner  items <c>DataContext</c>
+    /// type resolve.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class XamlItemsControlAttribute : Attribute { }
+
+    /// <summary>
+    /// XAML attibute. Indicates the property of some <c>BindingBase</c>-derived type, that
+    /// is used to bind some item of <c>ItemsControl</c>-derived type. This annotation will
+    /// enable the <c>DataContext</c> type resolve for XAML bindings for such properties.
+    /// </summary>
+    /// <remarks>
+    /// Property should have the tree ancestor of the <c>ItemsControl</c> type or
+    /// marked with the <see cref="XamlItemsControlAttribute"/> attribute.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class XamlItemBindingOfItemsControlAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspChildControlTypeAttribute : Attribute
+    {
+        public AspChildControlTypeAttribute(string tagName, Type controlType)
+        {
+            TagName = tagName;
+            ControlType = controlType;
+        }
+
+        public string TagName { get; private set; }
+        public Type ControlType { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspDataFieldAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspDataFieldsAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspMethodPropertyAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspRequiredAttributeAttribute : Attribute
+    {
+        public AspRequiredAttributeAttribute([NotNull] string attribute)
+        {
+            Attribute = attribute;
+        }
+
+        public string Attribute { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class AspTypePropertyAttribute : Attribute
+    {
+        public bool CreateConstructorReferences { get; private set; }
+
+        public AspTypePropertyAttribute(bool createConstructorReferences)
+        {
+            CreateConstructorReferences = createConstructorReferences;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorImportNamespaceAttribute : Attribute
+    {
+        public RazorImportNamespaceAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorInjectionAttribute : Attribute
+    {
+        public RazorInjectionAttribute(string type, string fieldName)
+        {
+            Type = type;
+            FieldName = fieldName;
+        }
+
+        public string Type { get; private set; }
+        public string FieldName { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorHelperCommonAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorLayoutAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorWriteLiteralMethodAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorWriteMethodAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class RazorWriteMethodParameterAttribute : Attribute { }
+
+    /// <summary>
+    /// Prevents the Member Reordering feature from tossing members of the marked class.
+    /// </summary>
+    /// <remarks>
+    /// The attribute must be mentioned in your member reordering patterns.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All)]
+    [Conditional("JETBRAINS_ANNOTATIONS")]
+    internal sealed class NoReorder : Attribute { }
+}

--- a/src/Transport/Sending/Batcher.cs
+++ b/src/Transport/Sending/Batcher.cs
@@ -45,7 +45,7 @@ namespace NServiceBus.AzureServiceBus
                 batch.Operations.Add(new BatchedOperation
                 {
                     Message = unicastOperation.Message,
-                    DeliveryConstraints = unicastOperation.DeliveryConstraints
+                    DeliveryConstraints = unicastOperation.DeliveryConstraints,
                 });
             }
         }
@@ -110,5 +110,40 @@ namespace NServiceBus.AzureServiceBus
         public OutgoingMessage Message { get; set; }
 
         public IEnumerable<DeliveryConstraint> DeliveryConstraints { get; set; }
+
+        public long GetEstimatedSize()
+        {
+            const int assumeSize = 256;
+            var standardPropertiesSize = GetStringSizeInBytes(Message.MessageId) +
+                                         assumeSize + // ContentType +
+                                         assumeSize + // CorrelationId +
+                                         4 + // DeliveryCount
+                                         8 + // EnqueuedSequenceNumber
+                                         8 + // EnqueuedTimeUtc
+                                         8 + // ExpiresAtUtc
+                                         1 + // ForcePersistence
+                                         1 + // IsBodyConsumed
+                                         assumeSize + // Label
+                                         8 + // LockedUntilUtc 
+                                         16 + // LockToken 
+                                         assumeSize + // PartitionKey
+                                         8 + // ScheduledEnqueueTimeUtc
+                                         8 + // SequenceNumber
+                                         assumeSize + // SessionId
+                                         4 + // State
+                                         8 + // TimeToLive +
+                                         assumeSize + // To +
+                                         assumeSize;  // ViaPartitionKey;
+
+            var headers = Message.Headers.Sum(property => GetStringSizeInBytes(property.Key) + GetStringSizeInBytes(property.Value));
+            var bodySize = Message.Body.Length;
+            var total = standardPropertiesSize + headers + bodySize;
+
+            const double addTenPercent = 1.1;
+            var estimatedSize = (long)(total * addTenPercent);
+            return estimatedSize;
+        }
+
+        private static int GetStringSizeInBytes(string value) => value != null ? Encoding.UTF8.GetByteCount(value) : 0;
     }
 }

--- a/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
@@ -9,11 +9,11 @@ namespace NServiceBus.AzureServiceBus
     using NServiceBus.Settings;
     using NServiceBus.Transports;
 
-    public class DefaultOutgoingMessagesToBrokeredMessagesConverter : IConvertOutgoingMessagesToBrokeredMessages
+    public class DefaultBatchedOperationsToBrokeredMessagesConverter : IConvertOutgoingMessagesToBrokeredMessages
     {
         readonly ReadOnlySettings settings;
 
-        public DefaultOutgoingMessagesToBrokeredMessagesConverter(ReadOnlySettings settings)
+        public DefaultBatchedOperationsToBrokeredMessagesConverter(ReadOnlySettings settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
@@ -41,7 +41,14 @@ namespace NServiceBus.AzureServiceBus
 
             SetViaPartitionKeyToIncomingBrokeredMessagePartitionKey(brokeredMessage, routingOptions);
 
+            SetEstimatedMessageSizeHeader(brokeredMessage, outgoingOperation.GetEstimatedSize());
+
             return brokeredMessage;
+        }
+
+        private void SetEstimatedMessageSizeHeader(BrokeredMessage brokeredMessage, long estimatedSize)
+        {
+            brokeredMessage.Properties[BrokeredMessageHeaders.EstimatedMessageSize] = estimatedSize;
         }
 
         private void SetViaPartitionKeyToIncomingBrokeredMessagePartitionKey(BrokeredMessage brokeredMessage, RoutingOptions routingOptions)

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -57,7 +57,7 @@ namespace NServiceBus.AzureServiceBus
             container.RegisterSingleton<AzureServiceBusTopicCreator>();
             container.RegisterSingleton<AzureServiceBusSubscriptionCreator>();
             container.Register<DefaultBrokeredMessagesToIncomingMessagesConverter>();
-            container.Register<DefaultOutgoingMessagesToBrokeredMessagesConverter>();
+            container.Register<DefaultBatchedOperationsToBrokeredMessagesConverter>();
             container.Register<TopologyCreator>();
             container.Register<Batcher>();
 

--- a/src/Transport/Topology/Topologies/StandardTopology.cs
+++ b/src/Transport/Topology/Topologies/StandardTopology.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.AzureServiceBus
             container.RegisterSingleton<AzureServiceBusTopicCreator>();
             container.RegisterSingleton<AzureServiceBusSubscriptionCreatorV6>();
             container.Register<DefaultBrokeredMessagesToIncomingMessagesConverter>();
-            container.Register<DefaultOutgoingMessagesToBrokeredMessagesConverter>();
+            container.Register<DefaultBatchedOperationsToBrokeredMessagesConverter>();
             container.Register<TopologyCreator>();
             container.Register<Batcher>();
 

--- a/src/Transport/Utils/BrokeredMessageExtensions.cs
+++ b/src/Transport/Utils/BrokeredMessageExtensions.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
     using System.Threading.Tasks;
     using System.Transactions;
     using Microsoft.ServiceBus.Messaging;
+    using NServiceBus.AzureServiceBus;
 
     static class BrokeredMessageExtensions
     {
@@ -78,6 +79,13 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus
                 Log.Warn($"A timeout exception occured while trying to abandon a message, the exception was {ex.Message}", ex);
             }
             return false;
+        }
+
+        public static long EstimatedSize(this BrokeredMessage message)
+        {
+            object size;
+            message.Properties.TryGetValue(BrokeredMessageHeaders.EstimatedMessageSize, out size);
+            return Convert.ToInt64(size);
         }
 
         static ILog Log = LogManager.GetLogger(typeof(BrokeredMessageExtensions));

--- a/src/Transport/Utils/BrokeredMessageHeaders.cs
+++ b/src/Transport/Utils/BrokeredMessageHeaders.cs
@@ -3,5 +3,6 @@ namespace NServiceBus.AzureServiceBus
     internal static class BrokeredMessageHeaders
     {
         public const string TransportEncoding = "NServiceBus.Transport.Encoding";
+        public const string EstimatedMessageSize = "NServiceBus.Transport.EstimatedSize";
     }
 }

--- a/src/Transport/Utils/Guard.cs
+++ b/src/Transport/Utils/Guard.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AzureServiceBus
+{
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Reflection;
+    using JetBrains.Annotations;
+
+    static class Guard
+    {
+        // ReSharper disable UnusedParameter.Global
+        public static void TypeHasDefaultConstructor(Type type, [InvokerParameterName] string argumentName)
+        {
+            if (type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .All(ctor => ctor.GetParameters().Length != 0))
+            {
+                var error = $"Type '{type.FullName}' must have a default constructor.";
+                throw new ArgumentException(error, argumentName);
+            }
+        }
+
+        [ContractAnnotation("value: null => halt")]
+        public static void AgainstNull([InvokerParameterName] string argumentName, [NotNull] object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+        }
+
+        [ContractAnnotation("value: null => halt")]
+        public static void AgainstNullAndEmpty([InvokerParameterName] string argumentName, [NotNull] string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+        }
+
+        [ContractAnnotation("value: null => halt")]
+        public static void AgainstNullAndEmpty([InvokerParameterName] string argumentName, [NotNull, NoEnumeration] ICollection value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+            if (value.Count == 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegativeAndZero([InvokerParameterName] string argumentName, int value)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegative([InvokerParameterName] string argumentName, int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegativeAndZero([InvokerParameterName] string argumentName, TimeSpan value)
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+
+        public static void AgainstNegative([InvokerParameterName] string argumentName, TimeSpan value)
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replacing ASB native API for `BrokeredMessage.Size` with estimated message size.

Estimated size is based on the following:
- Raw body size in bytes
- Custom headers size (keys and values) in bytes
- Guestimated standard properties size (for strings assumed size is 256 bytes) in bytes
- Additional 10% to take into consideration serialization and internals added by ASB upon sending

**Some stats**

Sending a message with a specific payload, with added standard NSB headers, and _no_ exception headers led to the following results:

| Single Payload Size   |.Size   | .EstimatedSize  | Increase |
|---|---:|---:|:---:|
|0K  | 1,474  | 3,232 | 119% |
|1K   | 2,807  | 4,754 | 69% |
| 10K  | 15,147  | 18,271 | 20% |
| 100K  | 137,977  | 153,439 | 11% |
| 170K  | 233,550  | 258,568 | 11% |

Based on the numbers, small messages will not be batched very well. Perhaps, some of the assumptions need to be reviewed (estimated size of the standard properties and additional percentage added to the overall size that might be too aggressive).

@Particular/azure-maintainers please review

Connect to #86 