### PR TITLE
Topologies and Publisher API

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -147,7 +147,6 @@ namespace NServiceBus.AzureServiceBus
         public EndpointOrientedTopology() { }
         public bool HasNativePubSubSupport { get; }
         public bool HasSupportForCentralizedPubSub { get; }
-        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
         public System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory() { }
         public System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory() { }
         public NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy() { }
@@ -192,7 +191,6 @@ namespace NServiceBus.AzureServiceBus
         public ForwardingTopology() { }
         public bool HasNativePubSubSupport { get; }
         public bool HasSupportForCentralizedPubSub { get; }
-        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
         public System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory() { }
         public System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory() { }
         public NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy() { }
@@ -370,7 +368,6 @@ namespace NServiceBus.AzureServiceBus
     {
         bool HasNativePubSubSupport { get; }
         bool HasSupportForCentralizedPubSub { get; }
-        bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
         System.Func<NServiceBus.Transports.IDispatchMessages> GetDispatcherFactory();
         System.Func<NServiceBus.Transports.IPushMessages> GetMessagePumpFactory();
         NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy();
@@ -535,6 +532,11 @@ namespace NServiceBus
         public NServiceBus.AzureServiceBusCompositionSettings UseStrategy<T>()
             where T : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy { }
     }
+    public class static AzureServiceBusEndpointOrientedTopologySettingsExtensions
+    {
+        public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.EndpointOrientedTopology> RegisterPublisherForAssembly(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.EndpointOrientedTopology> topologySettings, string publisherName, System.Reflection.Assembly assembly) { }
+        public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.EndpointOrientedTopology> RegisterPublisherForType(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.EndpointOrientedTopology> topologySettings, string publisherName, System.Type type) { }
+    }
     public class AzureServiceBusIndividualizationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public AzureServiceBusIndividualizationSettings(NServiceBus.Settings.SettingsHolder settings) { }
@@ -633,11 +635,10 @@ namespace NServiceBus
         public NServiceBus.AzureServiceBusTopicSettings RequiresDuplicateDetection(bool requiresDuplicateDetection) { }
         public NServiceBus.AzureServiceBusTopicSettings SupportOrdering(bool supported) { }
     }
-    public class AzureServiceBusTopologySettings : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport>
+    public class AzureServiceBusTopologySettings<T> : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport>
+        where T : NServiceBus.AzureServiceBus.ITopology
     {
         public AzureServiceBusTopologySettings(NServiceBus.Settings.SettingsHolder settings) { }
-        public NServiceBus.AzureServiceBusTopologySettings RegisterPublisherForAssembly(string publisherName, System.Reflection.Assembly assembly) { }
-        public NServiceBus.AzureServiceBusTopologySettings RegisterPublisherForType(string publisherName, System.Type type) { }
     }
     public class AzureServiceBusTransport : NServiceBus.Transports.TransportDefinition
     {
@@ -663,11 +664,11 @@ namespace NServiceBus
         public static NServiceBus.AzureServiceBusSubscriptionSettings Subscriptions(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusTopicSettings Topics(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void UseNamespaceNamesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
-        public static NServiceBus.AzureServiceBusTopologySettings UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
+        public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.AzureServiceBus.ITopology, new () { }
-        public static NServiceBus.AzureServiceBusTopologySettings UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<T> factory)
+        public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<T> factory)
             where T : NServiceBus.AzureServiceBus.ITopology { }
-        public static NServiceBus.AzureServiceBusTopologySettings UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, T topology)
+        public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, T topology)
             where T : NServiceBus.AzureServiceBus.ITopology { }
         public static NServiceBus.AzureServiceBusValidationSettings Validation(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
     }

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_failover_namespace_strategy.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_failover_namespace_strategy.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void SetUp()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(PrimaryName, PrimaryConnectionString);
             extensions.NamespacePartitioning().AddNamespace(SecondaryName, SecondaryConnectionString);
 
@@ -86,7 +86,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void Failover_partitioning_strategy_will_throw_if_no_secondary_namespace_is_provided()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(PrimaryName, PrimaryConnectionString);
 
             Assert.Throws<ConfigurationErrorsException>(() => new FailOverNamespacePartitioning(settings));
@@ -96,7 +96,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void Failover_partitioning_strategy_will_throw_if_more_than_primary_and_secondary_namespaces_are_provided()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(PrimaryName, PrimaryConnectionString);
             extensions.NamespacePartitioning().AddNamespace(SecondaryName, SecondaryConnectionString);
             extensions.NamespacePartitioning().AddNamespace(OtherName, OtherConnectionString);

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_replicated_strategy_on_multiple_namespaces.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_replicated_strategy_on_multiple_namespaces.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void SetUp()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace("namespace1", Primary);
             extensions.NamespacePartitioning().AddNamespace("namespace2", Secondary);
             extensions.NamespacePartitioning().AddNamespace("namespace3", Tertiary);
@@ -64,7 +64,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void Replicated_partitioning_strategy_will_throw_if_too_little_namespaces_are_provided()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace("namespace1", Primary);
 
             Assert.Throws<ConfigurationErrorsException>(() => new ReplicatedNamespacePartitioning(settings));

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_roundrobin_strategy_on_multiple_namespaces.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_roundrobin_strategy_on_multiple_namespaces.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void SetUp()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(PrimaryName, PrimaryConnectionString);
             extensions.NamespacePartitioning().AddNamespace(SecondaryName, SecondaryConnectionString);
             extensions.NamespacePartitioning().AddNamespace(TertiaryName, TertiaryConnectionString);
@@ -81,7 +81,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void Roundrobin_partitioning_strategy_will_throw_if_too_little_namespaces_are_provided()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(PrimaryName, PrimaryConnectionString);
 
             Assert.Throws<ConfigurationErrorsException>(() => new RoundRobinNamespacePartitioning(settings));

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_sharded_strategy_on_multiple_namespaces.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_sharded_strategy_on_multiple_namespaces.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void SetUp()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(Name1, ConnectionString1);
             extensions.NamespacePartitioning().AddNamespace(Name2, ConnectionString2);
             extensions.NamespacePartitioning().AddNamespace(Name3, ConnectionString3);
@@ -83,7 +83,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void Sharded_partitioning_strategy_will_throw_if_too_little_namespaces_defined()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(Name1, ConnectionString1);
 
             Assert.Throws<ConfigurationErrorsException>(() => new ShardedNamespacePartitioning(settings));

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_single_namespace_strategy.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_single_namespace_strategy.cs
@@ -23,7 +23,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void SetUp()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(Name, ConnectionString);
 
             strategy = new SingleNamespacePartitioning(settings);
@@ -73,7 +73,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         public void Single_partitioning_strategy_will_throw_if_more_namespaces_defined()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(Name, ConnectionString);
             extensions.NamespacePartitioning().AddNamespace(OtherName, OtherConnectionString);
 

--- a/src/Tests/Configuration/When_configuring.cs
+++ b/src/Tests/Configuration/When_configuring.cs
@@ -13,18 +13,18 @@
         public void Should_be_able_to_extend_topology_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topologySettings = extensions.UseTopology(A.Fake<ITopology>);
 
-            Assert.IsInstanceOf<AzureServiceBusTopologySettings>(topologySettings);
+            Assert.IsInstanceOf<TransportExtensions<AzureServiceBusTransport>>(topologySettings);
         }
 
         [Test]
         public void Should_be_able_to_extend_namespace_partitioning_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var partitioningSettings = extensions.NamespacePartitioning();
 
@@ -35,7 +35,7 @@
         public void Should_be_able_to_extend_composition_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var compositionSettings = extensions.Composition();
 
@@ -46,7 +46,7 @@
         public void Should_be_able_to_extend_validation_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var validationSettings = extensions.Validation();
 
@@ -57,7 +57,7 @@
         public void Should_be_able_to_extend_individualization_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var individualizationSettings = extensions.Individualization();
 
@@ -68,7 +68,7 @@
         public void Should_be_able_to_extend_queue_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var queueSettings = extensions.Queues();
 
@@ -79,7 +79,7 @@
         public void Should_be_able_to_extend_topic_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicsSettings = extensions.Topics();
 
@@ -90,7 +90,7 @@
         public void Should_be_able_to_extend_subscription_settings()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var subscriptionSettings = extensions.Subscriptions();
 

--- a/src/Tests/Configuration/When_configuring_composition.cs
+++ b/src/Tests/Configuration/When_configuring_composition.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_the_composition_strategy()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Composition().UseStrategy<MyCompositionStrategy>();
 

--- a/src/Tests/Configuration/When_configuring_individualization.cs
+++ b/src/Tests/Configuration/When_configuring_individualization.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_the_sanitization_strategy()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Individualization().UseStrategy<MyIndividualizationStrategy>();
 

--- a/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
+++ b/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_the_partitioning_strategy()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var partitioningSettings = extensions.NamespacePartitioning().UseStrategy<MyNamespacePartitioningStrategy>();
 
@@ -30,7 +30,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
             const string name = "namespace1";
 
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace(name, connectionString);
 
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Namespaces);

--- a/src/Tests/Configuration/When_configuring_publishers.cs
+++ b/src/Tests/Configuration/When_configuring_publishers.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 {
-    using System;
     using System.Collections.Generic;
     using System.Reflection;
     using AzureServiceBus;
@@ -46,13 +45,13 @@
             CollectionAssert.Contains(publishers["publisherName"], new AssemblyTypesScanner(Assembly.GetExecutingAssembly()));
         }
 
-        [Test]
+        [Test, Explicit("Works as per design. It's impossible to access Publisher API using a topology other than `EndpointOrientedTopology`")]
         public void Should_not_be_possible_configure_publishers_using_forwarding_topology()
         {
-            var topologySettings = extensions.UseTopology<ForwardingTopology>();
+//            var topologySettings = extensions.UseTopology<ForwardingTopology>();
 
-            Assert.Throws<InvalidOperationException>(() => topologySettings.RegisterPublisherForType("publisherName", typeof(MyType)));
-            Assert.Throws<InvalidOperationException>(() => topologySettings.RegisterPublisherForAssembly("publisherName", Assembly.GetExecutingAssembly()));
+//            Assert.Throws<InvalidOperationException>(() => topologySettings.RegisterPublisherForType("publisherName", typeof(MyType)));
+//            Assert.Throws<InvalidOperationException>(() => topologySettings.RegisterPublisherForAssembly("publisherName", Assembly.GetExecutingAssembly()));
         }
 
         class MyType

--- a/src/Tests/Configuration/When_configuring_queues.cs
+++ b/src/Tests/Configuration/When_configuring_queues.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_AutoDeleteOnIdle()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var idlePeriod = TimeSpan.FromDays(10);
             var queueSettings = extensions.Queues().AutoDeleteOnIdle(idlePeriod);
@@ -24,7 +24,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_DefaultMessageTimeToLive()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var expiryTimespan = TimeSpan.FromDays(1);
             var queueSettings = extensions.Queues().DefaultMessageTimeToLive(expiryTimespan);
@@ -35,7 +35,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_DuplicateDetectionHistoryTimeWindow()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var dedupTimespan = TimeSpan.FromMinutes(20);
             var queueSettings = extensions.Queues().DuplicateDetectionHistoryTimeWindow(dedupTimespan);
@@ -47,7 +47,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_EnableBatchedOperations()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var queueSettings = extensions.Queues().EnableBatchedOperations(true);
 
@@ -58,7 +58,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_EnableDeadLetteringOnMessageExpiration()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var queueSettings = extensions.Queues().EnableDeadLetteringOnMessageExpiration(true);
 
@@ -69,7 +69,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_EnableExpress()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var queueSettings = extensions.Queues().EnableExpress(true);
 
@@ -80,7 +80,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_EnableExpress_conditionally()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             Func<string, bool> condition = name => name != "expressqueue";
             var queueSettings = extensions.Queues().EnableExpress(condition, true);
@@ -94,7 +94,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_EnablePartitioning()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var queueSettings = extensions.Queues().EnablePartitioning(true);
 
@@ -105,7 +105,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_ForwardDeadLetteredMessagesTo()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var queueSettings = extensions.Queues().ForwardDeadLetteredMessagesTo("deadletteredmessages");
 
@@ -116,7 +116,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_ForwardDeadLetteredMessagesTo_conditionally()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             Func<string, bool> condition = n => n != "deadletteredmessages";
             var queueSettings = extensions.Queues().ForwardDeadLetteredMessagesTo(condition, "deadletteredmessages");
@@ -129,7 +129,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_LockDuration()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var lockDuration = TimeSpan.FromDays(1);
             var queueSettings = extensions.Queues().LockDuration(lockDuration);
@@ -141,7 +141,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_MaxDeliveryCount()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             const int selectedMaxDeliveryCount = 6;
             var queueSettings = extensions.Queues().MaxDeliveryCount(selectedMaxDeliveryCount);
@@ -153,7 +153,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_MaxSizeInMegabytes()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             const long maxTopicSizeInMB = 2048;
             var queueSettings = extensions.Queues().MaxSizeInMegabytes(SizeInMegabytes.Size2048);
@@ -165,7 +165,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_RequiresDuplicateDetection()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var queueSettings = extensions.Queues().RequiresDuplicateDetection(true);
 
@@ -176,7 +176,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_RequiresSession()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var queueSettings = extensions.Queues().RequiresSession(true);
 
@@ -187,7 +187,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_SupportOrdering()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var queueSettings = extensions.Queues().SupportOrdering(true);
 

--- a/src/Tests/Configuration/When_configuring_resource_creation.cs
+++ b/src/Tests/Configuration/When_configuring_resource_creation.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_queue_description_factory_method()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             Func<string, ReadOnlySettings, QueueDescription> registeredFactory = (name, s) => new QueueDescription(name);
 
@@ -28,7 +28,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_topic_description_factory_method()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             Func<string, ReadOnlySettings, TopicDescription> registeredFactory = (name, s) => new TopicDescription(name);
 
@@ -41,7 +41,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_subscription_description_factory_method()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             Func<string, string, ReadOnlySettings, SubscriptionDescription> registeredFactory = (topicname, subscriptionname, s) => new SubscriptionDescription(topicname, subscriptionname);
 

--- a/src/Tests/Configuration/When_configuring_sanitization.cs
+++ b/src/Tests/Configuration/When_configuring_sanitization.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         public void Should_be_able_to_set_the_sanitization_strategy()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Sanitization().UseStrategy<MySanitizationStrategy>();
 

--- a/src/Tests/Configuration/When_configuring_subscriptions.cs
+++ b/src/Tests/Configuration/When_configuring_subscriptions.cs
@@ -14,7 +14,7 @@
         public void Should_be_able_to_set_AutoDeleteOnIdle()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var idlePeriod = TimeSpan.FromDays(10);
             var topicSettings = extensions.Subscriptions().AutoDeleteOnIdle(idlePeriod);
@@ -26,7 +26,7 @@
         public void Should_be_able_to_set_DefaultMessageTimeToLive()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var expiryTimespan = TimeSpan.FromDays(1);
             var subscriptionSettings = extensions.Subscriptions().DefaultMessageTimeToLive(expiryTimespan);
@@ -38,7 +38,7 @@
         public void Should_be_able_to_set_EnableBatchedOperations()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var subscriptionSettings = extensions.Subscriptions().EnableBatchedOperations(true);
 
@@ -49,7 +49,7 @@
         public void Should_be_able_to_set_EnableDeadLetteringOnFilterEvaluationExceptions()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var subscriptionSettings = extensions.Subscriptions().EnableDeadLetteringOnFilterEvaluationExceptions(true);
 
@@ -60,7 +60,7 @@
         public void Should_be_able_to_set_EnableDeadLetteringOnMessageExpiration()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var subscriptionSettings = extensions.Subscriptions().EnableDeadLetteringOnMessageExpiration(true);
 
@@ -71,7 +71,7 @@
         public void Should_be_able_to_set_ForwardDeadLetteredMessagesTo()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var subscriptionSettings = extensions.Subscriptions().ForwardDeadLetteredMessagesTo("deadletteredmessages");
 
@@ -82,7 +82,7 @@
         public void Should_be_able_to_set_ForwardDeadLetteredMessagesTo_conditionally()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             Func<string, bool> condition = n => n != "deadletteredmessages";
             var subscriptionSettings = extensions.Subscriptions().ForwardDeadLetteredMessagesTo(condition, "deadletteredmessages");
@@ -95,7 +95,7 @@
         public void Should_be_able_to_set_LockDuration()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var lockDuration = TimeSpan.FromDays(1);
             var subscriptionSettings = extensions.Subscriptions().LockDuration(lockDuration);
@@ -107,7 +107,7 @@
         public void Should_be_able_to_set_MaxDeliveryCount()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             const int selectedMaxDeliveryCount = 6;
             var subscriptionSettings = extensions.Subscriptions().MaxDeliveryCount(selectedMaxDeliveryCount);
@@ -119,7 +119,7 @@
         public void Should_be_able_to_set_RequiresSession()
         {
             var setting = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(setting);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(setting);
 
             var subscriptionSettings = extensions.Subscriptions().RequiresSession(true);
 

--- a/src/Tests/Configuration/When_configuring_topics.cs
+++ b/src/Tests/Configuration/When_configuring_topics.cs
@@ -14,7 +14,7 @@
         public void Should_be_able_to_set_AutoDeleteOnIdle()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().AutoDeleteOnIdle(TimeSpan.MinValue);
 
@@ -25,7 +25,7 @@
         public void Should_be_able_to_set_DefaultMessageTimeToLive()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var timeToLive = TimeSpan.FromHours(5);
             var topicSettings = extensions.Topics().DefaultMessageTimeToLive(timeToLive);
@@ -37,7 +37,7 @@
         public void Should_be_able_to_set_DuplicateDetectionHistoryTimeWindow()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var dedupTimeWindow = TimeSpan.FromMilliseconds(30000);
             var topicSettings = extensions.Topics().DuplicateDetectionHistoryTimeWindow(dedupTimeWindow);
@@ -49,7 +49,7 @@
         public void Should_be_able_to_set_EnableBatchedOperations()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().EnableBatchedOperations(true);
 
@@ -60,7 +60,7 @@
         public void Should_be_able_to_set_EnableExpress()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().EnableExpress(true);
 
@@ -71,7 +71,7 @@
         public void Should_be_able_to_set_EnableExpress_conditionally()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             Func<string, bool> condition = name => name != "expresstopic";
             var topicSettings = extensions.Topics().EnableExpress(condition, true);
@@ -84,7 +84,7 @@
         public void Should_be_able_to_set_EnableFilteringMessagesBeforePublishing()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().EnableFilteringMessagesBeforePublishing(true);
 
@@ -95,7 +95,7 @@
         public void Should_be_able_to_set_EnablePartitioning()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().EnablePartitioning(true);
 
@@ -106,7 +106,7 @@
         public void Should_be_able_to_set_MaxSizeInMegabytes()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             const long maxTopicSizeInMB = 2048;
             var topicSettings = extensions.Topics().MaxSizeInMegabytes(SizeInMegabytes.Size2048);
@@ -118,7 +118,7 @@
         public void Should_be_able_to_set_RequiresDuplicateDetection()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().RequiresDuplicateDetection(true);
 
@@ -129,7 +129,7 @@
         public void Should_be_able_to_set_SupportOrdering()
         {
             var settings = new SettingsHolder();
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var topicSettings = extensions.Topics().SupportOrdering(true);
 

--- a/src/Tests/Configuration/When_configuring_use_logical_namespace_name.cs
+++ b/src/Tests/Configuration/When_configuring_use_logical_namespace_name.cs
@@ -11,14 +11,14 @@
     public class When_configuring_use_logical_namespace_name
     {
         SettingsHolder settingsHolder;
-        AzureServiceBusTopologySettings extensions;
+        TransportExtensions<AzureServiceBusTransport> extensions;
 
         [SetUp]
         public void SetUp()
         {
             settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
-            extensions = new AzureServiceBusTopologySettings(settingsHolder);
+            extensions = new TransportExtensions<AzureServiceBusTransport>(settingsHolder);
         }
 
         [Test]

--- a/src/Tests/Configuration/When_configuring_validation.cs
+++ b/src/Tests/Configuration/When_configuring_validation.cs
@@ -12,13 +12,13 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
     public class When_configuring_validation
     {
         SettingsHolder settingsHolder;
-        AzureServiceBusTopologySettings extensions;
+        TransportExtensions<AzureServiceBusTransport> extensions;
 
         [SetUp]
         public void SetUp()
         {
             settingsHolder = new SettingsHolder();
-            extensions = new AzureServiceBusTopologySettings(settingsHolder);
+            extensions = new TransportExtensions<AzureServiceBusTransport>(settingsHolder);
         }
 
         [Test]

--- a/src/Tests/Creation/When_creating_queues.cs
+++ b/src/Tests/Creation/When_creating_queues.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
         public async Task Uses_queue_description_when_provided_by_user()
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var descriptionToUse = new QueueDescription("myqueue");
@@ -67,7 +67,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
 
             // actual test
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().ForwardDeadLetteredMessagesTo("myotherqueue");
 
@@ -90,7 +90,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().ForwardDeadLetteredMessagesTo(name => name == "myqueue", "myotherqueue");
 
@@ -116,7 +116,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().EnableExpress(true);
 
@@ -138,7 +138,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().EnableExpress(name => name == "myqueue", true);
 
@@ -161,7 +161,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().AutoDeleteOnIdle(TimeSpan.FromDays(1));
 
@@ -186,7 +186,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             await namespaceManager.DeleteQueue("myqueue");
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().EnablePartitioning(true);
 
@@ -208,7 +208,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().EnableBatchedOperations(false);
 
@@ -230,7 +230,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().MaxDeliveryCount(10);
 
@@ -252,7 +252,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().DuplicateDetectionHistoryTimeWindow(TimeSpan.FromMinutes(20));
 
@@ -274,7 +274,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().EnableDeadLetteringOnMessageExpiration(true);
 
@@ -296,7 +296,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().DefaultMessageTimeToLive(TimeSpan.FromDays(1));
 
@@ -321,7 +321,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             await namespaceManager.DeleteQueue("myqueue");
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().RequiresSession(true);
 
@@ -343,7 +343,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().RequiresDuplicateDetection(true);
 
@@ -365,7 +365,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().MaxSizeInMegabytes(SizeInMegabytes.Size3072);
 
@@ -387,7 +387,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().LockDuration(TimeSpan.FromMinutes(5));
 
@@ -409,7 +409,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Queues().SupportOrdering(true);
 
@@ -432,7 +432,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             await namespaceManager.CreateQueue(new QueueDescription("existingqueue"));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Queues().DescriptionFactory((queuePath, readOnlySettings) => new QueueDescription(queuePath)
             {
                 AutoDeleteOnIdle = TimeSpan.FromMinutes(100),
@@ -458,11 +458,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
                 LockDuration = TimeSpan.FromSeconds(50),
                 RequiresDuplicateDetection = true,
                 EnablePartitioning = true,
-                RequiresSession = true,
+                RequiresSession = true
             });
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Queues().DescriptionFactory((queuePath, readOnlySettings) => new QueueDescription(queuePath)
             {
                 LockDuration = TimeSpan.FromSeconds(50),

--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -83,7 +83,7 @@
         public async Task Should_properly_set_use_subscription_description_provided_by_user()
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             const string subscriptionName = "sub2";
@@ -110,7 +110,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var autoDeleteTime = TimeSpan.FromDays(1);
             extensions.Subscriptions().AutoDeleteOnIdle(autoDeleteTime);
@@ -132,7 +132,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var timeToLive = TimeSpan.FromDays(10);
             extensions.Subscriptions().DefaultMessageTimeToLive(timeToLive);
@@ -155,7 +155,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Subscriptions().EnableBatchedOperations(false);
 
@@ -177,7 +177,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Subscriptions().EnableDeadLetteringOnFilterEvaluationExceptions(true);
 
@@ -199,7 +199,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Subscriptions().EnableDeadLetteringOnMessageExpiration(true);
 
@@ -221,7 +221,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var lockDuration = TimeSpan.FromMinutes(2);
             extensions.Subscriptions().LockDuration(lockDuration);
@@ -244,7 +244,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             const int deliveryCount = 10;
             extensions.Subscriptions().MaxDeliveryCount(deliveryCount);
@@ -267,7 +267,7 @@
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Subscriptions().RequiresSession(true);
 
@@ -315,7 +315,7 @@
 
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Subscriptions().ForwardDeadLetteredMessagesTo(topicToForwardTo.Path);
 
@@ -342,7 +342,7 @@
 
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Subscriptions().ForwardDeadLetteredMessagesTo(subName => subName == "sub14", topicToForwardTo.Path);
 
@@ -410,7 +410,7 @@
             await namespaceManager.CreateSubscription(new SubscriptionDescription("sometopic1", "existingsubscription1"), sqlFilter);
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Subscriptions().DescriptionFactory((topic, subName, readOnlySettings) => new SubscriptionDescription(topic, subName)
             {
                 AutoDeleteOnIdle = TimeSpan.FromMinutes(100),
@@ -439,11 +439,11 @@
             }, "1=1");
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Subscriptions().DescriptionFactory((topic, sub, readOnlySettings) => new SubscriptionDescription(topic, sub)
             {
                 EnableDeadLetteringOnFilterEvaluationExceptions = false,
-                RequiresSession = false,
+                RequiresSession = false
             });
 
             var creator = new AzureServiceBusSubscriptionCreator(settings);

--- a/src/Tests/Creation/When_creating_topics.cs
+++ b/src/Tests/Creation/When_creating_topics.cs
@@ -61,7 +61,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
         public async Task Should_use_topic_description_provided_by_user()
         {
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             const string topicPath = "mytopic3";
@@ -88,7 +88,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var autoDeleteTime = TimeSpan.FromDays(1);
             extensions.Topics().AutoDeleteOnIdle(autoDeleteTime);
@@ -110,7 +110,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var timeToLive = TimeSpan.FromDays(1);
             extensions.Topics().DefaultMessageTimeToLive(timeToLive);
@@ -132,7 +132,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var duplicateDetectionTime = TimeSpan.FromDays(1);
             extensions.Topics().DuplicateDetectionHistoryTimeWindow(duplicateDetectionTime);
@@ -154,7 +154,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Topics().EnableBatchedOperations(false);
 
@@ -175,7 +175,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Topics().EnableFilteringMessagesBeforePublishing(true);
 
@@ -200,7 +200,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             await namespaceManager.DeleteTopic(topicPath);
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Topics().EnablePartitioning(true);
 
@@ -219,7 +219,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Topics().MaxSizeInMegabytes(SizeInMegabytes.Size4096);
 
@@ -240,7 +240,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Topics().RequiresDuplicateDetection(true);
 
@@ -261,7 +261,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             extensions.Topics().SupportOrdering(true);
 
@@ -369,7 +369,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             await namespaceManager.CreateTopic(new TopicDescription("existingtopic1"));
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Topics().DescriptionFactory((topicPath, readOnlySettings) => new TopicDescription(topicPath)
             {
                 AutoDeleteOnIdle = TimeSpan.FromMinutes(100),
@@ -397,7 +397,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             });
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Topics().DescriptionFactory((queuePath, readOnlySettings) => new TopicDescription(queuePath)
             {
                 MaxSizeInMegabytes = 1024,

--- a/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
+++ b/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
@@ -464,7 +464,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             settings.SetDefault<EndpointName>(new EndpointName(enpointname));
             settings.Set<Conventions>(new Conventions());
 
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.NamespacePartitioning().AddNamespace("namespaceName", AzureServiceBusConnectionString.Value);
 
             var topology = new EndpointOrientedTopology(container);

--- a/src/Tests/Seam/When_receiving_messages.cs
+++ b/src/Tests/Seam/When_receiving_messages.cs
@@ -76,7 +76,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             settings.SetDefault<EndpointName>(new EndpointName(enpointname));
             extensions.NamespacePartitioning().AddNamespace("namespaceName", AzureServiceBusConnectionString.Value);
 

--- a/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
@@ -21,13 +21,14 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
 
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var definition = DetermineResourcesToCreate(settings, container);
 
+            // ReSharper disable once RedundantArgumentDefaultValue
             var namespaceInfo = new RuntimeNamespaceInfo(Name, Connectionstring, NamespaceMode.Active);
             Assert.IsTrue(definition.Namespaces.Any(nsi => nsi == namespaceInfo));
         }
@@ -40,7 +41,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
@@ -58,7 +59,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
@@ -32,6 +32,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var sectionManager = container.Resolve<ITopologySectionManager>();
             var definition = sectionManager.DetermineResourcesToCreate();
 
+            // ReSharper disable once RedundantArgumentDefaultValue
             var namespaceInfo = new RuntimeNamespaceInfo(Name, Connectionstring, NamespaceMode.Active);
             Assert.IsTrue(definition.Namespaces.Any(nsi => nsi == namespaceInfo));
         }
@@ -43,7 +44,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
@@ -65,7 +66,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
@@ -91,7 +92,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.UseTopology<ForwardingTopology>().NamespacePartitioning().AddNamespace(Name, Connectionstring);
@@ -116,7 +117,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.UseTopology<ForwardingTopology>().NamespacePartitioning().AddNamespace(Name, Connectionstring);
@@ -140,7 +141,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault<EndpointName>(new EndpointName("sales"));
             extensions.UseTopology<ForwardingTopology>().NamespacePartitioning().AddNamespace(Name, Connectionstring);

--- a/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
@@ -514,7 +514,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             settings.SetDefault<EndpointName>(new EndpointName(enpointname));
             extensions.NamespacePartitioning().AddNamespace("namespace", AzureServiceBusConnectionString.Value);
 

--- a/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             settings.SetDefault<EndpointName>(new EndpointName(enpointname));
             extensions.NamespacePartitioning().AddNamespace("namespace1", AzureServiceBusConnectionString.Value);
 

--- a/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
@@ -42,7 +42,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
         {
             var settings = new SettingsHolder();
             container.Register(typeof(SettingsHolder), () => settings);
-            var extensions = new AzureServiceBusTopologySettings(settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             settings.SetDefault<EndpointName>(new EndpointName(enpointname));
             extensions.NamespacePartitioning().AddNamespace("namespace1", AzureServiceBusConnectionString.Value);
 

--- a/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
+++ b/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
@@ -9,22 +9,22 @@ namespace NServiceBus
 
     public static class AzureServiceBusTransportExtensions
     {
-        public static AzureServiceBusTopologySettings UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions) where T : ITopology, new()
+        public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions) where T : ITopology, new()
         {
             var topology = Activator.CreateInstance<T>();
             return UseTopology(transportExtensions, topology);
         }
 
-        public static AzureServiceBusTopologySettings UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions, Func<T> factory) where T : ITopology
+        public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions, Func<T> factory) where T : ITopology
         {
             return UseTopology(transportExtensions, factory());
         }
 
-        public static AzureServiceBusTopologySettings UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions, T topology) where T : ITopology
+        public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions, T topology) where T : ITopology
         {
             var settings = transportExtensions.GetSettings();
             settings.Set<ITopology>(topology);
-            return new AzureServiceBusTopologySettings(settings);
+            return new AzureServiceBusTopologySettings<T>(settings);
         }
 
 

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using AzureServiceBus;
+    using AzureServiceBus.TypesScanner;
+    using Configuration.AdvanceExtensibility;
+    using Settings;
+
+    public static class AzureServiceBusEndpointOrientedTopologySettingsExtensions
+    {
+        public static AzureServiceBusTopologySettings<EndpointOrientedTopology> RegisterPublisherForType(this AzureServiceBusTopologySettings<EndpointOrientedTopology> topologySettings, string publisherName, Type type)
+        {
+            AddScannerForPublisher(topologySettings.GetSettings(), publisherName, new SingleTypeScanner(type));
+            return topologySettings;
+        }
+
+        public static AzureServiceBusTopologySettings<EndpointOrientedTopology> RegisterPublisherForAssembly(this AzureServiceBusTopologySettings<EndpointOrientedTopology> topologySettings, string publisherName, Assembly assembly)
+        {
+            AddScannerForPublisher(topologySettings.GetSettings(), publisherName, new AssemblyTypesScanner(assembly));
+            return topologySettings;
+        }
+
+        static void AddScannerForPublisher(SettingsHolder settings, string publisherName, ITypesScanner scanner)
+        {
+            Dictionary<string, List<ITypesScanner>> map;
+
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Publishers, out map))
+            {
+                map = new Dictionary<string, List<ITypesScanner>>();
+                settings.Set(WellKnownConfigurationKeys.Topology.Publishers, map);
+            }
+
+            if (!map.ContainsKey(publisherName))
+                map[publisherName] = new List<ITypesScanner>();
+
+            map[publisherName].Add(scanner);
+        }
+    }
+}

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
@@ -1,62 +1,12 @@
 ﻿namespace NServiceBus
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
     using AzureServiceBus;
-    using AzureServiceBus.TypesScanner;
     using Settings;
 
-    public class AzureServiceBusTopologySettings : TransportExtensions<AzureServiceBusTransport>
+    public class AzureServiceBusTopologySettings<T> : TransportExtensions<AzureServiceBusTransport> where T : ITopology
     {
-        SettingsHolder settings;
-
-        public AzureServiceBusTopologySettings(SettingsHolder settings)
-            : base(settings)
+        public AzureServiceBusTopologySettings(SettingsHolder settings) : base(settings)
         {
-            this.settings = settings;
-        }
-
-        public AzureServiceBusTopologySettings RegisterPublisherForType(string publisherName, Type type)
-        {
-            EnsureThatConfiguredTopologyNeedsMappingConfigurationBetweenPublishersAndEventTypes();
-
-            AddScannerForPublisher(publisherName, new SingleTypeScanner(type));
-            return this;
-        }
-
-        public AzureServiceBusTopologySettings RegisterPublisherForAssembly(string publisherName, Assembly assembly)
-        {
-            EnsureThatConfiguredTopologyNeedsMappingConfigurationBetweenPublishersAndEventTypes();
-
-            AddScannerForPublisher(publisherName, new AssemblyTypesScanner(assembly));
-            return this;
-        }
-
-        void AddScannerForPublisher(string publisherName, ITypesScanner scanner)
-        {
-            Dictionary<string, List<ITypesScanner>> map;
-
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Publishers, out map))
-            {
-                map = new Dictionary<string, List<ITypesScanner>>();
-                settings.Set(WellKnownConfigurationKeys.Topology.Publishers, map);
-            }
-
-            if (!map.ContainsKey(publisherName))
-                map[publisherName] = new List<ITypesScanner>();
-
-            map[publisherName].Add(scanner);
-        }
-
-        void EnsureThatConfiguredTopologyNeedsMappingConfigurationBetweenPublishersAndEventTypes()
-        {
-            var topology = settings.Get<ITopology>();
-
-            if (!topology.NeedsMappingConfigurationBetweenPublishersAndEventTypes)
-            {
-                throw new InvalidOperationException($"Configured topology (`{topology.GetType().FullName}`) doesn't need mapping configuration between publisher names and event types");
-            }
         }
     }
 }

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Addressing\Validation\Strategies\EntityNameValidationV6Rules.cs" />
     <Compile Include="CircuitBreakers\RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="Config\AzureServiceBusTransportInfrastructure.cs" />
+    <Compile Include="Config\ExtensionPoints\AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs" />
     <Compile Include="Config\TransactionModeSettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusTopologySettings.cs" />
     <Compile Include="Config\ExtensionPoints\SizeInMegabytes.cs" />

--- a/src/Transport/Topology/ITopology.cs
+++ b/src/Transport/Topology/ITopology.cs
@@ -18,6 +18,5 @@ namespace NServiceBus.AzureServiceBus
 
         bool HasNativePubSubSupport { get; }
         bool HasSupportForCentralizedPubSub { get;}
-        bool NeedsMappingConfigurationBetweenPublishersAndEventTypes { get; }
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -21,7 +21,6 @@ namespace NServiceBus.AzureServiceBus
 
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
-        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes => true;
 
         public void Initialize(SettingsHolder settings)
         {

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -23,7 +23,6 @@ namespace NServiceBus.AzureServiceBus
 
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
-        public bool NeedsMappingConfigurationBetweenPublishersAndEventTypes => false;
 
         public void Initialize(SettingsHolder settings)
         {


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.AzureServiceBus/issues/179

Potential solution for the #179.

The result of this spike prevents Publisher API from surfacing on the transports other than `EndpointOrientedTopology`.

**Before**:
```c#
endpoingConfiguration.UserTransport<AzureServiceBusTransport>()
  .UseTopology<EndpointOrientedTopology>()
  .RegisterPublisherForType("endpoint", SomeEvent);

endpoingConfiguration.UserTransport<AzureServiceBusTransport>()
  .UseTopology<ForwardingTopology>()
  .RegisterPublisherForType("endpoint", SomeEvent); // will throw an exception at runtime
```

**After**:
```c#
endpoingConfiguration.UserTransport<AzureServiceBusTransport>()
  .UseTopology<EndpointOrientedTopology>()  
  .RegisterPublisherForType("endpoint", SomeEvent); // Available for EndpointOrientedTopology ONLY
```