### PR TITLE
[WIP] implementing startup checks

### DIFF
--- a/src/Tests/Connectivity/When_managing_namespace_manager_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_namespace_manager_lifecycle.cs
@@ -64,6 +64,11 @@ namespace NServiceBus.AzureServiceBus.Tests
                 get { throw new NotImplementedException(); }
             }
 
+            public bool HasManageRights
+            {
+                get { throw new NotImplementedException(); }
+            }
+
             public Task CreateQueue(QueueDescription description)
             {
                 throw new NotImplementedException();

--- a/src/Transport/Connectivity/INamespaceManager.cs
+++ b/src/Transport/Connectivity/INamespaceManager.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.AzureServiceBus
     {
         NamespaceManagerSettings Settings { get; }
         Uri Address { get; }
+        bool HasManageRights { get; }
 
         Task CreateQueue(QueueDescription description);
         Task UpdateQueue(QueueDescription description);

--- a/src/Transport/Connectivity/NamespaceManagerAdapter.cs
+++ b/src/Transport/Connectivity/NamespaceManagerAdapter.cs
@@ -19,6 +19,22 @@ namespace NServiceBus.AzureServiceBus
 
         public Uri Address => _manager.Address;
 
+        public bool HasManageRights
+        {
+            get
+            {
+                try
+                {
+                    _manager.GetQueues();
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
         public Task CreateQueue(QueueDescription description)
         {
             return _manager.CreateQueueAsync(description);

--- a/src/Transport/Topology/ITopology.cs
+++ b/src/Transport/Topology/ITopology.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.AzureServiceBus
 
     public interface ITopology {
 
-        void Initialize(SettingsHolder settings);
+        IResolveTransportParts Initialize(SettingsHolder settings);
 
         Func<ICreateQueues> GetQueueCreatorFactory();
         // TODO: CriticalError no longer passed in to MessagePumpFactory. Ensure that Core is doing pushMessages.OnCriticalError(error);

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -20,10 +20,12 @@ namespace NServiceBus.AzureServiceBus
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
 
-        public void Initialize(SettingsHolder settings)
+        public IResolveTransportParts Initialize(SettingsHolder settings)
         {
             ApplyDefaults(settings);
             InitializeContainer(settings);
+
+            return container;
         }
 
         private void ApplyDefaults(SettingsHolder settings)

--- a/src/Transport/Topology/Topologies/StandardTopology.cs
+++ b/src/Transport/Topology/Topologies/StandardTopology.cs
@@ -20,10 +20,12 @@ namespace NServiceBus.AzureServiceBus
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
 
-        public void Initialize(SettingsHolder settings)
+        public IResolveTransportParts Initialize(SettingsHolder settings)
         {
             ApplyDefaults(settings);
             InitializeContainer(settings);
+
+            return container;
         }
 
         private void ApplyDefaults(SettingsHolder settings)


### PR DESCRIPTION
@Particular/azure-maintainers I need your feedback about changes to ITopology.Initialize signature to have container reference into AzureServiceBusTransport class. Any other way to obtain the same behaviour?
After this first check, I go ahead with refactoring.

Take a look at my comment at the beginning of startu check callback.

NOTE: ApiComparer test fails