### PR TITLE
Fix addressing logic with composed value

### DIFF
--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
@@ -39,21 +39,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
             Assert.AreEqual(sanitized, sanitization.Sanitize(endpointname, EntityType.Queue));
         }
 
-        [Test]
-        [TestCase("validendpoint@namespaceName", "validendpoint")]
-        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
-        [TestCase("endpoint$name@namespaceName", "endpointname")]
-        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpointname")]
-        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
-        {
-            var validation = new ValidationMock();
-            var sanitization = new EndpointOrientedTopologySanitization(validation);
-
-            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue);
-
-            Assert.AreEqual(expectedEndpointName, sanitizedResult);
-        }
-
         class ValidationMock : IValidationStrategy
         {
             public ValidationResult IsValid(string entityPath, EntityType entityType)

--- a/src/Tests/Addressing/When_apply_addressing_logic.cs
+++ b/src/Tests/Addressing/When_apply_addressing_logic.cs
@@ -1,0 +1,98 @@
+﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing
+{
+    using AzureServiceBus;
+    using AzureServiceBus.Addressing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_apply_addressing_logic
+    {
+        ValidationStrategy validationStrategy;
+        SanitizationStrategy sanitizationStrategy;
+        CompositionStrategy compositionStrategy;
+        AddressingLogic addressingLogic;
+
+        [SetUp]
+        public void SetUp()
+        {
+            validationStrategy = new ValidationStrategy();
+            sanitizationStrategy = new SanitizationStrategy();
+            compositionStrategy = new CompositionStrategy();
+            addressingLogic = new AddressingLogic(validationStrategy, sanitizationStrategy, compositionStrategy);
+        }
+
+        [Test]
+        [TestCase("validendpoint@namespaceName", "validendpoint")]
+        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
+        [TestCase("endpoint$name@namespaceName", "endpoint$name")]
+        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint$name")]
+        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
+        {
+            addressingLogic.Apply(endpointName, EntityType.Queue);
+
+            Assert.AreEqual(expectedEndpointName, sanitizationStrategy.ProvidedEntityPathOrName);
+        }
+
+        [Test]
+        [TestCase("validendpoint@namespaceName", "validendpoint")]
+        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
+        [TestCase("endpoint$name@namespaceName", "endpoint$name")]
+        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint$name")]
+        public void Only_queue_name_without_suffix_should_be_validated(string endpointName, string expectedEndpointName)
+        {
+            addressingLogic.Apply(endpointName, EntityType.Queue);
+
+            Assert.AreEqual(expectedEndpointName, validationStrategy.ProvidedEntityPath);
+        }
+
+        [Test]
+        [TestCase("validendpoint@namespaceName", "validendpoint")]
+        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
+        [TestCase("endpoint$name@namespaceName", "endpoint$name")]
+        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint$name")]
+        public void Only_queue_name_without_suffix_should_be_composed(string endpointName, string expectedEndpointName)
+        {
+            addressingLogic.Apply(endpointName, EntityType.Queue);
+
+            Assert.AreEqual(expectedEndpointName, compositionStrategy.ProvidedEntityName);
+        }
+
+        class ValidationStrategy : IValidationStrategy
+        {
+            public string ProvidedEntityPath { get; private set; }
+
+            public ValidationResult IsValid(string entityPath, EntityType entityType)
+            {
+                ProvidedEntityPath = entityPath;
+
+                var validationResult = new ValidationResult();
+                validationResult.AddError("fake error only for testing purpose");
+                return validationResult;
+            }
+        }
+
+        class SanitizationStrategy : ISanitizationStrategy
+        {
+            public string ProvidedEntityPathOrName { get; private set; }
+
+            public string Sanitize(string entityPathOrName, EntityType entityType)
+            {
+                ProvidedEntityPathOrName = entityPathOrName;
+                return entityPathOrName;
+            }
+        }
+
+        class CompositionStrategy : ICompositionStrategy
+        {
+            public string ProvidedEntityName { get; private set; }
+
+            public string GetEntityPath(string entityname, EntityType entityType)
+            {
+                ProvidedEntityName = entityname;
+
+                return entityname;
+            }
+        }
+    }
+}

--- a/src/Tests/Addressing/When_apply_addressing_logic.cs
+++ b/src/Tests/Addressing/When_apply_addressing_logic.cs
@@ -27,7 +27,7 @@
         [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
         [TestCase("endpoint$name@namespaceName", "endpoint$name")]
         [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint$name")]
-        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
+        public void Sanitization_strategy_should_receive_value_without_suffix(string endpointName, string expectedEndpointName)
         {
             addressingLogic.Apply(endpointName, EntityType.Queue);
 
@@ -39,7 +39,7 @@
         [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
         [TestCase("endpoint$name@namespaceName", "endpoint$name")]
         [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint$name")]
-        public void Only_queue_name_without_suffix_should_be_validated(string endpointName, string expectedEndpointName)
+        public void Validation_strategy_should_receive_value_without_suffix(string endpointName, string expectedEndpointName)
         {
             addressingLogic.Apply(endpointName, EntityType.Queue);
 
@@ -51,7 +51,7 @@
         [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
         [TestCase("endpoint$name@namespaceName", "endpoint$name")]
         [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpoint$name")]
-        public void Only_queue_name_without_suffix_should_be_composed(string endpointName, string expectedEndpointName)
+        public void Composition_strategy_should_receive_value_without_suffix(string endpointName, string expectedEndpointName)
         {
             addressingLogic.Apply(endpointName, EntityType.Queue);
 

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Addressing\Sanitization\When_sanitizing_entity_names_by_throwing_exception.cs" />
     <Compile Include="Addressing\Validation\When_using_entity_validation_v6_rules.cs" />
     <Compile Include="Addressing\Validation\When_using_entity_validation_rules.cs" />
+    <Compile Include="Addressing\When_apply_addressing_logic.cs" />
     <Compile Include="API\APIApprovals.cs" />
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiApprover.cs" />
     <Compile Include="App_Packages\ApiApprover.3.0.1\PublicApiGenerator.cs" />

--- a/src/Transport/Addressing/AddressingLogic.cs
+++ b/src/Transport/Addressing/AddressingLogic.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.AzureServiceBus.Addressing
 {
+    using Topology.MetaModel;
+
     class AddressingLogic
     {
         readonly IValidationStrategy validationStrategy;
@@ -15,6 +17,9 @@
 
         public string Apply(string entityname, EntityType entityType)
         {
+            var address = new EntityAddress(entityname);
+            entityname = address.Name;
+
             var path = composition.GetEntityPath(entityname, entityType);
             var validationResult = validationStrategy.IsValid(path, entityType);
             if (!validationResult.IsValid)

--- a/src/Transport/Addressing/Sanitization/Strategies/EndpointOrientedTopologySanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/EndpointOrientedTopologySanitization.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AzureServiceBus.Addressing
 {
     using System.Text.RegularExpressions;
-    using Topology.MetaModel;
 
     public class EndpointOrientedTopologySanitization : ISanitizationStrategy
     {
@@ -14,12 +13,6 @@
 
         public string Sanitize(string entityPathOrName, EntityType entityType)
         {
-            if (entityType == EntityType.Queue)
-            {
-                var address = new EntityAddress(entityPathOrName);
-                entityPathOrName = address.Name;
-            }
-
             // remove invalid characters
             var rgx = new Regex(@"[^a-zA-Z0-9\-\._]");
             entityPathOrName = rgx.Replace(entityPathOrName, "");


### PR DESCRIPTION
Connects to #235 

I solved the issue moving logic to remove possible suffix (`@something`) at the beginning of `Apply` method of `AddressingLogic`

Composition, sanitization and validation strategies have to work on entity path or name without suffix

@Particular/azure-service-bus-maintainers please review