### PR TITLE
Remove _if_ check over topology type during configuration

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -147,6 +147,7 @@ namespace NServiceBus.AzureServiceBus
         public EndpointOrientedTopology() { }
         public bool HasNativePubSubSupport { get; }
         public bool HasSupportForCentralizedPubSub { get; }
+        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
         public System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory() { }
         public System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory() { }
         public NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy() { }
@@ -191,6 +192,7 @@ namespace NServiceBus.AzureServiceBus
         public ForwardingTopology() { }
         public bool HasNativePubSubSupport { get; }
         public bool HasSupportForCentralizedPubSub { get; }
+        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
         public System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory() { }
         public System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory() { }
         public NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy() { }
@@ -368,6 +370,7 @@ namespace NServiceBus.AzureServiceBus
     {
         bool HasNativePubSubSupport { get; }
         bool HasSupportForCentralizedPubSub { get; }
+        bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
         System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory();
         System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory();
         NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy();

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
@@ -19,7 +19,7 @@
 
         public AzureServiceBusTopologySettings RegisterPublisherForType(string publisherName, Type type)
         {
-            SelectedTopologyHasToBeOfTypeEndpointOrientedTopology();
+            EnsureThatConfiguredTopologyNeedsMappingConfigurationBetweenPublishersAndEventTypes();
 
             AddScannerForPublisher(publisherName, new SingleTypeScanner(type));
             return this;
@@ -27,7 +27,7 @@
 
         public AzureServiceBusTopologySettings RegisterPublisherForAssembly(string publisherName, Assembly assembly)
         {
-            SelectedTopologyHasToBeOfTypeEndpointOrientedTopology();
+            EnsureThatConfiguredTopologyNeedsMappingConfigurationBetweenPublishersAndEventTypes();
 
             AddScannerForPublisher(publisherName, new AssemblyTypesScanner(assembly));
             return this;
@@ -49,12 +49,12 @@
             map[publisherName].Add(scanner);
         }
 
-        private void SelectedTopologyHasToBeOfTypeEndpointOrientedTopology()
+        private void EnsureThatConfiguredTopologyNeedsMappingConfigurationBetweenPublishersAndEventTypes()
         {
             var topology = _settings.Get<ITopology>();
 
-            if (topology.GetType() != typeof(EndpointOrientedTopology))
-                throw new InvalidOperationException("Only `EndpointOrientedTopology` needs mapping configuration between publisher names and event types");
+            if (!topology.NeedsMappingConfigurationBetweenPublishersAndEventTypes)
+                throw new InvalidOperationException($"Configured topology (`{topology.GetType().FullName}`) doesn't need mapping configuration between publisher names and event types");
         }
     }
 }

--- a/src/Transport/Topology/ITopology.cs
+++ b/src/Transport/Topology/ITopology.cs
@@ -5,8 +5,8 @@ namespace NServiceBus.AzureServiceBus
     using NServiceBus.Settings;
     using NServiceBus.Transports;
 
-    public interface ITopology {
-
+    public interface ITopology
+    {
         void Initialize(SettingsHolder settings);
 
         Func<ICreateQueues> GetQueueCreatorFactory();
@@ -15,7 +15,9 @@ namespace NServiceBus.AzureServiceBus
         Task<StartupCheckResult> RunPreStartupChecks();
         Func<IManageSubscriptions> GetSubscriptionManagerFactory();
         OutboundRoutingPolicy GetOutboundRoutingPolicy();
+
         bool HasNativePubSubSupport { get; }
         bool HasSupportForCentralizedPubSub { get;}
+        bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -21,6 +21,7 @@ namespace NServiceBus.AzureServiceBus
 
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
+        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes => true;
 
         public void Initialize(SettingsHolder settings)
         {

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -23,6 +23,7 @@ namespace NServiceBus.AzureServiceBus
 
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
+        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes => false;
 
         public void Initialize(SettingsHolder settings)
         {


### PR DESCRIPTION
Improved design changing _if_ check over type with a more OOP approach 

@Particular/azure-maintainers