### PR TITLE
IValidationStrategy to distinguish between errors

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -20,12 +20,12 @@
     public class EntityNameValidationRules : NServiceBus.AzureServiceBus.Addressing.IValidationStrategy
     {
         public EntityNameValidationRules(NServiceBus.Settings.ReadOnlySettings settings) { }
-        public bool IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+        public NServiceBus.AzureServiceBus.Addressing.ValidationResult IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
     }
     public class EntityNameValidationV6Rules : NServiceBus.AzureServiceBus.Addressing.IValidationStrategy
     {
         public EntityNameValidationV6Rules(NServiceBus.Settings.ReadOnlySettings settings) { }
-        public bool IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
+        public NServiceBus.AzureServiceBus.Addressing.ValidationResult IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType) { }
     }
     public enum FailOverMode
     {
@@ -67,7 +67,7 @@
     }
     public interface IValidationStrategy
     {
-        bool IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType);
+        NServiceBus.AzureServiceBus.Addressing.ValidationResult IsValid(string entityPath, NServiceBus.AzureServiceBus.EntityType entityType);
     }
     public enum PartitioningIntent
     {
@@ -91,6 +91,13 @@
     {
         public ThrowOnFailingSanitization(NServiceBus.AzureServiceBus.Addressing.IValidationStrategy validationStrategy) { }
         public string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType) { }
+    }
+    public class ValidationResult
+    {
+        public ValidationResult() { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<string> Errors { get; }
+        public bool IsValid { get; }
+        public void AddError(string error) { }
     }
 }
 namespace NServiceBus.AzureServiceBus

--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
@@ -56,9 +56,20 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
 
         class ValidationMock : IValidationStrategy
         {
-            public bool IsValid(string entityPath, EntityType entityType)
+            public ValidationResult IsValid(string entityPath, EntityType entityType)
             {
-                return !entityPath.Contains("$") && entityPath.Length < 260;
+                var validationResult = new ValidationResult();
+                if (entityPath.Contains("$"))
+                {
+                    validationResult.AddError("contains `$` sign");
+                }
+
+                if (entityPath.Length > 260)
+                {
+                    validationResult.AddError("lenth is more than 260 characters");
+                }
+
+                return validationResult;
             }
         }
     }

--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_throwing_exception.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_throwing_exception.cs
@@ -38,9 +38,16 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
                 this.shouldValidationPass = shouldValidationPass;
             }
 
-            public bool IsValid(string entityPath, EntityType entityType)
+            public ValidationResult IsValid(string entityPath, EntityType entityType)
             {
-                return shouldValidationPass;
+                var validationResult = new ValidationResult();
+
+                if (!shouldValidationPass)
+                {
+                    validationResult.AddError("validation should fail");
+                }
+
+                return validationResult;
             }
         }
     }

--- a/src/Tests/Addressing/Validation/When_using_entity_validation_rules.cs
+++ b/src/Tests/Addressing/Validation/When_using_entity_validation_rules.cs
@@ -18,24 +18,16 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
         const string illegalCharacterSubscriptionName = "6pwTRR34FFr/6YhPi-iDNfdSRLNDFIqZ97_Ky64w49r50n72vk";
 
         [Test]
-        public void Namespaces_allow_queues_with_paths_up_to_260_characters()
+        public void Namespaces_allow_queues_with_paths_up_to_260_characters_slashes_dashes_dots_and_underscores()
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(validEntityName, EntityType.Queue);
 
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Queue));
-        }
-
-        [Test]
-        public void Namespaces_allow_queues_with_slashes_dashes_dots_and_underscores()
-        {
-            var settingsHolder = new SettingsHolder();
-            new DefaultConfigurationValues().Apply(settingsHolder);
-            var validation = new EntityNameValidationRules(settingsHolder);
-
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Queue));
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.That(validationResult.Errors, Is.Empty);
         }
 
         [Test]
@@ -45,8 +37,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongEntityName, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(tooLongEntityName, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -56,42 +50,37 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(illegalCharacterEntityName, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(illegalCharacterEntityName, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
-        [TestCase("/" + validEntityName)]
-        [TestCase(validEntityName + "/")]
+        [TestCase("/queue")]
+        [TestCase("queue/")]
         public void Namespaces_do_not_allows_queues_with_leading_or_trailing_slash(string entityPath)
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(entityPath, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(entityPath, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
-        public void Namespaces_allow_topics_with_paths_up_to_260_characters()
+        public void Namespaces_allow_topics_with_paths_up_to_260_characters_with_slashes_dashes_dots_and_underscores()
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(validEntityName, EntityType.Topic);
 
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Topic));
-        }
-
-        [Test]
-        public void Namespaces_allow_topics_with_slashes_dashes_dots_and_underscores()
-        {
-            var settingsHolder = new SettingsHolder();
-            new DefaultConfigurationValues().Apply(settingsHolder);
-
-            var validation = new EntityNameValidationRules(settingsHolder);
-
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Queue));
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.That(validationResult.Errors, Is.Empty);
         }
 
         [Test]
@@ -101,8 +90,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongEntityName, EntityType.Topic);
 
-            Assert.IsFalse(validation.IsValid(tooLongEntityName, EntityType.Topic));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -112,42 +103,37 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(illegalCharacterEntityName, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(illegalCharacterEntityName, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
-        [TestCase("/" + validEntityName)]
-        [TestCase(validEntityName + "/")]
+        [TestCase("/topic")]
+        [TestCase("topic/")]
         public void Namespaces_do_not_allow_topics_with_leading_or_trailing_slash(string entityPath)
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(entityPath, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(entityPath, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
-        public void Namespaces_allow_subscriptions_with_paths_up_to_50_characters()
+        public void Namespaces_allow_subscriptions_with_paths_up_to_50_characters_with_dashes_dots_and_underscores()
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(validSubscriptionName, EntityType.Subscription);
 
-            Assert.IsTrue(validation.IsValid(validSubscriptionName, EntityType.Subscription));
-        }
-
-        [Test]
-        public void Namespaces_allow_subscriptions_with_dashes_dots_and_underscores()
-        {
-            var settingsHolder = new SettingsHolder();
-            new DefaultConfigurationValues().Apply(settingsHolder);
-
-            var validation = new EntityNameValidationRules(settingsHolder);
-
-            Assert.IsTrue(validation.IsValid(validSubscriptionName, EntityType.Subscription));
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.That(validationResult.Errors, Is.Empty);
         }
 
         [Test]
@@ -157,8 +143,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongSubscriptionName, EntityType.Subscription);
 
-            Assert.IsFalse(validation.IsValid(tooLongSubscriptionName, EntityType.Subscription));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -168,8 +156,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(illegalCharacterSubscriptionName, EntityType.Subscription);
 
-            Assert.IsFalse(validation.IsValid(illegalCharacterSubscriptionName, EntityType.Subscription));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [TestCase("illegal/queue/")]
@@ -181,8 +171,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(queuePath, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(queuePath, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [TestCase("illegal/topic/")]
@@ -194,8 +186,22 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(topicPath, EntityType.Topic);
 
-            Assert.IsFalse(validation.IsValid(topicPath, EntityType.Topic));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
+        }
+
+        public void Should_return_2_error_messages_for_length_and_invalid_characters()
+        {
+            var settingsHolder = new SettingsHolder();
+            new DefaultConfigurationValues().Apply(settingsHolder);
+
+            var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongEntityName + "$$$", EntityType.Queue);
+
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(2));
         }
     }
 }

--- a/src/Tests/Addressing/Validation/When_using_entity_validation_v6_rules.cs
+++ b/src/Tests/Addressing/Validation/When_using_entity_validation_v6_rules.cs
@@ -18,24 +18,16 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
         const string illegalCharacterSubscriptionName = "6pwTRR34FFr/6YhPi-iDNfdSRLNDFIqZ97_Ky64w49r50n72vk";
 
         [Test]
-        public void Namespaces_allow_queues_with_paths_up_to_260_characters()
+        public void Namespaces_allow_queues_with_paths_up_to_260_characters_with_slashes_dashes_dots_and_underscores()
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(validEntityName, EntityType.Queue);
 
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Queue));
-        }
-
-        [Test]
-        public void Namespaces_allow_queues_with_slashes_dashes_dots_and_underscores()
-        {
-            var settingsHolder = new SettingsHolder();
-            new DefaultConfigurationValues().Apply(settingsHolder);
-            var validation = new EntityNameValidationV6Rules(settingsHolder);
-
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Queue));
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.That(validationResult.Errors, Is.Empty);
         }
 
         [Test]
@@ -45,8 +37,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongEntityName, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(tooLongEntityName, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -56,43 +50,39 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(illegalCharacterEntityName, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(illegalCharacterEntityName, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
-        [TestCase("/" + validEntityName)]
-        [TestCase(validEntityName + "/")]
+        [TestCase("/queue")]
+        [TestCase("queue/")]
         public void Namespaces_do_not_allows_queues_with_leading_or_trailing_slash(string entityPath)
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(entityPath, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(entityPath, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
-        public void Namespaces_allow_topics_with_paths_up_to_260_characters()
+        public void Namespaces_allow_topics_with_paths_up_to_260_characters_with_slashes_dashes_dots_and_underscores()
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(validEntityName, EntityType.Topic);
 
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Topic));
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.That(validationResult.Errors, Is.Empty);
         }
 
-        [Test]
-        public void Namespaces_allow_topics_with_slashes_dashes_dots_and_underscores()
-        {
-            var settingsHolder = new SettingsHolder();
-            new DefaultConfigurationValues().Apply(settingsHolder);
-
-            var validation = new EntityNameValidationV6Rules(settingsHolder);
-
-            Assert.IsTrue(validation.IsValid(validEntityName, EntityType.Queue));
-        }
 
         [Test]
         public void Namespaces_do_not_allow_topics_with_paths_over_260_characters()
@@ -101,8 +91,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongEntityName, EntityType.Topic);
 
-            Assert.IsFalse(validation.IsValid(tooLongEntityName, EntityType.Topic));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -112,42 +104,37 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(illegalCharacterEntityName, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(illegalCharacterEntityName, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
-        [TestCase("/" + validEntityName)]
-        [TestCase(validEntityName + "/")]
+        [TestCase("/topic")]
+        [TestCase("topic/")]
         public void Namespaces_do_not_allow_topics_with_leading_or_trailing_slash(string entityPath)
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(entityPath, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(entityPath, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
-        public void Namespaces_allow_subscriptions_with_paths_up_to_50_characters()
+        public void Namespaces_allow_subscriptions_with_paths_up_to_50_characters_with_dashes_dots_and_underscores()
         {
             var settingsHolder = new SettingsHolder();
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(validSubscriptionName, EntityType.Subscription);
 
-            Assert.IsTrue(validation.IsValid(validSubscriptionName, EntityType.Subscription));
-        }
-
-        [Test]
-        public void Namespaces_allow_subscriptions_with_dashes_dots_and_underscores()
-        {
-            var settingsHolder = new SettingsHolder();
-            new DefaultConfigurationValues().Apply(settingsHolder);
-
-            var validation = new EntityNameValidationV6Rules(settingsHolder);
-
-            Assert.IsTrue(validation.IsValid(validSubscriptionName, EntityType.Subscription));
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.That(validationResult.Errors, Is.Empty);
         }
 
         [Test]
@@ -157,8 +144,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongSubscriptionName, EntityType.Subscription);
 
-            Assert.IsFalse(validation.IsValid(tooLongSubscriptionName, EntityType.Subscription));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -168,8 +157,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(illegalCharacterSubscriptionName, EntityType.Subscription);
 
-            Assert.IsFalse(validation.IsValid(illegalCharacterSubscriptionName, EntityType.Subscription));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [TestCase("illegal/queue")]
@@ -182,8 +173,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(queuePath, EntityType.Queue);
 
-            Assert.IsFalse(validation.IsValid(queuePath, EntityType.Queue));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
         }
 
         [TestCase("illegal/topic")]
@@ -196,8 +189,22 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
             new DefaultConfigurationValues().Apply(settingsHolder);
 
             var validation = new EntityNameValidationV6Rules(settingsHolder);
+            var validationResult = validation.IsValid(topicPath, EntityType.Topic);
 
-            Assert.IsFalse(validation.IsValid(topicPath, EntityType.Topic));
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(1));
+        }
+
+        public void Should_return_2_error_messages_for_length_and_invalid_characters()
+        {
+            var settingsHolder = new SettingsHolder();
+            new DefaultConfigurationValues().Apply(settingsHolder);
+
+            var validation = new EntityNameValidationRules(settingsHolder);
+            var validationResult = validation.IsValid(tooLongEntityName + "$$$", EntityType.Queue);
+
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.That(validationResult.Errors.Count, Is.EqualTo(2));
         }
     }
 }

--- a/src/Tests/Configuration/When_configuring_validation.cs
+++ b/src/Tests/Configuration/When_configuring_validation.cs
@@ -31,7 +31,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 
         class MyValidationStrategy : IValidationStrategy
         {
-            public bool IsValid(string entityPath, EntityType entityType)
+            public ValidationResult IsValid(string entityPath, EntityType entityType)
             {
                 throw new NotImplementedException(); // not relevant for test
             }

--- a/src/Transport/Addressing/AddressingLogic.cs
+++ b/src/Transport/Addressing/AddressingLogic.cs
@@ -16,7 +16,8 @@
         public string Apply(string entityname, EntityType entityType)
         {
             var path = composition.GetEntityPath(entityname, entityType);
-            if (!validationStrategy.IsValid(path, entityType))
+            var validationResult = validationStrategy.IsValid(path, entityType);
+            if (!validationResult.IsValid)
             {
                 path = sanitizationStrategy.Sanitize(path, entityType);
             }

--- a/src/Transport/Addressing/Sanitization/Strategies/EndpointOrientedTopologySanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/EndpointOrientedTopologySanitization.cs
@@ -24,7 +24,8 @@
             var rgx = new Regex(@"[^a-zA-Z0-9\-\._]");
             entityPathOrName = rgx.Replace(entityPathOrName, "");
 
-            if (!validationStrategy.IsValid(entityPathOrName, entityType))
+            var validationResult = validationStrategy.IsValid(entityPathOrName, entityType);
+            if (!validationResult.IsValid)
             {
                 // turn long name into a guid
                 entityPathOrName = MD5DeterministicNameBuilder.Build(entityPathOrName);

--- a/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailingSanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailingSanitization.cs
@@ -23,7 +23,7 @@ namespace NServiceBus.AzureServiceBus.Addressing
             var validationResult = validationStrategy.IsValid(entityPathOrName, entityType);
             if (!validationResult.IsValid)
             {
-                throw new Exception($"Invalid {entityType} {pathOrName} `{entityPathOrName}` that cannot be used with Azure Service Bus. Errors: " + string.Join("; ", validationResult.Errors) 
+                throw new Exception($"Invalid {entityType} entity {pathOrName} `{entityPathOrName}` that cannot be used with Azure Service Bus. Errors: " + string.Join("; ", validationResult.Errors) 
                                     + Environment.NewLine + "Use `Sanitization().UseStrategy<ISanitizationStrategy>()` configuration API to register a custom sanitization strategy if required.");
             }
 

--- a/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailingSanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailingSanitization.cs
@@ -20,10 +20,11 @@ namespace NServiceBus.AzureServiceBus.Addressing
                 pathOrName = "name";
             }
 
-            if (!validationStrategy.IsValid(entityPathOrName, entityType))
+            var validationResult = validationStrategy.IsValid(entityPathOrName, entityType);
+            if (!validationResult.IsValid)
             {
-                throw new Exception($"Invalid {entityType} {pathOrName} `{entityPathOrName}` that cannot be used with Azure Service Bus. {entityType} {pathOrName} exceeds maximum allowed length or contains invalid characters. " + 
-                                    "Check for invalid characters, shorten the name, or use `Sanitization().UseStrategy<ISanitizationStrategy>()` configuration extension.");
+                throw new Exception($"Invalid {entityType} {pathOrName} `{entityPathOrName}` that cannot be used with Azure Service Bus. Errors: " + string.Join("; ", validationResult.Errors) 
+                                    + Environment.NewLine + "Use `Sanitization().UseStrategy<ISanitizationStrategy>()` configuration API to register a custom sanitization strategy if required.");
             }
 
             return entityPathOrName;

--- a/src/Transport/Addressing/Validation/IValidationStrategy.cs
+++ b/src/Transport/Addressing/Validation/IValidationStrategy.cs
@@ -2,6 +2,6 @@
 {
     public interface IValidationStrategy
     {
-        bool IsValid(string entityPath, EntityType entityType);
+        ValidationResult IsValid(string entityPath, EntityType entityType);
     }
 }

--- a/src/Transport/Addressing/Validation/ValidationResult.cs
+++ b/src/Transport/Addressing/Validation/ValidationResult.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.AzureServiceBus.Addressing
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+
+    public class ValidationResult
+    {
+        List<string> validationErrors = new List<string>();
+
+        public void AddError(string error)
+        {
+            validationErrors.Add(error);
+        }
+
+        public bool IsValid => !validationErrors.Any();
+
+        public ReadOnlyCollection<string> Errors => validationErrors.AsReadOnly();
+    }
+}

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Addressing\Individualization\Strategies\DiscriminatorBasedIndividualization.cs" />
     <Compile Include="Addressing\Sanitization\Strategies\EndpointOrientedTopologySanitization.cs" />
     <Compile Include="Addressing\Validation\Strategies\EntityNameValidationV6Rules.cs" />
+    <Compile Include="Addressing\Validation\ValidationResult.cs" />
     <Compile Include="CircuitBreakers\RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="Config\AzureServiceBusTransportInfrastructure.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusCompositionExtensionPoint.cs" />


### PR DESCRIPTION
Connect to #230
Connect to #228 

`IValidationStrategy` to return `ValidationResult` which in turn can provide if an entity path/name is valid or not, and list reasons why it was considered invalid. Previously, reason was not clear (issue #228).