### PR TITLE
Batched completion

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -261,6 +261,7 @@ namespace NServiceBus.AzureServiceBus
         Microsoft.ServiceBus.Messaging.ReceiveMode Mode { get; }
         int PrefetchCount { get; set; }
         System.Threading.Tasks.Task CloseAsync();
+        System.Threading.Tasks.Task CompleteBatchAsync(System.Collections.Generic.IEnumerable<System.Guid> lockTokens);
         void OnMessage(System.Func<Microsoft.ServiceBus.Messaging.BrokeredMessage, System.Threading.Tasks.Task> callback, Microsoft.ServiceBus.Messaging.OnMessageOptions options);
     }
     public interface IMessageSender : NServiceBus.AzureServiceBus.IClientEntity

--- a/src/Tests/Connectivity/When_creating_message_receivers.cs
+++ b/src/Tests/Connectivity/When_creating_message_receivers.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
@@ -124,6 +125,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             }
 
             public Task CloseAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task CompleteBatchAsync(IEnumerable<Guid> lockTokens)
             {
                 throw new NotImplementedException();
             }

--- a/src/Tests/Connectivity/When_managing_client_entity_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_client_entity_lifecycle.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
@@ -106,6 +107,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             }
 
             public Task CloseAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task CompleteBatchAsync(IEnumerable<Guid> lockTokens)
             {
                 throw new NotImplementedException();
             }

--- a/src/Transport/Connectivity/IMessageReceiver.cs
+++ b/src/Transport/Connectivity/IMessageReceiver.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AzureServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
@@ -10,5 +11,6 @@ namespace NServiceBus.AzureServiceBus
         ReceiveMode Mode { get; }
         void OnMessage(Func<BrokeredMessage, Task> callback, OnMessageOptions options);
         Task CloseAsync();
+        Task CompleteBatchAsync(IEnumerable<Guid> lockTokens);
     }
 }

--- a/src/Transport/Connectivity/MessageReceiverAdapter.cs
+++ b/src/Transport/Connectivity/MessageReceiverAdapter.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AzureServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
@@ -38,6 +39,11 @@ namespace NServiceBus.AzureServiceBus
         public Task CloseAsync()
         {
            return receiver.CloseAsync();
+        }
+
+        public Task CompleteBatchAsync(IEnumerable<Guid> lockTokens)
+        {
+            return receiver.CompleteBatchAsync(lockTokens);
         }
     }
 }

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Sending\Time.cs" />
     <Compile Include="Topology\ConventionsAdapter.cs" />
     <Compile Include="Topology\IConventions.cs" />
+    <Compile Include="Utils\MessageReceiverExtensions.cs" />
     <Compile Include="Utils\TypeExtensions.cs" />
     <Compile Include="Topology\TypesScanner\AssemblyTypesScanner.cs" />
     <Compile Include="Topology\TypesScanner\ITypesScanner.cs" />

--- a/src/Transport/Utils/MessageReceiverExtensions.cs
+++ b/src/Transport/Utils/MessageReceiverExtensions.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus.AzureServiceBus.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using Logging;
+    using Microsoft.ServiceBus.Messaging;
+
+    static class MessageReceiverExtensions
+    {
+        static ILog Log = LogManager.GetLogger(typeof(MessageReceiverExtensions));
+
+        public static async Task<bool> SafeCompleteBatchAsync(this IMessageReceiver messageReceiver, IEnumerable<Guid> lockTokens)
+        {
+            try
+            {
+                await messageReceiver.CompleteBatchAsync(lockTokens).ConfigureAwait(false);
+                return true;
+            }
+            catch (MessageLockLostException ex)
+            {
+                // It's too late to compensate the loss of a message lock. We should just ignore it so that it does not break the receive loop.
+                Log.Warn($"A message lock lost exception occured while trying to complete a batch of messages, you may consider to increase the lock duration or reduce the batch size, the exception was {ex.Message}", ex);
+            }
+            catch (MessagingException ex)
+            {
+                // There is nothing we can do as the connection may have been lost, or the underlying queue may have been removed.
+                // If Complete() fails with this exception, the only recourse is to receive another message.
+                Log.Warn($"A messaging exception occured while trying to complete a batch of message, this might imply that the connection was lost or the underlying queue got removed, the exception was {ex.Message}", ex);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // There is nothing we can do as the object has already been disposed elsewhere
+                Log.Warn($"An object disposed exception occured while trying to complete a batch of messages, this might imply that the connection was lost or the underlying queue got removed, the exception was {ex.Message}", ex);
+            }
+            catch (TransactionException ex)
+            {
+                // ASB Sdk beat us to it
+                Log.Warn($"A transaction exception occured while trying to complete a batch of messages, this probably means that the Azure ServiceBus SDK has rolled back the transaction already, the exception was {ex.Message}", ex);
+            }
+            catch (TimeoutException ex)
+            {
+                // took to long
+                Log.Warn($"A timeout exception occured while trying to complete a batch of messages, the exception was {ex.Message}", ex);
+            }
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/718

~~A spike for~~ Solves #212.
(related PRs: #223) 

Using ~~`ConcurrentQueue<Guid>`~~ `ConcurrentStack<Guid>` to store incoming message lock tokens for a batched completion.
Batched completion is taking place on a separate task. The task is backing off (delay) by 0.5 second if there's nothing to complete. Upon notifier stop, operation is blocked until all lock tokens have been completed.

**Things to consider**

The original implementation was using `await message.SafeCompleteAsync().ConfigureAwait(false);`. `SafeCompleteAsync() was logging exceptions _per message_. This is no longer an option with batched completion. Exception will be logged per batch of lock tokens (ie no message IDs.)

@Particular/azure-service-bus-maintainers please review and chime in