### PR TITLE
Added section with steps to setup ATTs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,16 @@ Follow these steps to run the acceptance tests locally:
 * Add a new environment variable `AzureServiceBusTransport.ConnectionString` containing a connection string to your Azure storage account 
 * Add a new environment variable `AzureServiceBusTransport.Topology` and set it to _ForwardingTopology_ to run tests configuring transport with `ForwardingTopology` topology. Don't setup `AzureServiceBusTransport.Topology` environment variable to run tests with `EndpointOrientedTopology` topology
 
+
+## Running Unit/Integration Tests
+
+To execute tests under `NServiceBus.AzureServiceBus.Tests`, two environment variables are required:
+
+1. `AzureServiceBus.ConnectionString`
+1. `AzureServiceBus.ConnectionString.Fallback`
+
+Note that those should **not** point to the same namespace.
+
 ## Making Changes
 
 * Create a feature branch from where you want to base your work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ top of things.
   * If it is a bug make sure you tell us what version you have encountered this bug on.
 * Fork the repository on GitHub
 
+## Running the Acceptance Tests
+ 
+Follow these steps to run the acceptance tests locally:
+
+* Add a new environment variable `Transport.UseSpecific` with the value `AzureServiceBusTransport`
+* Add a new environment variable `AzureServiceBusTransport.ConnectionString` containing a connection string to your Azure storage account 
+* Add a new environment variable `AzureServiceBusTransport.Topology` and set it to _ForwardingTopology_ to run tests configuring transport with `ForwardingTopology` topology. Don't setup `AzureServiceBusTransport.Topology` environment variable to run tests with `EndpointOrientedTopology` topology
+
 ## Making Changes
 
 * Create a feature branch from where you want to base your work.


### PR DESCRIPTION
Connects to #184 

Since repo has another "tests" project (`NServiceBus.AzureServiceBus.Tests`) that needs environment variables setup (`AzureServiceBus.ConnectionString` and `AzureServiceBus.ConnectionString.Fallback`), does make sense to create a section to describe this steps too?

@Particular/azure-service-bus-maintainers take a look here