### PR TITLE
Bug with native deadlettering poisonous messages - wrong exception handling

### DIFF
--- a/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
+++ b/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
@@ -34,6 +34,7 @@
                         var queueClient = factory.CreateQueueClient("receivingamessagewithunknowntransportencoding.receiver/$DeadLetterQueue", ReceiveMode.ReceiveAndDelete); // queue name from the test name
                         var message = queueClient.Receive();
                         ctx.MessageWasMovedToDlq = message.MessageId == ctx.OriginalMessageId && (message.Properties["$AcceptanceTesting.TestRunId"] as string) == ctx.TestRunId.ToString();
+                        ctx.MessageWasMovedToDlq &= message.DeliveryCount == 1;
                         return ctx.MessageWasMovedToDlq;
                     })
                     .Run(new RunSettings() {TestExecutionTimeout = TimeSpan.FromMinutes(2)});

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.AzureServiceBus
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Configuration;
     using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
@@ -120,7 +119,7 @@ namespace NServiceBus.AzureServiceBus
             {
                 incomingMessage = brokeredMessageConverter.Convert(message);
             }
-            catch (ConfigurationErrorsException exception)
+            catch (UnsupportedBrokeredMessageBodyTypeException exception)
             {
                 await message.DeadLetterAsync("BrokeredMessage to IncomingMessageDetails conversion failure", exception.ToString()).ConfigureAwait(false);
                 return;


### PR DESCRIPTION
The test was passing because message was DLQed after exhausting maximum number of delivery counts and not because it was DLQ-ed by our code. By handling correct exception and fixing the test the code now tests for the right scenario.

@Particular/azure-maintainers please review

Connect to https://github.com/Particular/NServiceBus.AzureServiceBus/issues/90