### PR TITLE
Namespace API registration with case insensitive equality check on Name property

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -485,7 +485,7 @@ namespace NServiceBus.AzureServiceBus
     public class NamespaceInfo : System.IEquatable<NServiceBus.AzureServiceBus.NamespaceInfo>
     {
         public NamespaceInfo(string name, string connectionString) { }
-        public string ConnectionString { get; }
+        public NServiceBus.AzureServiceBus.Topology.MetaModel.ConnectionString ConnectionString { get; }
         public string Name { get; }
         public bool Equals(NServiceBus.AzureServiceBus.NamespaceInfo other) { }
         public override bool Equals(object obj) { }
@@ -631,6 +631,23 @@ namespace NServiceBus.AzureServiceBus
         public UnsupportedBrokeredMessageBodyTypeException(string message) { }
         public UnsupportedBrokeredMessageBodyTypeException(string message, System.Exception innerException) { }
         protected UnsupportedBrokeredMessageBodyTypeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+}
+namespace NServiceBus.AzureServiceBus.Topology.MetaModel
+{
+    
+    public class ConnectionString : System.IEquatable<NServiceBus.AzureServiceBus.Topology.MetaModel.ConnectionString>
+    {
+        public static readonly string Sample;
+        public ConnectionString(string value) { }
+        public string NamespaceName { get; }
+        public string SharedAccessPolicyName { get; }
+        public string SharedAccessPolicyValue { get; }
+        public bool Equals(NServiceBus.AzureServiceBus.Topology.MetaModel.ConnectionString other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+        public static bool TryParse(string value, out NServiceBus.AzureServiceBus.Topology.MetaModel.ConnectionString connectionString) { }
     }
 }
 namespace NServiceBus

--- a/src/Tests/ConnectionStringValue.cs
+++ b/src/Tests/ConnectionStringValue.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests
+{
+    class ConnectionStringValue
+    {
+        static readonly string Template = "Endpoint=sb://{0}.servicebus.windows.net;SharedAccessKeyName={1};SharedAccessKey={2}";
+
+        internal static readonly string Sample = Build();
+
+        internal static string Build(string namespaceName = "namespace", string sharedAccessPolicyName = "RootManageSharedAccessKey", string sharedAccessPolicyValue = "YourSecret")
+        {
+            return string.Format(Template, namespaceName, sharedAccessPolicyName, sharedAccessPolicyValue);
+        }
+    }
+}

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Configuration\When_configuring_serialization.cs" />
     <Compile Include="Configuration\When_configuring_use_logical_namespace_name.cs" />
     <Compile Include="Configuration\When_configuring_validation.cs" />
+    <Compile Include="ConnectionStringValue.cs" />
     <Compile Include="Connectivity\When_executing_task_with_retry.cs" />
     <Compile Include="Creation\When_creating_forwarding_subscription.cs" />
     <Compile Include="Creation\When_creating_subscription_backward_compatible_with_v6.cs" />

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -154,7 +154,7 @@
     <Compile Include="Sending\When_routing_outgoingmessages_to_endpoints.cs" />
     <Compile Include="Sending\When_sending_brokeredmessages_to_queues.cs" />
     <Compile Include="Topology\MetaModel\When_configuring_entity_address.cs" />
-    <Compile Include="Topology\MetaModel\When_configuring_namespaces_definition.cs" />
+    <Compile Include="Topology\MetaModel\When_configuring_namespace_configurations.cs" />
     <Compile Include="Topology\MetaModel\When_configuring_namespace_info.cs" />
     <Compile Include="Topology\MetaModel\When_mapping_namespace_name_to_connection_string.cs" />
     <Compile Include="Topology\MetaModel\When_mapping_connection_string_to_namespace_name.cs" />

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Sending\When_sending_brokeredmessages_to_queues.cs" />
     <Compile Include="Topology\MetaModel\When_configuring_entity_address.cs" />
     <Compile Include="Topology\MetaModel\When_configuring_namespaces_definition.cs" />
+    <Compile Include="Topology\MetaModel\When_configuring_namespace_info.cs" />
     <Compile Include="Topology\MetaModel\When_mapping_namespace_name_to_connection_string.cs" />
     <Compile Include="Topology\MetaModel\When_mapping_connection_string_to_namespace_name.cs" />
     <Compile Include="Topology\MetaModel\When_parsing_string_to_connection_string.cs" />

--- a/src/Tests/PreStartupChecks/When_all_pre_startup_checks_for_forwarding_topology_fail.cs
+++ b/src/Tests/PreStartupChecks/When_all_pre_startup_checks_for_forwarding_topology_fail.cs
@@ -18,7 +18,7 @@
             var container = new TransportPartsContainer();
 
             settings.Set(WellKnownConfigurationKeys.Core.CreateTopology, true);
-            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, new NamespaceConfigurations { {"namespace1", "namespace1-connString"} });
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, new NamespaceConfigurations { {"namespace1", ConnectionStringValue.Sample} });
             settings.Set(WellKnownConfigurationKeys.Topology.Resources.Topics.EnablePartitioning, true);
 
             container.Register(typeof(SettingsHolder), () => settings);

--- a/src/Tests/PreStartupChecks/When_execute_manage_rights_startup_check.cs
+++ b/src/Tests/PreStartupChecks/When_execute_manage_rights_startup_check.cs
@@ -30,8 +30,8 @@
 
             var namespaces = new NamespaceConfigurations
             {
-                {"name1", "connectionString1"},
-                {"name2", "connectionString2"}
+                {"name1", ConnectionStringValue.Build("namespace1")},
+                {"name2", ConnectionStringValue.Build("namespace2")}
             };
             settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, namespaces);
 
@@ -54,8 +54,8 @@
 
             var namespaces = new NamespaceConfigurations
             {
-                {"name1", "connectionString1"},
-                {"name2", "connectionString2"}
+                {"name1", ConnectionStringValue.Build("namespace1")},
+                {"name2", ConnectionStringValue.Build("namespace2")}
             };
             settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, namespaces);
 
@@ -64,8 +64,8 @@
             var falseNamespaceManager = A.Fake<INamespaceManager>();
             A.CallTo(() => falseNamespaceManager.CanManageEntities()).Returns(Task.FromResult(false));
             var manageNamespaceLifeCycle = A.Fake<IManageNamespaceManagerLifeCycle>();
-            A.CallTo(() => manageNamespaceLifeCycle.Get("connectionString1")).Returns(trueNamespaceManager);
-            A.CallTo(() => manageNamespaceLifeCycle.Get("connectionString2")).Returns(falseNamespaceManager);
+            A.CallTo(() => manageNamespaceLifeCycle.Get("name1")).Returns(trueNamespaceManager);
+            A.CallTo(() => manageNamespaceLifeCycle.Get("name2")).Returns(falseNamespaceManager);
 
             var check = new ManageRightsCheck(manageNamespaceLifeCycle, settings);
             var result = await check.Run();
@@ -81,9 +81,9 @@
 
             var namespaces = new NamespaceConfigurations
             {
-                {"name1", "connectionString1"},
-                {"name2", "connectionString2"},
-                {"name3", "connectionString3"}
+                {"name1", ConnectionStringValue.Build("namespace1")},
+                {"name2", ConnectionStringValue.Build("namespace2")},
+                {"name3", ConnectionStringValue.Build("namespace3")},
             };
             settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces, namespaces);
 

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using NServiceBus.Azure.WindowsAzureServiceBus.Tests;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.Routing;
     using NServiceBus.Settings;
@@ -132,7 +133,7 @@
         {
             return new TopologySection
             {
-                Namespaces = new List<RuntimeNamespaceInfo> { new RuntimeNamespaceInfo("name", "connectionString") },
+                Namespaces = new List<RuntimeNamespaceInfo> { new RuntimeNamespaceInfo("name", ConnectionStringValue.Sample) },
                 Entities = new List<EntityInfo> { new EntityInfo() }
             };
         }
@@ -141,7 +142,7 @@
         {
             return new TopologySection
             {
-                Namespaces = new List<RuntimeNamespaceInfo> { new RuntimeNamespaceInfo("name", "connectionString") },
+                Namespaces = new List<RuntimeNamespaceInfo> { new RuntimeNamespaceInfo("name", ConnectionStringValue.Sample) },
                 Entities = new List<EntityInfo> { new EntityInfo() }
             };
 

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
@@ -41,43 +41,39 @@
         public void Should_add_definition_if_it_does_not_exist()
         {
             _namespaces.Add("name", ConnectionStringValue.Sample);
+            var connectionString = _namespaces.GetConnectionString("name");
 
             Assert.AreEqual(1, _namespaces.Count);
-        }
-
-        [Test]
-        public void Should_not_add_definition_if_exists()
-        {
-            _namespaces.Add("name", ConnectionStringValue.Sample);
-            _namespaces.Add("Name", ConnectionStringValue.Sample);
-
-            Assert.AreEqual(1, _namespaces.Count);
+            Assert.AreEqual(ConnectionStringValue.Sample, connectionString);
         }
 
         [Test]
         public void Should_add_default_connection_string_if_it_does_not_exist()
         {
             _namespaces.AddDefault(ConnectionStringValue.Sample);
+            var connectionString = _namespaces.GetConnectionString(NamespaceConfigurations.DefaultName);
+
+            Assert.AreEqual(1, _namespaces.Count);
+            Assert.AreEqual(ConnectionStringValue.Sample, connectionString);
+        }
+
+        [Test]
+        [TestCase("name", "name")]
+        [TestCase("name", "Name")]
+        [TestCase("name", "NAME")]
+        public void Should_not_add_definition_if_namespace_name_already_exists_with_case_insensitive_check(string name1, string name2)
+        {
+            _namespaces.Add(name1, ConnectionStringValue.Build("namespace1"));
+            _namespaces.Add(name2, ConnectionStringValue.Build("namespace2"));
 
             Assert.AreEqual(1, _namespaces.Count);
         }
 
         [Test]
-        public void Should_not_add_if_connection_string_exists()
+        public void Should_not_add_definition_if_connection_string_exists()
         {
-            _namespaces.Add("name", ConnectionStringValue.Sample);
-
-            _namespaces.AddDefault(ConnectionStringValue.Sample);
-
-            Assert.AreEqual(1, _namespaces.Count);
-        }
-
-        [Test]
-        public void Should_override_default_connection_string()
-        {
-            _namespaces.AddDefault(ConnectionStringValue.Sample);
-
-            _namespaces.Add("name", ConnectionStringValue.Sample);
+            _namespaces.Add("namespace1", ConnectionStringValue.Sample);
+            _namespaces.Add("namespace2", ConnectionStringValue.Sample);
 
             Assert.AreEqual(1, _namespaces.Count);
         }

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
@@ -46,7 +46,7 @@
         }
 
         [Test]
-        public void Should_does_not_add_definition_if_exists()
+        public void Should_not_add_definition_if_exists()
         {
             _namespaces.Add("name", "connectionString");
             _namespaces.Add("Name", "connectionString");
@@ -63,7 +63,7 @@
         }
 
         [Test]
-        public void Should_does_not_add_if_connection_string_exists()
+        public void Should_not_add_if_connection_string_exists()
         {
             _namespaces.Add("name", "connectionString");
 

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
@@ -7,7 +7,7 @@
 
     [TestFixture]
     [Category("AzureServiceBus")]
-    public class When_configuring_namespaces_definition
+    public class When_configuring_namespace_configurations
     {
         private NamespaceConfigurations _namespaces;
 

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
@@ -23,7 +23,7 @@
         [TestCase(null)]
         public void Should_throws_an_exception_if_name_is_not_valid(string name)
         {
-            var exception = Assert.Throws<ArgumentException>(() => _namespaces.Add(name, "connectionString"));
+            var exception = Assert.Throws<ArgumentException>(() => _namespaces.Add(name, ConnectionStringValue.Sample));
             Assert.AreEqual("name", exception.ParamName);
         }
 
@@ -40,7 +40,7 @@
         [Test]
         public void Should_add_definition_if_it_does_not_exist()
         {
-            _namespaces.Add("name", "connectionString");
+            _namespaces.Add("name", ConnectionStringValue.Sample);
 
             Assert.AreEqual(1, _namespaces.Count);
         }
@@ -48,8 +48,8 @@
         [Test]
         public void Should_not_add_definition_if_exists()
         {
-            _namespaces.Add("name", "connectionString");
-            _namespaces.Add("Name", "connectionString");
+            _namespaces.Add("name", ConnectionStringValue.Sample);
+            _namespaces.Add("Name", ConnectionStringValue.Sample);
 
             Assert.AreEqual(1, _namespaces.Count);
         }
@@ -57,7 +57,7 @@
         [Test]
         public void Should_add_default_connection_string_if_it_does_not_exist()
         {
-            _namespaces.AddDefault("connectionString");
+            _namespaces.AddDefault(ConnectionStringValue.Sample);
 
             Assert.AreEqual(1, _namespaces.Count);
         }
@@ -65,9 +65,9 @@
         [Test]
         public void Should_not_add_if_connection_string_exists()
         {
-            _namespaces.Add("name", "connectionString");
+            _namespaces.Add("name", ConnectionStringValue.Sample);
 
-            _namespaces.AddDefault("connectionString");
+            _namespaces.AddDefault(ConnectionStringValue.Sample);
 
             Assert.AreEqual(1, _namespaces.Count);
         }
@@ -75,9 +75,9 @@
         [Test]
         public void Should_override_default_connection_string()
         {
-            _namespaces.AddDefault("connectionString");
+            _namespaces.AddDefault(ConnectionStringValue.Sample);
 
-            _namespaces.Add("name", "connectionString");
+            _namespaces.Add("name", ConnectionStringValue.Sample);
 
             Assert.AreEqual(1, _namespaces.Count);
         }
@@ -85,11 +85,11 @@
         [Test]
         public void Should_get_connection_string_by_namespace_name_with_a_case_insensitive_match()
         {
-            _namespaces.Add("name", "connectionString");
+            _namespaces.Add("name", ConnectionStringValue.Sample);
 
             var connectionString = _namespaces.GetConnectionString("NaMe");
 
-            StringAssert.AreEqualIgnoringCase("connectionString", connectionString);
+            StringAssert.AreEqualIgnoringCase(ConnectionStringValue.Sample, connectionString);
         }
 
         [Test]

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
@@ -12,8 +12,8 @@
         [TestCase("name", "Name")]
         public void Two_namespaces_should_be_equal_if_name_and_connection_string_are_case_insensitive_equal(string name1, string name2)
         {
-            var namespace1 = new NamespaceInfo(name1, "connectionstring");
-            var namespace2 = new NamespaceInfo(name2, "connectionstring");
+            var namespace1 = new NamespaceInfo(name1, ConnectionStringValue.Sample);
+            var namespace2 = new NamespaceInfo(name2, ConnectionStringValue.Sample);
 
             Assert.AreEqual(namespace1, namespace2);
         }
@@ -23,8 +23,8 @@
         [TestCase("name", "Name")]
         public void Two_namespaces_should_have_the_same_hash_code_if_name_and_connection_string_are_case_insensitive_equal(string name1, string name2)
         {
-            var namespace1 = new NamespaceInfo(name1, "connectionstring");
-            var namespace2 = new NamespaceInfo(name2, "connectionstring");
+            var namespace1 = new NamespaceInfo(name1, ConnectionStringValue.Sample);
+            var namespace2 = new NamespaceInfo(name2, ConnectionStringValue.Sample);
 
             var hashCode1 = namespace1.GetHashCode();
             var hashCode2 = namespace2.GetHashCode();

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
@@ -1,0 +1,34 @@
+﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.MetaModel
+{
+    using NServiceBus.AzureServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_configuring_namespace_info
+    {
+        [Test]
+        [TestCase("name", "name")]
+        [TestCase("name", "Name")]
+        public void Two_namespaces_should_be_equal_if_name_and_connection_string_are_case_insensitive_equal(string name1, string name2)
+        {
+            var namespace1 = new NamespaceInfo(name1, "connectionstring");
+            var namespace2 = new NamespaceInfo(name2, "connectionstring");
+
+            Assert.AreEqual(namespace1, namespace2);
+        }
+
+        [Test]
+        [TestCase("name", "name")]
+        [TestCase("name", "Name")]
+        public void Two_namespaces_should_have_the_same_hash_code_if_name_and_connection_string_are_case_insensitive_equal(string name1, string name2)
+        {
+            var namespace1 = new NamespaceInfo(name1, "connectionstring");
+            var namespace2 = new NamespaceInfo(name2, "connectionstring");
+
+            var hashCode1 = namespace1.GetHashCode();
+            var hashCode2 = namespace2.GetHashCode();
+            Assert.AreEqual(hashCode1, hashCode2);
+        }
+    }
+}

--- a/src/Tests/Topology/MetaModel/When_configuring_namespaces_definition.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespaces_definition.cs
@@ -49,7 +49,7 @@
         public void Should_does_not_add_definition_if_exists()
         {
             _namespaces.Add("name", "connectionString");
-            _namespaces.Add("name", "connectionString");
+            _namespaces.Add("Name", "connectionString");
 
             Assert.AreEqual(1, _namespaces.Count);
         }
@@ -83,11 +83,11 @@
         }
 
         [Test]
-        public void Should_get_connection_string_by_namespace_name()
+        public void Should_get_connection_string_by_namespace_name_with_a_case_insensitive_match()
         {
             _namespaces.Add("name", "connectionString");
 
-            var connectionString = _namespaces.GetConnectionString("name");
+            var connectionString = _namespaces.GetConnectionString("NaMe");
 
             StringAssert.AreEqualIgnoringCase("connectionString", connectionString);
         }

--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -7,14 +7,14 @@
     [Category("AzureServiceBus")]
     public class When_parsing_string_to_connection_string
     {
-        private static readonly string Template = "Endpoint=sb://{0}.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=YourSecret";
+        private static readonly string Template = "Endpoint=sb://{0}.servicebus.windows.net;SharedAccessKeyName={1};SharedAccessKey={2}";
 
         [Test]
         [TestCase("a")]
         [TestCase("abcde")]
         public void Should_return_false_if_input_length_is_shorter_than_6_chars(string value)
         {
-            var @namespace = string.Format(Template, value);
+            var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
             ConnectionString connectionString;
             var isValid = ConnectionString.TryParse(@namespace, out connectionString);
@@ -28,7 +28,7 @@
         [TestCase("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")]
         public void Should_return_false_if_input_length_is_longer_than_50_chars(string value)
         {
-            var @namespace = string.Format(Template, value);
+            var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
             ConnectionString connectionString;
             var isValid = ConnectionString.TryParse(@namespace, out connectionString);
@@ -42,7 +42,7 @@
         [TestCase("-abcdef")]
         public void Should_return_false_if_input_does_not_start_with_a_letter(string value)
         {
-            var @namespace = string.Format(Template, value);
+            var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
             ConnectionString connectionString;
             var isValid = ConnectionString.TryParse(@namespace, out connectionString);
@@ -54,7 +54,7 @@
         [Test]
         public void Should_return_false_if_input_does_not_finish_with_a_letter_or_a_number()
         {
-            var @namespace = string.Format(Template, "abcdef-");
+            var @namespace = string.Format(Template, "abcdef-", "RootManageSharedAccessKey", "YourSecret");
 
             ConnectionString connectionString;
             var isValid = ConnectionString.TryParse(@namespace, out connectionString);
@@ -72,7 +72,7 @@
         [TestCase("abcdef&")]
         public void Should_return_false_if_input_contains_not_valid_chars(string value)
         {
-            var @namespace = string.Format(Template, value);
+            var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
             ConnectionString connectionString;
             var isValid = ConnectionString.TryParse(@namespace, out connectionString);
@@ -90,7 +90,7 @@
         [TestCase("ABCD-EF")]
         public void Should_return_true_if_input_follows_namespace_name_rules(string value)
         {
-            var @namespace = string.Format(Template, value);
+            var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
             ConnectionString connectionString;
             var isValid = ConnectionString.TryParse(@namespace, out connectionString);
@@ -102,13 +102,123 @@
         [Test]
         public void Should_extract_namespace_name_and_shared_access_policy_name_and_shared_access_policy_value()
         {
-            var @namespace = string.Format(Template, "namespace");
+            var @namespace = string.Format(Template, "namespace", "RootManageSharedAccessKey", "YourSecret");
 
             var connectionString = new ConnectionString(@namespace);
 
             Assert.AreEqual("namespace", connectionString.NamespaceName);
             Assert.AreEqual("RootManageSharedAccessKey", connectionString.SharedAccessPolicyName);
             Assert.AreEqual("YourSecret", connectionString.SharedAccessPolicyValue);
+        }
+
+        [Test]
+        public void Two_connection_strings_are_different_if_namespace_names_are_different()
+        {
+            var namespace1 = string.Format(Template, "namespace1", "RootManageSharedAccessKey", "YourSecret");
+            var namespace2 = string.Format(Template, "namespace2", "RootManageSharedAccessKey", "YourSecret");
+            
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            Assert.AreNotEqual(connectionString1, connectionString2);
+        }
+
+        [Test]
+        public void Two_connection_strings_are_different_if_shared_access_policy_names_are_different()
+        {
+            var namespace1 = string.Format(Template, "namespace", "RootManageSharedAccessKey1", "YourSecret");
+            var namespace2 = string.Format(Template, "namespace", "RootManageSharedAccessKey2", "YourSecret");
+
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            Assert.AreNotEqual(connectionString1, connectionString2);
+        }
+
+        [Test]
+        [TestCase("YourSecret", "yoursecret")]
+        [TestCase("YourSecret", "YOURSECRET")]
+        [TestCase("YourSecret1", "YourSecret2")]
+        public void Two_connection_strings_are_different_if_shared_access_policy_values_are_differentwith_case_sensitive_check(string value1, string value2)
+        {
+            var namespace1 = string.Format(Template, "namespace", "RootManageSharedAccessKey", value1);
+            var namespace2 = string.Format(Template, "namespace", "RootManageSharedAccessKey", value2);
+
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            Assert.AreNotEqual(connectionString1, connectionString2);
+        }
+
+        [Test]
+        [TestCase("namespace", "namespace")]
+        [TestCase("namespace", "Namespace")]
+        [TestCase("namespace", "NAMESPACE")]
+        public void Two_connection_strings_are_equal_if_namespace_names_are_equal_with_case_insensitive_check_and_other_components_are_the_same(string value1, string value2)
+        {
+            var namespace1 = string.Format(Template, value1, "RootManageSharedAccessKey", "YourSecret");
+            var namespace2 = string.Format(Template, value2, "RootManageSharedAccessKey", "YourSecret");
+
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            Assert.AreEqual(connectionString1, connectionString2);
+        }
+
+        [Test]
+        [TestCase("RootManageSharedAccessKey", "RootManageSharedAccessKey")]
+        [TestCase("RootManageSharedAccessKey", "rootmanagesharedaccesskey")]
+        [TestCase("RootManageSharedAccessKey", "ROOTMANAGESHAREDACCESSKEY")]
+        public void Two_connection_strings_are_equal_if_shared_access_policy_names_are_equal_with_case_insensitive_check_and_other_components_are_the_same(string value1, string value2)
+        {
+            var namespace1 = string.Format(Template, "namespace", value1, "YourSecret");
+            var namespace2 = string.Format(Template, "namespace", value2, "YourSecret");
+
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            Assert.AreEqual(connectionString1, connectionString2);
+        }
+
+        [Test]
+        public void Two_connection_strings_are_equal_if_shared_access_policy_values_are_equal_with_case_sensitive_check_and_other_components_are_the_same()
+        {
+            var namespace1 = string.Format(Template, "namespace", "RootManageSharedAccessKey", "YourSecret");
+            var namespace2 = string.Format(Template, "namespace", "RootManageSharedAccessKey", "YourSecret");
+
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            Assert.AreEqual(connectionString1, connectionString2);
+        }
+
+        [Test]
+        public void Two_connection_strings_are_differente_if_one_of_them_is_null()
+        {
+            var @namespace = string.Format(Template, "namespace", "RootManageSharedAccessKey", "YourSecret");
+
+            var connectionString = new ConnectionString(@namespace);
+            var areEqual = connectionString.Equals(null);
+
+            Assert.False(areEqual);
+        }
+
+        [Test]
+        [TestCase("namespace", "namespace", "RootManageSharedAccessKey", "RootManageSharedAccessKey")]
+        [TestCase("namespace", "Namespace", "RootManageSharedAccessKey", "rootmanagesharedaccesskey")]
+        [TestCase("namespace", "NAMESPACE", "RootManageSharedAccessKey", "ROOTMANAGESHAREDACCESSKEY")]
+        public void Two_connection_strings_have_the_same_hash_code_if_they_are_equal(string namespaceName1, string namespaceName2, string sharedAccessPolicyName1, string sharedAccessPolicyName2)
+        {
+            var namespace1 = string.Format(Template, namespaceName1, sharedAccessPolicyName1, "YourSecret");
+            var namespace2 = string.Format(Template, namespaceName2, sharedAccessPolicyName2, "YourSecret");
+
+            var connectionString1 = new ConnectionString(namespace1);
+            var connectionString2 = new ConnectionString(namespace2);
+
+            var hashCode1 = connectionString1.GetHashCode();
+            var hashCode2 = connectionString2.GetHashCode();
+
+            Assert.AreEqual(hashCode1, hashCode2);
         }
     }
 }

--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -193,7 +193,7 @@
         }
 
         [Test]
-        public void Two_connection_strings_are_differente_if_one_of_them_is_null()
+        public void Two_connection_strings_are_different_if_one_of_them_is_null()
         {
             var @namespace = string.Format(Template, "namespace", "RootManageSharedAccessKey", "YourSecret");
 

--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -7,7 +7,7 @@
     [Category("AzureServiceBus")]
     public class When_parsing_string_to_connection_string
     {
-        private static readonly string Template = "Endpoint=sb://{0}.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=yoursecret";
+        private static readonly string Template = "Endpoint=sb://{0}.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=YourSecret";
 
         [Test]
         [TestCase("a")]
@@ -97,6 +97,18 @@
 
             Assert.True(isValid);
             Assert.NotNull(connectionString);
+        }
+
+        [Test]
+        public void Should_extract_namespace_name_and_shared_access_policy_name_and_shared_access_policy_value()
+        {
+            var @namespace = string.Format(Template, "namespace");
+
+            var connectionString = new ConnectionString(@namespace);
+
+            Assert.AreEqual("namespace", connectionString.NamespaceName);
+            Assert.AreEqual("RootManageSharedAccessKey", connectionString.SharedAccessPolicyName);
+            Assert.AreEqual("YourSecret", connectionString.SharedAccessPolicyValue);
         }
     }
 }

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -1,14 +1,19 @@
 ﻿namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 {
     using System;
+    using System.Linq;
     using System.Text.RegularExpressions;
 
     class ConnectionString
     {
         public static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
-        private static readonly string Pattern = "^Endpoint=sb://([A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net;SharedAccessKeyName=([\\w\\W]+);SharedAccessKey=([\\w\\W]+)$";
+        private static readonly string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
 
         private readonly string _value;
+
+        public string NamespaceName { get; }
+        public string SharedAccessPolicyName { get; }
+        public string SharedAccessPolicyValue { get; }
 
         public ConnectionString(string value)
         {
@@ -18,6 +23,10 @@
                                             $"f.e.: {ConnectionString.Sample}", nameof(value));
 
             _value = value;
+
+            NamespaceName = Regex.Match(value, Pattern).Groups["namespaceName"].Value;
+            SharedAccessPolicyName = Regex.Match(value, Pattern).Groups["sharedAccessPolicyName"].Value;
+            SharedAccessPolicyValue = Regex.Match(value, Pattern).Groups["sharedAccessPolicyValue"].Value;
         }
 
         public static bool TryParse(string value, out ConnectionString connectionString)

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -1,10 +1,9 @@
 ﻿namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 {
     using System;
-    using System.Linq;
     using System.Text.RegularExpressions;
 
-    class ConnectionString
+    class ConnectionString : IEquatable<ConnectionString>
     {
         public static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
         private static readonly string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
@@ -27,6 +26,28 @@
             NamespaceName = Regex.Match(value, Pattern).Groups["namespaceName"].Value;
             SharedAccessPolicyName = Regex.Match(value, Pattern).Groups["sharedAccessPolicyName"].Value;
             SharedAccessPolicyValue = Regex.Match(value, Pattern).Groups["sharedAccessPolicyValue"].Value;
+        }
+
+        public bool Equals(ConnectionString other)
+        {
+            return other != null
+                && string.Equals(NamespaceName, other.NamespaceName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(SharedAccessPolicyName, other.SharedAccessPolicyName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(SharedAccessPolicyValue, other.SharedAccessPolicyValue);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var target = obj as ConnectionString;
+            return Equals(target);
+        }
+
+        public override int GetHashCode()
+        {
+            var namespaceName = NamespaceName.ToLower();
+            var sharedAccessPolicyName = SharedAccessPolicyName.ToLower();
+
+            return string.Concat(namespaceName, sharedAccessPolicyName, SharedAccessPolicyValue).GetHashCode();
         }
 
         public static bool TryParse(string value, out ConnectionString connectionString)

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -30,10 +30,10 @@
 
         public bool Equals(ConnectionString other)
         {
-            return other != null
-                && string.Equals(NamespaceName, other.NamespaceName, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(SharedAccessPolicyName, other.SharedAccessPolicyName, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(SharedAccessPolicyValue, other.SharedAccessPolicyValue);
+            return other != null && (
+                string.Equals(NamespaceName, other.NamespaceName, StringComparison.OrdinalIgnoreCase) && 
+                string.Equals(SharedAccessPolicyName, other.SharedAccessPolicyName, StringComparison.OrdinalIgnoreCase) && 
+                string.Equals(SharedAccessPolicyValue, other.SharedAccessPolicyValue));
         }
 
         public override bool Equals(object obj)
@@ -76,6 +76,7 @@
 
         public static bool operator ==(ConnectionString connectionString1, ConnectionString connectionString2)
         {
+            if (ReferenceEquals(connectionString1, null) && ReferenceEquals(connectionString2, null)) return true;
             if (ReferenceEquals(connectionString1, null) || ReferenceEquals(connectionString2, null)) return false;
 
             return connectionString1.Equals(connectionString2);

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -73,5 +73,17 @@
         {
             return connectionString.ToString();
         }
+
+        public static bool operator ==(ConnectionString connectionString1, ConnectionString connectionString2)
+        {
+            if (ReferenceEquals(connectionString1, null) || ReferenceEquals(connectionString2, null)) return false;
+
+            return connectionString1.Equals(connectionString2);
+        }
+
+        public static bool operator !=(ConnectionString connectionString1, ConnectionString connectionString2)
+        {
+            return !(connectionString1 == connectionString2);
+        }
     }
 }

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -3,10 +3,10 @@
     using System;
     using System.Text.RegularExpressions;
 
-    class ConnectionString : IEquatable<ConnectionString>
+    public class ConnectionString : IEquatable<ConnectionString>
     {
         public static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
-        private static readonly string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
+        private static readonly string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
 
         private readonly string _value;
 
@@ -50,6 +50,11 @@
             return string.Concat(namespaceName, sharedAccessPolicyName, SharedAccessPolicyValue).GetHashCode();
         }
 
+        public override string ToString()
+        {
+            return _value;
+        }
+
         public static bool TryParse(string value, out ConnectionString connectionString)
         {
             try
@@ -66,7 +71,7 @@
 
         public static implicit operator string(ConnectionString connectionString)
         {
-            return connectionString._value;
+            return connectionString.ToString();
         }
     }
 }

--- a/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
@@ -41,7 +41,7 @@
         {
             try
             {
-                var selected = _inner.Single(x => x.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+                var selected = _inner.Single(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
                 return selected.ConnectionString;
             }
             catch (InvalidOperationException ex)

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -21,7 +21,7 @@
         public bool Equals(NamespaceInfo other)
         {
             return other != null
-                   && Name.Equals(other.Name, StringComparison.InvariantCultureIgnoreCase)
+                   && Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase)
                    && ConnectionString.Equals(other.ConnectionString);
         }
 

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -21,8 +21,8 @@
         public bool Equals(NamespaceInfo other)
         {
             return other != null
-                   && Name.Equals(other.Name)
-                   && ConnectionString.Equals(other.ConnectionString);
+                   && Name.Equals(other.Name, StringComparison.InvariantCultureIgnoreCase)
+                   && ConnectionString.Equals(other.ConnectionString, StringComparison.InvariantCultureIgnoreCase);
         }
 
         public override bool Equals(object obj)
@@ -33,7 +33,9 @@
 
         public override int GetHashCode()
         {
-            return String.Concat(Name, "-", ConnectionString).GetHashCode();
+            var name = Name.ToLower();
+            var connectionString = ConnectionString.ToLower();
+            return string.Concat(name, "#", connectionString).GetHashCode();
         }
     }
 }

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -1,10 +1,12 @@
 ﻿namespace NServiceBus.AzureServiceBus
 {
     using System;
+    using NServiceBus.AzureServiceBus.Topology.MetaModel;
+
     public class NamespaceInfo : IEquatable<NamespaceInfo>
     {
         public string Name { get; }
-        public string ConnectionString { get; }
+        public ConnectionString ConnectionString { get; }
 
         public NamespaceInfo(string name, string connectionString)
         {
@@ -15,7 +17,7 @@
                 throw new ArgumentException("Namespace connection string can't be null or empty", nameof(connectionString));
 
             Name = name;
-            ConnectionString = connectionString;
+            ConnectionString = new ConnectionString(connectionString);
         }
 
         public bool Equals(NamespaceInfo other)

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -22,7 +22,7 @@
         {
             return other != null
                    && Name.Equals(other.Name, StringComparison.InvariantCultureIgnoreCase)
-                   && ConnectionString.Equals(other.ConnectionString, StringComparison.InvariantCultureIgnoreCase);
+                   && ConnectionString.Equals(other.ConnectionString);
         }
 
         public override bool Equals(object obj)
@@ -34,8 +34,7 @@
         public override int GetHashCode()
         {
             var name = Name.ToLower();
-            var connectionString = ConnectionString.ToLower();
-            return string.Concat(name, "#", connectionString).GetHashCode();
+            return string.Concat(name, "#", ConnectionString).GetHashCode();
         }
     }
 }


### PR DESCRIPTION
Crossposting comment from issue: what about adding two namespaces with different names and the same connection string?

@Particular/azure-maintainers ready to review

Connects to #135 