### PR TITLE
PurgeOnStartup should throw because not supported

### DIFF
--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Connectivity\When_executing_task_with_retry.cs" />
     <Compile Include="Creation\When_creating_subscription_backward_compatible_with_v6.cs" />
     <Compile Include="Seam\When_dispatching_messages.cs" />
+    <Compile Include="Seam\When_purge_on_startup_is_enabled.cs" />
     <Compile Include="Seam\When_dispatching_messages_in_receive_context.cs" />
     <Compile Include="Seam\When_message_pump_is_failing_to_receive_messages.cs" />
     <Compile Include="Seam\When_receiving_messages.cs" />

--- a/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
+++ b/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
@@ -1,17 +1,8 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
 {
-    using System;
-    using System.Collections.Generic;
     using System.Configuration;
-    using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AzureServiceBus;
-    using NServiceBus.AzureServiceBus.Tests;
-    using NServiceBus.DeliveryConstraints;
-    using NServiceBus.Routing;
-    using NServiceBus.Settings;
     using NServiceBus.Transports;
     using NUnit.Framework;
 

--- a/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
+++ b/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
@@ -1,0 +1,39 @@
+namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.ServiceBus.Messaging;
+    using NServiceBus.AzureServiceBus;
+    using NServiceBus.AzureServiceBus.Tests;
+    using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Routing;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_purge_on_startup_is_enabled
+    {
+        MessagePump pump;
+
+        [SetUp]
+        public void SetUp()
+        {
+            pump = new MessagePump(null, null);
+        }
+
+        [Test]
+        public async Task Should_throw()
+        {
+            // Dummy CriticalError
+            var criticalError = new CriticalError(ctx => Task.FromResult(0));
+
+            Assert.Throws<ConfigurationErrorsException>(async () => await pump.Init(context => TaskEx.Completed, criticalError, new PushSettings("sales", "error", true, TransportTransactionMode.SendsAtomicWithReceive)));
+        }
+    }
+}

--- a/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
+++ b/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
 {
-    using System.Configuration;
+    using System;
     using System.Threading.Tasks;
     using NServiceBus.AzureServiceBus;
     using NServiceBus.Transports;
@@ -24,7 +24,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             // Dummy CriticalError
             var criticalError = new CriticalError(ctx => Task.FromResult(0));
 
-            Assert.Throws<ConfigurationErrorsException>(async () => await pump.Init(context => TaskEx.Completed, criticalError, new PushSettings("sales", "error", true, TransportTransactionMode.SendsAtomicWithReceive)));
+            Assert.Throws<InvalidOperationException>(async () => await pump.Init(context => TaskEx.Completed, criticalError, new PushSettings("sales", "error", true, TransportTransactionMode.SendsAtomicWithReceive)));
         }
     }
 }

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.AzureServiceBus
 {
     using System;
-    using System.Configuration;
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
@@ -30,7 +29,7 @@ namespace NServiceBus.AzureServiceBus
 
             if (settings.PurgeOnStartup)
             {
-                throw new ConfigurationErrorsException("Azure Service Bus transport doesn't support PurgeOnStartup behaviour");
+                throw new InvalidOperationException("Azure Service Bus transport doesn't support PurgeOnStartup behaviour");
             }
 
             //TODO: integrate these

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AzureServiceBus
 {
     using System;
+    using System.Configuration;
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
@@ -26,6 +27,11 @@ namespace NServiceBus.AzureServiceBus
         {
             messagePump = pump;
             circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MessagePump", TimeSpan.FromSeconds(30), ex => criticalError.Raise("Failed to receive message from Azure Service Bus.", ex));
+
+            if (settings.PurgeOnStartup)
+            {
+                throw new ConfigurationErrorsException("Azure Service Bus transport doesn't support PurgeOnStartup behaviour");
+            }
 
             //TODO: integrate these
             //settings.ErrorQueue


### PR DESCRIPTION
During the Init phase of MessagePump there is a new check to verify PurgeOnStartup setting value. 

@Particular/azure-maintainers please review

Connect to #100 