### PR TITLE
[SPIKE] Do not perform validation in sanitization code

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -13,8 +13,8 @@
     }
     public class EndpointOrientedTopologySanitization : NServiceBus.AzureServiceBus.Addressing.ISanitizationStrategy
     {
-        public EndpointOrientedTopologySanitization(NServiceBus.AzureServiceBus.Addressing.IValidationStrategy validationStrategy) { }
-        public string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType) { }
+        public EndpointOrientedTopologySanitization() { }
+        public string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType, NServiceBus.AzureServiceBus.Addressing.ValidationResult validationResult) { }
     }
     public class EntityNameValidationRules : NServiceBus.AzureServiceBus.Addressing.IValidationStrategy
     {
@@ -62,7 +62,7 @@
     }
     public interface ISanitizationStrategy
     {
-        string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType);
+        string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType, NServiceBus.AzureServiceBus.Addressing.ValidationResult validationResult);
     }
     public interface IValidationStrategy
     {
@@ -88,15 +88,18 @@
     }
     public class ThrowOnFailingSanitization : NServiceBus.AzureServiceBus.Addressing.ISanitizationStrategy
     {
-        public ThrowOnFailingSanitization(NServiceBus.AzureServiceBus.Addressing.IValidationStrategy validationStrategy) { }
-        public string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType) { }
+        public ThrowOnFailingSanitization() { }
+        public string Sanitize(string entityPathOrName, NServiceBus.AzureServiceBus.EntityType entityType, NServiceBus.AzureServiceBus.Addressing.ValidationResult validationResult) { }
     }
     public class ValidationResult
     {
         public ValidationResult() { }
+        public bool CharactersAreValid { get; }
         public System.Collections.ObjectModel.ReadOnlyCollection<string> Errors { get; }
         public bool IsValid { get; }
-        public void AddError(string error) { }
+        public bool LengthIsValid { get; }
+        public void AddErrorForInvalidCharacter(string error) { }
+        public void AddErrorForInvalidLength(string error) { }
     }
 }
 namespace NServiceBus.AzureServiceBus

--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
@@ -42,21 +42,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
             Assert.AreEqual(sanitized, sanitization.Sanitize(endpointname, EntityType.Queue, validationResult));
         }
 
-        [Test]
-        [TestCase("validendpoint@namespaceName", "validendpoint")]
-        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
-        [TestCase("endpoint$name@namespaceName", "endpointname")]
-        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpointname")]
-        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
-        {
-            var validation = new ValidationMock();
-            var sanitization = new EndpointOrientedTopologySanitization();
-            var validationResult = validation.IsValid(endpointName, EntityType.Queue);
-            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue, validationResult);
-
-            Assert.AreEqual(expectedEndpointName, sanitizedResult);
-        }
-
         class ValidationMock : IValidationStrategy
         {
             public ValidationResult IsValid(string entityPath, EntityType entityType)

--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_adjusting_to_v6.cs
@@ -11,11 +11,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
         [Test]
         public void Valid_entity_names_are_returned_as_is()
         {
-            var validation = new ValidationMock();
-            var sanitization = new EndpointOrientedTopologySanitization(validation);
             var endpointname = "validendpoint";
+            var validationResult = new ValidationResult();
+            var sanitization = new EndpointOrientedTopologySanitization();
 
-            Assert.AreEqual(endpointname, sanitization.Sanitize(endpointname, EntityType.Queue));
+            Assert.AreEqual(endpointname, sanitization.Sanitize(endpointname, EntityType.Queue, validationResult));
         }
 
         [TestCase("endpoint$name", "endpointname")]
@@ -23,8 +23,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
         public void Invalid_entity_names_will_be_stripped_from_illegal_characters_for_version_6_of_transport(string endpointName, string sanitizedName)
         {
             var validation = new ValidationMock();
-            var sanitization = new EndpointOrientedTopologySanitization(validation);
-            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue);
+            var sanitization = new EndpointOrientedTopologySanitization();
+            var validationResult = validation.IsValid(endpointName, EntityType.Queue);
+            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue, validationResult);
+
             Assert.AreEqual(sanitizedName, sanitizedResult);
         }
 
@@ -32,11 +34,27 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
         public void Too_long_entity_names_will_be_turned_into_a_deterministic_guid()
         {
             var validation = new ValidationMock();
-            var sanitization = new EndpointOrientedTopologySanitization(validation);
+            var sanitization = new EndpointOrientedTopologySanitization();
             var endpointname = "endpointrw3pSH5zk5aQahkzt-E_U0aPf6KbXpWMZ7vnRFb_8_AAptt5Gp6YVt3rSnWwREBx3-BgnqNw9ol-Rn.wFRTFR1UzoCuHZM443EqKvSt-fzpMHPusH8rm4OQeiBCwBRVDA29rLC6RlOBZ4Xs_h415HW2lAdOPR6j4L-CaaVkfnDO2-9bjUTAGCDKs6jWYmgoCYMBx6x5PS_e0nRT05S_J78qd3SOKWTM-YjVj9fwQZ9xG2x02uCW-XIh0siprJp9c3jLE";
             var sanitized = MD5DeterministicNameBuilder.Build(endpointname);
+            var validationResult = validation.IsValid(endpointname, EntityType.Queue);
 
-            Assert.AreEqual(sanitized, sanitization.Sanitize(endpointname, EntityType.Queue));
+            Assert.AreEqual(sanitized, sanitization.Sanitize(endpointname, EntityType.Queue, validationResult));
+        }
+
+        [Test]
+        [TestCase("validendpoint@namespaceName", "validendpoint")]
+        [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "validendpoint")]
+        [TestCase("endpoint$name@namespaceName", "endpointname")]
+        [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey", "endpointname")]
+        public void Only_queue_name_without_suffix_should_be_sanitized(string endpointName, string expectedEndpointName)
+        {
+            var validation = new ValidationMock();
+            var sanitization = new EndpointOrientedTopologySanitization();
+            var validationResult = validation.IsValid(endpointName, EntityType.Queue);
+            var sanitizedResult = sanitization.Sanitize(endpointName, EntityType.Queue, validationResult);
+
+            Assert.AreEqual(expectedEndpointName, sanitizedResult);
         }
 
         class ValidationMock : IValidationStrategy
@@ -46,12 +64,12 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
                 var validationResult = new ValidationResult();
                 if (entityPath.Contains("$"))
                 {
-                    validationResult.AddError("contains `$` sign");
+                    validationResult.AddErrorForInvalidCharacter("contains `$` sign");
                 }
 
                 if (entityPath.Length > 260)
                 {
-                    validationResult.AddError("lenth is more than 260 characters");
+                    validationResult.AddErrorForInvalidLength("lenth is more than 260 characters");
                 }
 
                 return validationResult;

--- a/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_throwing_exception.cs
+++ b/src/Tests/Addressing/Sanitization/When_sanitizing_entity_names_by_throwing_exception.cs
@@ -12,21 +12,21 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
         [Test]
         public void Valid_entity_names_are_returned_as_is()
         {
-            var validation = new ValidationMock(shouldValidationPass:true);
-            var sanitization = new ThrowOnFailingSanitization(validation);
+            var sanitization = new ThrowOnFailingSanitization();
             var endpointname = "validendpoint";
+            var validationResult = new ValidationMock(shouldValidationPass: true).IsValid(endpointname, EntityType.Queue);
 
-            Assert.AreEqual(endpointname, sanitization.Sanitize(endpointname, EntityType.Queue));
+            Assert.AreEqual(endpointname, sanitization.Sanitize(endpointname, EntityType.Queue, validationResult));
         }
 
         [Test]
         public void Invalid_entity_names_result_in_exception()
         {
-            var validation = new ValidationMock(shouldValidationPass:false);
-            var sanitization = new ThrowOnFailingSanitization(validation);
+            var sanitization = new ThrowOnFailingSanitization();
             var endpointname = "invalidendpoint";
+            var validationResult = new ValidationMock(shouldValidationPass:false).IsValid(endpointname, EntityType.Queue);
 
-            Assert.Throws<Exception>(() => sanitization.Sanitize(endpointname, EntityType.Queue));
+            Assert.Throws<Exception>(() => sanitization.Sanitize(endpointname, EntityType.Queue, validationResult));
         }
 
         class ValidationMock : IValidationStrategy
@@ -44,7 +44,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Sanitization
 
                 if (!shouldValidationPass)
                 {
-                    validationResult.AddError("validation should fail");
+                    validationResult.AddErrorForInvalidLength("validation should fail");
                 }
 
                 return validationResult;

--- a/src/Tests/Addressing/Validation/When_using_validation_result.cs
+++ b/src/Tests/Addressing/Validation/When_using_validation_result.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Validation
+{
+    using AzureServiceBus.Addressing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_using_validation_result
+    {
+        [Test]
+        public void Should_be_valid_by_default()
+        {
+            var validationResult = new ValidationResult();
+
+            Assert.IsTrue(validationResult.IsValid);
+            Assert.IsTrue(validationResult.LengthIsValid);
+            Assert.IsTrue(validationResult.CharactersAreValid);
+        }
+
+        [Test]
+        public void Should_be_invalid_for_invalid_characters_error_message()
+        {
+            var validationResult = new ValidationResult();
+            validationResult.AddErrorForInvalidCharacter("invalid chars");
+
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.IsTrue(validationResult.LengthIsValid);
+            Assert.IsFalse(validationResult.CharactersAreValid);
+        }
+
+        [Test]
+        public void Should_be_invalid_for_invalid_length_error_message()
+        {
+            var validationResult = new ValidationResult();
+            validationResult.AddErrorForInvalidLength("invalid length");
+
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.IsFalse(validationResult.LengthIsValid);
+            Assert.IsTrue(validationResult.CharactersAreValid);
+        }
+
+        [Test]
+        public void Should_be_invalid_for_invalid_length_and_character_error_messages()
+        {
+            var validationResult = new ValidationResult();
+            validationResult.AddErrorForInvalidCharacter("invalid chars");
+            validationResult.AddErrorForInvalidLength("invalid length");
+
+            Assert.IsFalse(validationResult.IsValid);
+            Assert.IsFalse(validationResult.LengthIsValid);
+            Assert.IsFalse(validationResult.CharactersAreValid);
+        }
+
+    }
+}

--- a/src/Tests/Addressing/When_apply_addressing_logic.cs
+++ b/src/Tests/Addressing/When_apply_addressing_logic.cs
@@ -67,7 +67,7 @@
                 ProvidedEntityPath = entityPath;
 
                 var validationResult = new ValidationResult();
-                validationResult.AddError("fake error only for testing purpose");
+                validationResult.AddErrorForInvalidCharacter("fake error only for testing purpose");
                 return validationResult;
             }
         }
@@ -76,7 +76,7 @@
         {
             public string ProvidedEntityPathOrName { get; private set; }
 
-            public string Sanitize(string entityPathOrName, EntityType entityType)
+            public string Sanitize(string entityPathOrName, EntityType entityType, ValidationResult validationResult)
             {
                 ProvidedEntityPathOrName = entityPathOrName;
                 return entityPathOrName;

--- a/src/Tests/Configuration/When_configuring_sanitization.cs
+++ b/src/Tests/Configuration/When_configuring_sanitization.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 
         class MySanitizationStrategy : ISanitizationStrategy
         {
-            public string Sanitize(string entityPathOrName, EntityType entityType)
+            public string Sanitize(string entityPathOrName, EntityType entityType, ValidationResult validationResult)
             {
                 throw new NotImplementedException();//not relevant for test
             }

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Addressing\NamespacePartitioning\When_using_single_namespace_strategy.cs" />
     <Compile Include="Addressing\Sanitization\When_sanitizing_entity_names_by_adjusting_to_v6.cs" />
     <Compile Include="Addressing\Sanitization\When_sanitizing_entity_names_by_throwing_exception.cs" />
+    <Compile Include="Addressing\Validation\When_using_validation_result.cs" />
     <Compile Include="Addressing\Validation\When_using_entity_validation_v6_rules.cs" />
     <Compile Include="Addressing\Validation\When_using_entity_validation_rules.cs" />
     <Compile Include="Addressing\When_apply_addressing_logic.cs" />

--- a/src/Transport/Addressing/AddressingLogic.cs
+++ b/src/Transport/Addressing/AddressingLogic.cs
@@ -24,7 +24,7 @@
             var validationResult = validationStrategy.IsValid(path, entityType);
             if (!validationResult.IsValid)
             {
-                path = sanitizationStrategy.Sanitize(path, entityType);
+                path = sanitizationStrategy.Sanitize(path, entityType, validationResult);
             }
             return path;
         }

--- a/src/Transport/Addressing/Sanitization/ISanitizationStrategy.cs
+++ b/src/Transport/Addressing/Sanitization/ISanitizationStrategy.cs
@@ -2,6 +2,6 @@
 {
     public interface ISanitizationStrategy
     {
-        string Sanitize(string entityPathOrName, EntityType entityType);
+        string Sanitize(string entityPathOrName, EntityType entityType, ValidationResult validationResult);
     }
 }

--- a/src/Transport/Addressing/Sanitization/Strategies/EndpointOrientedTopologySanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/EndpointOrientedTopologySanitization.cs
@@ -4,21 +4,13 @@
 
     public class EndpointOrientedTopologySanitization : ISanitizationStrategy
     {
-        IValidationStrategy validationStrategy;
-
-        public EndpointOrientedTopologySanitization(IValidationStrategy validationStrategy)
-        {
-            this.validationStrategy = validationStrategy;
-        }
-
-        public string Sanitize(string entityPathOrName, EntityType entityType)
+        public string Sanitize(string entityPathOrName, EntityType entityType, ValidationResult validationResult)
         {
             // remove invalid characters
             var rgx = new Regex(@"[^a-zA-Z0-9\-\._]");
             entityPathOrName = rgx.Replace(entityPathOrName, "");
 
-            var validationResult = validationStrategy.IsValid(entityPathOrName, entityType);
-            if (!validationResult.IsValid)
+            if (!validationResult.LengthIsValid)
             {
                 // turn long name into a guid
                 entityPathOrName = MD5DeterministicNameBuilder.Build(entityPathOrName);

--- a/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailingSanitization.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailingSanitization.cs
@@ -4,14 +4,7 @@ namespace NServiceBus.AzureServiceBus.Addressing
 
     public class ThrowOnFailingSanitization : ISanitizationStrategy
     {
-        IValidationStrategy validationStrategy;
-
-        public ThrowOnFailingSanitization(IValidationStrategy validationStrategy)
-        {
-            this.validationStrategy = validationStrategy;
-        }
-
-        public string Sanitize(string entityPathOrName, EntityType entityType)
+        public string Sanitize(string entityPathOrName, EntityType entityType, ValidationResult validationResult)
         {
             var pathOrName = "path";
 
@@ -20,7 +13,6 @@ namespace NServiceBus.AzureServiceBus.Addressing
                 pathOrName = "name";
             }
 
-            var validationResult = validationStrategy.IsValid(entityPathOrName, entityType);
             if (!validationResult.IsValid)
             {
                 throw new Exception($"Invalid {entityType} entity {pathOrName} `{entityPathOrName}` that cannot be used with Azure Service Bus. Errors: " + string.Join("; ", validationResult.Errors) 

--- a/src/Transport/Addressing/Validation/Strategies/EntityNameValidationRules.cs
+++ b/src/Transport/Addressing/Validation/Strategies/EntityNameValidationRules.cs
@@ -25,34 +25,34 @@ namespace NServiceBus.AzureServiceBus.Addressing
             {
                 case EntityType.Queue:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.QueuePathMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.QueuePathMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.QueuePathMaximumLength)));
 
                     if (!topicAndQueueNameRegex.IsMatch(entityPath))
-                        validationResult.AddError(FormatCharactersError(entityType, topicAndQueueNameRegex));
+                        validationResult.AddErrorForInvalidCharacter(FormatCharactersError(entityType, topicAndQueueNameRegex));
                     break;
 
                 case EntityType.Topic:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.TopicPathMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.TopicPathMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.TopicPathMaximumLength)));
 
                     if (!topicAndQueueNameRegex.IsMatch(entityPath))
-                        validationResult.AddError(FormatCharactersError(entityType, topicAndQueueNameRegex));
+                        validationResult.AddErrorForInvalidCharacter(FormatCharactersError(entityType, topicAndQueueNameRegex));
                     break;
 
                 case EntityType.Subscription:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.SubscriptionPathMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.SubscriptionPathMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.SubscriptionPathMaximumLength)));
 
                     if (!subscriptionAndRuleNameRegex.IsMatch(entityPath))
-                        validationResult.AddError(FormatCharactersError(entityType, subscriptionAndRuleNameRegex));
+                        validationResult.AddErrorForInvalidCharacter(FormatCharactersError(entityType, subscriptionAndRuleNameRegex));
                     break;
 
                 case EntityType.Rule:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength)));
 
                     if (!subscriptionAndRuleNameRegex.IsMatch(entityPath))
-                        validationResult.AddError(FormatCharactersError(entityType, subscriptionAndRuleNameRegex));
+                        validationResult.AddErrorForInvalidCharacter(FormatCharactersError(entityType, subscriptionAndRuleNameRegex));
                     break;
 
 

--- a/src/Transport/Addressing/Validation/Strategies/EntityNameValidationV6Rules.cs
+++ b/src/Transport/Addressing/Validation/Strategies/EntityNameValidationV6Rules.cs
@@ -24,22 +24,22 @@
             {
                 case EntityType.Queue:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.QueuePathMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.QueuePathMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.QueuePathMaximumLength)));
                     break;
 
                 case EntityType.Topic:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.TopicPathMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.TopicPathMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.TopicPathMaximumLength)));
                     break;
 
                 case EntityType.Subscription:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.SubscriptionPathMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.SubscriptionPathMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.SubscriptionPathMaximumLength)));
                     break;
 
                 case EntityType.Rule:
                     if (entityPath.Length > settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength))
-                        validationResult.AddError(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength)));
+                        validationResult.AddErrorForInvalidLength(FormatLengthError(entityType, settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Validation.RuleNameMaximumLength)));
                     break;
 
                 default:
@@ -47,7 +47,7 @@
             }
 
             if (!v6PathRegex.IsMatch(entityPath))
-                validationResult.AddError(FormatCharactersError(entityType, v6PathRegex));
+                validationResult.AddErrorForInvalidCharacter(FormatCharactersError(entityType, v6PathRegex));
 
             return validationResult;
         }

--- a/src/Transport/Addressing/Validation/ValidationResult.cs
+++ b/src/Transport/Addressing/Validation/ValidationResult.cs
@@ -2,19 +2,29 @@
 {
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Linq;
 
     public class ValidationResult
     {
         List<string> validationErrors = new List<string>();
 
-        public void AddError(string error)
+        public ReadOnlyCollection<string> Errors => validationErrors.AsReadOnly();
+
+        public bool LengthIsValid { get; private set; } = true;
+
+        public bool CharactersAreValid { get; private set; } = true;
+
+        public bool IsValid => CharactersAreValid && LengthIsValid;
+
+        public void AddErrorForInvalidCharacter(string error)
         {
             validationErrors.Add(error);
+            CharactersAreValid = false;
         }
 
-        public bool IsValid => !validationErrors.Any();
-
-        public ReadOnlyCollection<string> Errors => validationErrors.AsReadOnly();
+        public void AddErrorForInvalidLength(string error)
+        {
+            validationErrors.Add(error);
+            LengthIsValid = false;
+        }
     }
 }


### PR DESCRIPTION
Connect to #252 

The issue what @melkio brought up in #252 (Check validation during sanitization is useless) should be not about if check is useless since, but about unnecessary duplicated validation.

This spike is to demonstrate how we can remove double validation and remove dependency on validation strategy when creating a sanitization strategy by flowing in validation result..

@Particular/azure-service-bus-maintainers what do you think? Should we proceed this route? 

**UPDATE**:
Alternative spike: #257 (sanitization and validation combined into `ISanitizationStrategy`)