### PR TITLE
Ensuring backward compat after namespace naming introduction

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -291,9 +291,11 @@
     <Compile Include="OldTests\When_sending_a_message_with_no_correlation_id.cs" />
     <Compile Include="OldTests\When_sending_an_oversized_message_without_a_transaction_scope.cs" />
     <Compile Include="OldTests\When_sending_an_oversized_message_from_a_transaction_scope.cs" />
+    <Compile Include="Routing\AzureServiceBusTransportConfigContext.cs" />
     <Compile Include="Routing\When_scaling_out_senders_that_uses_callbacks.cs" />
     <Compile Include="Routing\When_sending_to_specific_namespace.cs" />
     <Compile Include="Routing\When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs" />
+    <Compile Include="Routing\When_using_single_namespace.cs" />
     <Compile Include="Serialization\When_using_default_serialization.cs" />
     <Compile Include="SetupAcceptanceTests.cs" />
     <Compile Include="TransportEncoding\When_receiving_a_message_with_unknown_transport_encoding.cs" />

--- a/src/AcceptanceTests/Routing/AzureServiceBusTransportConfigContext.cs
+++ b/src/AcceptanceTests/Routing/AzureServiceBusTransportConfigContext.cs
@@ -1,0 +1,13 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System;
+
+    public class AzureServiceBusTransportConfigContext
+    {
+        public Action<string, TransportExtensions< AzureServiceBusTransport>> Callback
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/AcceptanceTests/Routing/When_using_single_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_using_single_namespace.cs
@@ -43,34 +43,9 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
 
             Assert.IsTrue(context.RequestReceived, "context.RequestReceived");
             Assert.IsTrue(context.ReplyReceived, "context.ReplyReceived");
-            Assert.IsTrue(context.ReplyToContainsNamespace, "context.ReplyToContainsNamespace");
+            Assert.IsTrue(context.ReplyToContainsNamespaceName, "context.ReplyToContainsNamespaceName");
         }
-
-
-        [Test]
-        public async Task Should_not_append_namespace_name_to_reply_address_when_using_connection_strings()
-        {
-            var runSettings = new RunSettings();
-            runSettings.TestExecutionTimeout = TimeSpan.FromMinutes(1);
-
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<SourceEndpoint>(b =>
-                {
-                    b.When(async (bus, c) =>
-                    {
-                        var sendOptions = new SendOptions();
-                        sendOptions.SetDestination("usingsinglenamespace.targetendpoint");
-                        await bus.Send(new MyRequest(), sendOptions);
-                    });
-                })
-                .WithEndpoint<TargetEndpoint>()
-                .Done(c => c.ReplyReceived)
-                .Run(runSettings);
-
-            Assert.IsTrue(context.RequestReceived, "context.RequestReceived");
-            Assert.IsTrue(context.ReplyReceived, "context.ReplyReceived");
-            Assert.IsFalse(context.ReplyToContainsNamespace, "context.ReplyToContainsNamespace");
-        }
+      
 
         public class SourceEndpoint : EndpointConfigurationBuilder
         {
@@ -106,7 +81,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                 public async Task Handle(MyRequest message, IMessageHandlerContext context)
                 {
                     Context.RequestReceived = true;
-                    Context.ReplyToContainsNamespace = context.ReplyToAddress.Contains("@");
+                    Context.ReplyToContainsNamespaceName = context.ReplyToAddress.Contains("@default");
                     await context.Reply(new MyResponse());
                 }
             }
@@ -124,7 +99,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
         {
             public bool RequestReceived { get; set; }
             public bool ReplyReceived { get; set; }
-            public bool ReplyToContainsNamespace { get; set; }
+            public bool ReplyToContainsNamespaceName { get; set; }
         }
     }
 }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -494,6 +494,7 @@ namespace NServiceBus.AzureServiceBus.Topology.MetaModel
         public bool Equals(NServiceBus.AzureServiceBus.Topology.MetaModel.ConnectionString other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public static bool IsConnectionString(string value) { }
         public override string ToString() { }
         public static bool TryParse(string value, out NServiceBus.AzureServiceBus.Topology.MetaModel.ConnectionString connectionString) { }
     }

--- a/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
+++ b/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
@@ -229,7 +229,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
 
             var brokeredMessage = converter.Convert(batchedOperation, new RoutingOptions());
 
-            Assert.IsTrue(brokeredMessage.ReplyTo == "MappedMyQueue");
+            Assert.IsTrue(brokeredMessage.ReplyTo == "MyQueue"); // the mapper should be ignored, need to respect user's setting
         }
 
         [Test]

--- a/src/Transport/Connectivity/NamespaceManagerCreator.cs
+++ b/src/Transport/Connectivity/NamespaceManagerCreator.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AzureServiceBus
     using System;
     using Microsoft.ServiceBus;
     using Settings;
+    using Topology.MetaModel;
 
     class NamespaceManagerCreator : ICreateNamespaceManagers
     {
@@ -24,11 +25,15 @@ namespace NServiceBus.AzureServiceBus
             }
         }
 
-        public INamespaceManager Create(string namespaceName)
+        public INamespaceManager Create(string @namespace)
         {
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-            var connectionString = namespacesDefinition.GetConnectionString(namespaceName);
-            
+            var connectionString = @namespace;
+            if (!ConnectionString.IsConnectionString(connectionString))
+            {
+                connectionString = namespacesDefinition.GetConnectionString(connectionString);
+            }
+
             NamespaceManager manager;
             if (settingsFactory != null)
             {

--- a/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
@@ -66,7 +66,7 @@ namespace NServiceBus.AzureServiceBus
         {
             if (outgoingMessage.Headers.ContainsKey(Headers.ReplyToAddress))
             {
-                var replyTo = mapper.Map(outgoingMessage.Headers[Headers.ReplyToAddress]);
+                var replyTo = new EntityAddress(outgoingMessage.Headers[Headers.ReplyToAddress]);
 
                 if (!replyTo.HasSuffix)
                 {
@@ -89,7 +89,6 @@ namespace NServiceBus.AzureServiceBus
                             replyTo = new EntityAddress(replyTo.Name, selected.Name);
                         }
                     }
-
                 }
 
                 outgoingMessage.Headers[Headers.ReplyToAddress] = replyTo;

--- a/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
@@ -67,24 +67,6 @@ namespace NServiceBus.AzureServiceBus
             if (outgoingMessage.Headers.ContainsKey(Headers.ReplyToAddress))
             {
                 var replyTo = mapper.Map(outgoingMessage.Headers[Headers.ReplyToAddress]);
-
-                // ensure that the reply to address contains namespace info in case the message is sent to destination only namespace.
-                if (!replyTo.HasSuffix)
-                {
-                    var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-                    var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
-                    var selected = namespaces.FirstOrDefault(ns => ns.Name == defaultName);
-                    if (selected == null)
-                    {
-                        selected = namespaces.FirstOrDefault(ns => ns.Purpose == NamespacePurpose.Partitioning);
-                    }
-
-                    if (selected != null)
-                    {
-                        replyTo = mapper.Map(new EntityAddress(replyTo.Name, selected.Name));
-                    }
-                }
-
                 outgoingMessage.Headers[Headers.ReplyToAddress] = replyTo;
                 brokeredMessage.ReplyTo = replyTo;
             }

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -71,6 +71,12 @@
             }
         }
 
+        public static bool IsConnectionString(string value)
+        {
+            ConnectionString sampler;
+            return TryParse(value, out sampler);
+        }
+
         public static implicit operator string(ConnectionString connectionString)
         {
             return connectionString.ToString();

--- a/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
+++ b/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
@@ -14,23 +14,6 @@ namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 
         public EntityAddress Map(EntityAddress value)
         {
-            if (!value.HasSuffix)
-            {
-                var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-                var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
-                var selected = namespaces.FirstOrDefault(ns => ns.Name == defaultName);
-                if (selected == null)
-                {
-                    selected = namespaces.FirstOrDefault(ns => ns.Purpose == NamespacePurpose.Partitioning);
-                }
-
-                if (selected != null)
-                {
-                    return new EntityAddress(value.Name, selected.Name);
-                }
-
-            }
-
             return new EntityAddress(value);
         }
     }

--- a/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
+++ b/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
@@ -1,17 +1,7 @@
 namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 {
-    using System.Linq;
-    using Settings;
-
     class PassThroughNamespaceNameToConnectionStringMapper : ICanMapNamespaceNameToConnectionString
     {
-        ReadOnlySettings settings;
-
-        public PassThroughNamespaceNameToConnectionStringMapper(ReadOnlySettings settings)
-        {
-            this.settings = settings;
-        }
-
         public EntityAddress Map(EntityAddress value)
         {
             return new EntityAddress(value);

--- a/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
+++ b/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
@@ -1,9 +1,36 @@
 namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 {
+    using System.Linq;
+    using Settings;
+
     class PassThroughNamespaceNameToConnectionStringMapper : ICanMapNamespaceNameToConnectionString
     {
+        ReadOnlySettings settings;
+
+        public PassThroughNamespaceNameToConnectionStringMapper(ReadOnlySettings settings)
+        {
+            this.settings = settings;
+        }
+
         public EntityAddress Map(EntityAddress value)
         {
+            if (!value.HasSuffix)
+            {
+                var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
+                var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
+                var selected = namespaces.FirstOrDefault(ns => ns.Name == defaultName);
+                if (selected == null)
+                {
+                    selected = namespaces.FirstOrDefault(ns => ns.Purpose == NamespacePurpose.Partitioning);
+                }
+
+                if (selected != null)
+                {
+                    return new EntityAddress(value.Name, selected.Name);
+                }
+
+            }
+
             return new EntityAddress(value);
         }
     }


### PR DESCRIPTION
Found a few backward compatibility issues when not using namespace names