### PR TITLE
Sanitize "composed" entityPath

### DIFF
--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting.cs
@@ -66,6 +66,21 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
             Assert.AreEqual(sanitized, sanitization.Sanitize(endpointname, EntityType.Queue));
         }
 
+        [Test]
+        [TestCase("validendpoint@namespaceName", "validendpoint")]
+        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
+        [TestCase("/endpoint/name/@namespaceName", "endpoint/name")]
+        [TestCase("/endpoint/name/@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint/name")]
+        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
+        {
+            var validation = new ValidationMock();
+            var sanitization = new AdjustmentSanitization(validation);
+
+            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue);
+
+            Assert.AreEqual(expectedEndpointName, sanitizedResult);
+        }
+
         class ValidationMock : IValidationStrategy
         {
             public bool IsValid(string entityPath, EntityType entityType)

--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
@@ -39,6 +39,21 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
             Assert.AreEqual(sanitized, sanitization.Sanitize(endpointname, EntityType.Queue));
         }
 
+        [Test]
+        [TestCase("validendpoint@namespaceName", "validendpoint")]
+        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
+        [TestCase("endpoint$name@namespaceName", "endpointname")]
+        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpointname")]
+        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
+        {
+            var validation = new ValidationMock();
+            var sanitization = new AdjustmentSanitizationV6(validation);
+
+            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue);
+
+            Assert.AreEqual(expectedEndpointName, sanitizedResult);
+        }
+
         class ValidationMock : IValidationStrategy
         {
             public bool IsValid(string entityPath, EntityType entityType)

--- a/src/Transport/Addressing/Sanitization/Strategies/AdjustmentSanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/AdjustmentSanitization.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AzureServiceBus.Addressing
 {
     using System.Text.RegularExpressions;
+    using NServiceBus.AzureServiceBus.Topology.MetaModel;
 
     public class AdjustmentSanitization : ISanitizationStrategy
     {
@@ -13,8 +14,13 @@ namespace NServiceBus.AzureServiceBus.Addressing
 
         public string Sanitize(string entityPath, EntityType entityType)
         {
-            // remove invalid characters
+            if (entityType == EntityType.Queue)
+            {
+                var address = new EntityAddress(entityPath);
+                entityPath = address.Name;
+            }
 
+            // remove invalid characters
             if (entityType == EntityType.Queue || entityType == EntityType.Topic)
             {
                 var regexQueueAndTopicValidCharacters = new Regex(@"[^a-zA-Z0-9\-\._\/]");

--- a/src/Transport/Addressing/Sanitization/Strategies/AdjustmentSanitizationV6.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/AdjustmentSanitizationV6.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AzureServiceBus.Addressing
 {
     using System.Text.RegularExpressions;
+    using NServiceBus.AzureServiceBus.Topology.MetaModel;
 
     public class AdjustmentSanitizationV6 : ISanitizationStrategy
     {
@@ -13,6 +14,12 @@
 
         public string Sanitize(string entityPath, EntityType entityType)
         {
+            if (entityType == EntityType.Queue)
+            {
+                var address = new EntityAddress(entityPath);
+                entityPath = address.Name;
+            }
+
             // remove invalid characters
             var rgx = new Regex(@"[^a-zA-Z0-9\-\._]");
             entityPath = rgx.Replace(entityPath, "");


### PR DESCRIPTION
Connects to #156 

Sanitization strategies didn't work with composed entity path like `queueName@connectionString` or `queueName@namespaceName`.
New implementation splits `queueName` and `suffix`, then it sanitizes only `queueName`

@Particular/azure-maintainers ready to review