### PR TITLE
Verify AutoRenewTimeout works as it shood

### DIFF
--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Creation\When_creating_subscription_backward_compatible_with_v6.cs" />
     <Compile Include="PreStartupChecks\When_executing_topic_partitioning_check_for_forwarding_topology.cs" />
     <Compile Include="PreStartupChecks\When_all_pre_startup_checks_for_forwarding_topology_fail.cs" />
+    <Compile Include="Receiving\When_incoming_message_processing_takes_longer_than_LockDuration.cs" />
     <Compile Include="Receiving\When_comparing_performance_for_prefetch.cs" />
     <Compile Include="Sending\When_using_defaults_for_sending.cs" />
     <Compile Include="TestUtility.cs" />

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageReceiverSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageReceiverSettings.cs
@@ -50,8 +50,8 @@
         }
 
         /// <summary>
-        /// Maximum duration within which the message lock will be renewed automatically.
-        /// <remarks>Default is 5 minutes.</remarks>
+        /// Maximum duration within which the message lock will be renewed automatically. 
+        /// <remarks>This value should be greater than the message lock duration. Default is 5 minutes.</remarks>
         /// </summary>
         public AzureServiceBusMessageReceiverSettings AutoRenewTimeout(TimeSpan autoRenewTimeout)
         {

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -212,13 +212,8 @@ namespace NServiceBus.AzureServiceBus
 
             logger.Info("Stopping notifier for " + fullPath);
 
-            var closeReceiverTask = internalReceiver.CloseAsync();
-
             var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
-            var allTasks = pipelineInvocationTasks.Values.Concat(new[]
-            {
-                closeReceiverTask
-            });
+            var allTasks = pipelineInvocationTasks.Values;
             var finishedTask = await Task.WhenAny(Task.WhenAll(allTasks), timeoutTask).ConfigureAwait(false);
 
             if (finishedTask.Equals(timeoutTask))
@@ -227,6 +222,8 @@ namespace NServiceBus.AzureServiceBus
             }
 
             pipelineInvocationTasks.Clear();
+
+            await internalReceiver.CloseAsync().ConfigureAwait(false);
 
             logger.Info("Notifier for " + fullPath + " stopped");
 


### PR DESCRIPTION
- Validates AutoRenewTimeout of OnMessage API works
- Fixes the issue where messages with completed callbacks where not marked as completed and removed from the queue (we didn't discover this because switched from manual completion to auto-completion, but queues were removed at the end of tests).

Connect to #146 

@Particular/azure-maintainers please review