### PR TITLE
HierarchyComposition fixes

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -46,9 +46,8 @@
     }
     public class HierarchyComposition : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy
     {
-        public HierarchyComposition() { }
+        public HierarchyComposition(NServiceBus.Settings.ReadOnlySettings settings) { }
         public string GetEntityPath(string entityname, NServiceBus.AzureServiceBus.EntityType entityType) { }
-        public void SetPathGenerator(System.Func<string, string> pathGenerator) { }
     }
     public interface ICompositionStrategy
     {
@@ -500,10 +499,15 @@ namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 namespace NServiceBus
 {
     
+    public class AzureServiceBusCompositionExtensionPoint<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+        where T : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy
+    {
+        public AzureServiceBusCompositionExtensionPoint(NServiceBus.Settings.SettingsHolder settings) { }
+    }
     public class AzureServiceBusCompositionSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public AzureServiceBusCompositionSettings(NServiceBus.Settings.SettingsHolder settings) { }
-        public NServiceBus.AzureServiceBusCompositionSettings UseStrategy<T>()
+        public NServiceBus.AzureServiceBusCompositionExtensionPoint<T> UseStrategy<T>()
             where T : NServiceBus.AzureServiceBus.Addressing.ICompositionStrategy { }
     }
     public class static AzureServiceBusEndpointOrientedTopologySettingsExtensions
@@ -515,6 +519,10 @@ namespace NServiceBus
     {
         public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.ForwardingTopology> BundlePrefix(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.ForwardingTopology> topologySettings, string prefix) { }
         public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.ForwardingTopology> NumberOfEntitiesInBundle(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.AzureServiceBus.ForwardingTopology> topologySettings, int number) { }
+    }
+    public class static AzureServiceBusHierarchyCompositionSettingsExtensions
+    {
+        public static NServiceBus.AzureServiceBusCompositionExtensionPoint<NServiceBus.AzureServiceBus.Addressing.HierarchyComposition> PathGenerator(this NServiceBus.AzureServiceBusCompositionExtensionPoint<NServiceBus.AzureServiceBus.Addressing.HierarchyComposition> composition, System.Func<string, string> pathGenerator) { }
     }
     public class AzureServiceBusIndividualizationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -161,8 +161,7 @@ namespace NServiceBus.AzureServiceBus
         Queue = 0,
         Topic = 1,
         Subscription = 2,
-        EventHub = 3,
-        Rule = 4,
+        Rule = 3,
     }
     public class ForwardingTopology : NServiceBus.AzureServiceBus.ITopology
     {

--- a/src/Tests/Addressing/Composition/When_using_hierarchy_composition_strategy.cs
+++ b/src/Tests/Addressing/Composition/When_using_hierarchy_composition_strategy.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var entityname = "myqueue";
 
             var settings = new SettingsHolder();
-            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator, (Func<string, string>)(s => prefix));
             var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(prefix + entityname, strategy.GetEntityPath(entityname, EntityType.Queue));
@@ -30,7 +30,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var entityname = "mytopic";
 
             var settings = new SettingsHolder();
-            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator, (Func<string, string>)(s => prefix));
             var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(prefix + entityname, strategy.GetEntityPath(entityname, EntityType.Topic));
@@ -43,7 +43,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var entityname = "myqueue";
 
             var settings = new SettingsHolder();
-            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator, (Func<string, string>)(s => prefix));
             var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(entityname, strategy.GetEntityPath(entityname, EntityType.Subscription));
@@ -56,7 +56,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var entityname = "myrule";
 
             var settings = new SettingsHolder();
-            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator, (Func<string, string>)(s => prefix));
             var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(entityname, strategy.GetEntityPath(entityname, EntityType.Rule));

--- a/src/Tests/Addressing/Composition/When_using_hierarchy_composition_strategy.cs
+++ b/src/Tests/Addressing/Composition/When_using_hierarchy_composition_strategy.cs
@@ -1,8 +1,10 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
 {
+    using System;
     using AzureServiceBus;
     using AzureServiceBus.Addressing;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     [Category("AzureServiceBus")]
@@ -14,8 +16,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var prefix = "/my/path/";
             var entityname = "myqueue";
 
-            var strategy = new HierarchyComposition();
-            strategy.SetPathGenerator(s => prefix);
+            var settings = new SettingsHolder();
+            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(prefix + entityname, strategy.GetEntityPath(entityname, EntityType.Queue));
         }
@@ -26,8 +29,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var prefix = "/my/path/";
             var entityname = "mytopic";
 
-            var strategy = new HierarchyComposition();
-            strategy.SetPathGenerator(s => prefix);
+            var settings = new SettingsHolder();
+            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(prefix + entityname, strategy.GetEntityPath(entityname, EntityType.Topic));
         }
@@ -38,11 +42,24 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             var prefix = "/my/path/";
             var entityname = "myqueue";
 
-            var strategy = new HierarchyComposition();
-            strategy.SetPathGenerator(s => prefix);
+            var settings = new SettingsHolder();
+            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            var strategy = new HierarchyComposition(settings);
 
             Assert.AreEqual(entityname, strategy.GetEntityPath(entityname, EntityType.Subscription));
         }
 
+        [Test]
+        public void Hierarchy_composition_will_not_prefix_entity_name_with_path_for_rules()
+        {
+            var prefix = "/my/path/";
+            var entityname = "myrule";
+
+            var settings = new SettingsHolder();
+            settings.Set(HierarchyComposition.PathGeneratorSettingsKey, (Func<string, string>)(s => prefix));
+            var strategy = new HierarchyComposition(settings);
+
+            Assert.AreEqual(entityname, strategy.GetEntityPath(entityname, EntityType.Rule));
+        }
     }
 }

--- a/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
+++ b/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
@@ -5,8 +5,6 @@ namespace NServiceBus.AzureServiceBus.Addressing
 
     public class HierarchyComposition : ICompositionStrategy
     {
-        internal const string PathGeneratorSettingsKey = "HierarchyComposition.PathGenerator";
-
         ReadOnlySettings settings;
         
         public HierarchyComposition(ReadOnlySettings settings)
@@ -16,7 +14,7 @@ namespace NServiceBus.AzureServiceBus.Addressing
 
         public string GetEntityPath(string entityname, EntityType entityType)
         {
-            var pathGenerator = settings.Get<Func<string, string>>(PathGeneratorSettingsKey);
+            var pathGenerator = settings.Get<Func<string, string>>(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator);
 
             switch (entityType)
             {

--- a/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
+++ b/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
@@ -1,18 +1,23 @@
 namespace NServiceBus.AzureServiceBus.Addressing
 {
     using System;
+    using Settings;
 
     public class HierarchyComposition : ICompositionStrategy
     {
-        Func<string, string> pathGenerator;
+        internal const string PathGeneratorSettingsKey = "HierarchyComposition.PathGenerator";
 
-        public void SetPathGenerator(Func<string, string> pathGenerator)
+        ReadOnlySettings settings;
+        
+        public HierarchyComposition(ReadOnlySettings settings)
         {
-            this.pathGenerator = pathGenerator;
+            this.settings = settings;
         }
 
         public string GetEntityPath(string entityname, EntityType entityType)
         {
+            var pathGenerator = settings.Get<Func<string, string>>(PathGeneratorSettingsKey);
+
             switch (entityType)
             {
                 case EntityType.Queue:

--- a/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
+++ b/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
@@ -13,12 +13,19 @@ namespace NServiceBus.AzureServiceBus.Addressing
 
         public string GetEntityPath(string entityname, EntityType entityType)
         {
-            if (entityType == EntityType.Subscription)
+            switch (entityType)
             {
-                return entityname;
-            }
+                case EntityType.Queue:
+                case EntityType.Topic:
+                    return pathGenerator(entityname) + entityname;
 
-            return pathGenerator(entityname) + entityname;
+                case EntityType.Subscription:
+                case EntityType.Rule:
+                    return entityname;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null);
+            }
         }
     }
 }

--- a/src/Transport/Addressing/Validation/Strategies/EntityNameValidationRules.cs
+++ b/src/Transport/Addressing/Validation/Strategies/EntityNameValidationRules.cs
@@ -39,8 +39,6 @@ namespace NServiceBus.AzureServiceBus.Addressing
                     valid &= entityPath.Length <= settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength);
                     valid &= subscriptionAndRuleNameRegex.IsMatch(entityPath);
                     break;
-                case EntityType.EventHub:
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null);
             }

--- a/src/Transport/Addressing/Validation/Strategies/EntityNameValidationV6Rules.cs
+++ b/src/Transport/Addressing/Validation/Strategies/EntityNameValidationV6Rules.cs
@@ -38,8 +38,6 @@
                     isValid &= entityPath.Length <= settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength);
                     isValid &= v6PathRegex.IsMatch(entityPath);
                     break;
-                case EntityType.EventHub:
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null);
             }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionExtensionPoint.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionExtensionPoint.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus
+{
+    using AzureServiceBus.Addressing;
+    using Configuration.AdvanceExtensibility;
+    using Settings;
+
+    public class AzureServiceBusCompositionExtensionPoint<T> : ExposeSettings where T : ICompositionStrategy
+    {
+        public AzureServiceBusCompositionExtensionPoint(SettingsHolder settings) : base(settings)
+        {
+        }
+    }
+}

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionSettings.cs
@@ -9,8 +9,7 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusCompositionSettings(SettingsHolder settings)
-            : base(settings)
+        public AzureServiceBusCompositionSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }
@@ -20,11 +19,11 @@
         /// <remarks>Default is <see cref="FlatComposition"/></remarks>
         /// <seealso cref="HierarchyComposition"/>
         /// </summary>
-        public AzureServiceBusCompositionSettings UseStrategy<T>() where T : ICompositionStrategy
+        public AzureServiceBusCompositionExtensionPoint<T> UseStrategy<T>() where T : ICompositionStrategy
         {
             settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.Strategy, typeof(T));
 
-            return this;
+            return new AzureServiceBusCompositionExtensionPoint<T>(settings);
         }
     }
 }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusHierarchyCompositionSettingsExtensions.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusHierarchyCompositionSettingsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using AzureServiceBus;
     using AzureServiceBus.Addressing;
     using Configuration.AdvanceExtensibility;
 
@@ -8,7 +9,7 @@
     {
         public static AzureServiceBusCompositionExtensionPoint<HierarchyComposition> PathGenerator(this AzureServiceBusCompositionExtensionPoint<HierarchyComposition> composition, Func<string, string> pathGenerator)
         {
-            composition.GetSettings().Set(HierarchyComposition.PathGeneratorSettingsKey, pathGenerator);
+            composition.GetSettings().Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator, pathGenerator);
             return composition;
         }
     }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusHierarchyCompositionSettingsExtensions.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusHierarchyCompositionSettingsExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using AzureServiceBus.Addressing;
+    using Configuration.AdvanceExtensibility;
+
+    public static class AzureServiceBusHierarchyCompositionSettingsExtensions
+    {
+        public static AzureServiceBusCompositionExtensionPoint<HierarchyComposition> PathGenerator(this AzureServiceBusCompositionExtensionPoint<HierarchyComposition> composition, Func<string, string> pathGenerator)
+        {
+            composition.GetSettings().Set(HierarchyComposition.PathGeneratorSettingsKey, pathGenerator);
+            return composition;
+        }
+    }
+}

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -81,6 +81,7 @@ namespace NServiceBus.AzureServiceBus
                 public static class Composition
                 {
                     public const string Strategy = "AzureServiceBus.Settings.Topology.Addressing.Composition.Strategy";
+                    public const string HierarchyCompositionPathGenerator = "AzureServiceBus.Settings.Topology.Addressing.Composition.HierarchyCompositionPathGenerator";
                 }
 
                 public static class Validation

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -93,8 +93,10 @@
     <Compile Include="Addressing\Validation\Strategies\EntityNameValidationV6Rules.cs" />
     <Compile Include="CircuitBreakers\RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="Config\AzureServiceBusTransportInfrastructure.cs" />
+    <Compile Include="Config\ExtensionPoints\AzureServiceBusCompositionExtensionPoint.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusForwardingTopologySettingsExtensions.cs" />
+    <Compile Include="Config\ExtensionPoints\AzureServiceBusHierarchyCompositionSettingsExtensions.cs" />
     <Compile Include="Config\TransactionModeSettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusTopologySettings.cs" />
     <Compile Include="Config\ExtensionPoints\SizeInMegabytes.cs" />

--- a/src/Transport/Topology/MetaModel/EntityType.cs
+++ b/src/Transport/Topology/MetaModel/EntityType.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.AzureServiceBus
         Queue,
         Topic,
         Subscription,
-        EventHub,
         Rule
     }
 }


### PR DESCRIPTION
`HierarchyComposition` should not be applied on entities of a rule type. Also, there was no way to set path generator, which rendered this strategy useless.

fixes #190 - allow to set path generator
fixes #222 - `EntityType.EventHub` is not used