### PR TITLE
Namespace manager creation config options

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -568,6 +568,13 @@ namespace NServiceBus
         public NServiceBus.AzureServiceBusMessagingFactoriesSettings NumberOfMessagingFactoriesPerNamespace(int number) { }
         public NServiceBus.AzureServiceBusMessagingFactoriesSettings RetryPolicy(Microsoft.ServiceBus.RetryPolicy retryPolicy) { }
     }
+    public class AzureServiceBusNamespaceManagersSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+    {
+        public AzureServiceBusNamespaceManagersSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.AzureServiceBusNamespaceManagersSettings NamespaceManagerSettingsFactory(System.Func<string, Microsoft.ServiceBus.NamespaceManagerSettings> factory) { }
+        public NServiceBus.AzureServiceBusNamespaceManagersSettings RetryPolicy(Microsoft.ServiceBus.RetryPolicy retryPolicy) { }
+        public NServiceBus.AzureServiceBusNamespaceManagersSettings TokenProvider(System.Func<string, Microsoft.ServiceBus.TokenProvider> factory) { }
+    }
     public class AzureServiceBusNamespacePartitioningSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public AzureServiceBusNamespacePartitioningSettings(NServiceBus.Settings.SettingsHolder settings) { }
@@ -676,6 +683,7 @@ namespace NServiceBus
         public static NServiceBus.AzureServiceBusMessageReceiverSettings MessageReceivers(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusMessageSenderSettings MessageSenders(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusMessagingFactoriesSettings MessagingFactories(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusNamespaceManagersSettings NamespaceManagers(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusNamespacePartitioningSettings NamespacePartitioning(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusNamespaceRoutingSettings NamespaceRouting(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void NumberOfClientsPerEntity(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int number) { }

--- a/src/Tests/Configuration/When_configuring_connectivity.cs
+++ b/src/Tests/Configuration/When_configuring_connectivity.cs
@@ -1,9 +1,6 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 {
-    using System;
-    using Microsoft.ServiceBus.Messaging;
     using AzureServiceBus;
-    using NServiceBus.Configuration.AdvanceExtensibility;
     using Settings;
     using NUnit.Framework;
 
@@ -11,30 +8,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
     [Category("AzureServiceBus")]
     public class When_configuring_connectivity
     {
-        [Test]
-        public void Should_be_able_to_set_messaging_factory_settings_factory_method()
-        {
-            var settings = new SettingsHolder();
-            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
-            Func<string, MessagingFactorySettings> registeredFactory = s => new MessagingFactorySettings();
-
-            var connectivitySettings = extensions.MessagingFactories().MessagingFactorySettingsFactory(registeredFactory);
-
-            Assert.AreEqual(registeredFactory, connectivitySettings.GetSettings().Get<Func<string, MessagingFactorySettings>>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.MessagingFactorySettingsFactory));
-        }
-
-        [Test]
-        public void Should_be_able_to_set_number_of_messaging_factories_per_namespace()
-        {
-            var settings = new SettingsHolder();
-            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
-            var connectivitySettings = extensions.MessagingFactories().NumberOfMessagingFactoriesPerNamespace(4);
-
-            Assert.AreEqual(4, connectivitySettings.GetSettings().Get<int>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.NumberOfMessagingFactoriesPerNamespace));
-        }
-
         [Test]
         public void Should_be_able_to_set_number_of_clients_per_entity()
         {

--- a/src/Tests/Configuration/When_configuring_messaging_factories.cs
+++ b/src/Tests/Configuration/When_configuring_messaging_factories.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
     using System;
     using Microsoft.ServiceBus;
     using AzureServiceBus;
+    using Microsoft.ServiceBus.Messaging;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using Settings;
     using NUnit.Framework;
@@ -11,6 +12,30 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
     [Category("AzureServiceBus")]
     public class When_configuring_messaging_factories
     {
+        [Test]
+        public void Should_be_able_to_set_messaging_factory_settings_factory_method()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Func<string, MessagingFactorySettings> registeredFactory = s => new MessagingFactorySettings();
+
+            var connectivitySettings = extensions.MessagingFactories().MessagingFactorySettingsFactory(registeredFactory);
+
+            Assert.AreEqual(registeredFactory, connectivitySettings.GetSettings().Get<Func<string, MessagingFactorySettings>>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.MessagingFactorySettingsFactory));
+        }
+
+        [Test]
+        public void Should_be_able_to_set_number_of_messaging_factories_per_namespace()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            var connectivitySettings = extensions.MessagingFactories().NumberOfMessagingFactoriesPerNamespace(4);
+
+            Assert.AreEqual(4, connectivitySettings.GetSettings().Get<int>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.NumberOfMessagingFactoriesPerNamespace));
+        }
+
         [Test]
         public void Should_be_able_to_set_retrypolicy()
         {

--- a/src/Tests/Configuration/When_configuring_namespace_managers.cs
+++ b/src/Tests/Configuration/When_configuring_namespace_managers.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
+{
+    using System;
+    using AzureServiceBus;
+    using Microsoft.ServiceBus;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_configuring_namespace_managers
+    {
+        [Test]
+        public void Should_be_able_to_set_namespace_managers_settings_factory_method()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Func<string, NamespaceManagerSettings> registeredFactory = s => new NamespaceManagerSettings();
+
+            var connectivitySettings = extensions.NamespaceManagers().NamespaceManagerSettingsFactory(registeredFactory);
+
+            Assert.AreEqual(registeredFactory, connectivitySettings.GetSettings().Get<Func<string, NamespaceManagerSettings>>(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.NamespaceManagerSettingsFactory));
+        }
+
+        [Test]
+        public void Should_be_able_to_set_retrypolicy()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            var connectivitySettings = extensions.NamespaceManagers().RetryPolicy(RetryPolicy.NoRetry);
+
+            Assert.IsInstanceOf<NoRetry>(connectivitySettings.GetSettings().Get<RetryPolicy>(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.RetryPolicy));
+        }
+
+        [Test]
+        public void Should_be_able_to_set_token_provider_factory_method()
+        {
+            var settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+
+            Func<string, TokenProvider> registeredFactory = s => null;//illegal token provider, but don't want to provide credential info
+
+            var connectivitySettings = extensions.NamespaceManagers().TokenProvider(registeredFactory);
+
+            Assert.AreEqual(registeredFactory, connectivitySettings.GetSettings().Get<Func<string, TokenProvider>>(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.TokenProviderFactory));
+        }
+
+    }
+}

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Configuration\When_configuring_message_receivers.cs" />
     <Compile Include="Configuration\When_configuring_message_senders.cs" />
     <Compile Include="Configuration\When_configuring_messaging_factories.cs" />
+    <Compile Include="Configuration\When_configuring_namespace_managers.cs" />
     <Compile Include="Configuration\When_configuring_namespace_partitioning.cs" />
     <Compile Include="Configuration\When_configuring_publishers.cs" />
     <Compile Include="Configuration\When_configuring_queues.cs" />

--- a/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
+++ b/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
@@ -93,6 +93,13 @@ namespace NServiceBus
             return new AzureServiceBusMessagingFactoriesSettings(transportExtensions.GetSettings());
         }
 
+        /// <summary>
+        /// Access to namespace managers configuration.
+        /// </summary>
+        public static AzureServiceBusNamespaceManagersSettings NamespaceManagers(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        {
+            return new AzureServiceBusNamespaceManagersSettings(transportExtensions.GetSettings());
+        }
 
         /// <summary>
         /// Force usage of namespace names instead of raw connection strings.

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceManagersSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceManagersSettings.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using AzureServiceBus;
+    using Configuration.AdvanceExtensibility;
+    using Microsoft.ServiceBus;
+    using Settings;
+
+    public class AzureServiceBusNamespaceManagersSettings : ExposeSettings
+    {
+        SettingsHolder settings;
+
+        public AzureServiceBusNamespaceManagersSettings(SettingsHolder settings)
+            : base(settings)
+        {
+            this.settings = settings;
+        }
+
+        /// <summary>
+        /// Customize <see cref="NamespaceManager"/> creation.
+        /// </summary>
+        public AzureServiceBusNamespaceManagersSettings NamespaceManagerSettingsFactory(Func<string, NamespaceManagerSettings> factory)
+        {
+            settings.Set(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.NamespaceManagerSettingsFactory, factory);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Customize the token provider.
+        /// </summary>
+        public AzureServiceBusNamespaceManagersSettings TokenProvider(Func<string, TokenProvider> factory)
+        {
+            settings.Set(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.TokenProviderFactory, factory);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Retry policy configured on Namespace Manager level.
+        /// <remarks>Default is RetryPolicy.Default</remarks>
+        /// </summary>
+        public AzureServiceBusNamespaceManagersSettings RetryPolicy(RetryPolicy retryPolicy)
+        {
+            settings.Set(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.RetryPolicy, retryPolicy);
+
+            return this;
+        }
+        
+    }
+}

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -149,6 +149,13 @@ namespace NServiceBus.AzureServiceBus
                 public const string MessagingFactorySettingsFactory = "AzureServiceBus.Connectivity.MessagingFactories.MessagingFactorySettingsFactory";
                 public const string BatchFlushInterval = "AzureServiceBus.Connectivity.MessagingFactories.BatchFlushInterval";
             }
+
+            public static class NamespaceManagers
+            {
+                public const string RetryPolicy = "AzureServiceBus.Connectivity.NamespaceManagers.RetryPolicy";
+                public const string NamespaceManagerSettingsFactory = "AzureServiceBus.Connectivity.NamespaceManagers.NamespaceManagerSettingsFactory";
+                public const string TokenProviderFactory = "AzureServiceBus.Connectivity.NamespaceManagers.TokenProviderFactory";
+            }
         }
 
         internal static class Core

--- a/src/Transport/Connectivity/NamespaceManagerCreator.cs
+++ b/src/Transport/Connectivity/NamespaceManagerCreator.cs
@@ -1,23 +1,62 @@
 namespace NServiceBus.AzureServiceBus
 {
+    using System;
     using Microsoft.ServiceBus;
     using Settings;
 
     class NamespaceManagerCreator : ICreateNamespaceManagers
     {
         ReadOnlySettings settings;
+        Func<string, NamespaceManagerSettings> settingsFactory;
+        Func<string, TokenProvider> tokenProviderFactory;
 
         public NamespaceManagerCreator(ReadOnlySettings settings)
         {
             this.settings = settings;
+
+            if (settings.HasExplicitValue(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.NamespaceManagerSettingsFactory))
+            {
+                settingsFactory = settings.Get<Func<string, NamespaceManagerSettings>>(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.NamespaceManagerSettingsFactory);
+            }
+            else if (settings.HasExplicitValue(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.TokenProviderFactory))
+            {
+                tokenProviderFactory = settings.Get<Func<string, TokenProvider>>(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.TokenProviderFactory);
+            }
         }
 
         public INamespaceManager Create(string namespaceName)
         {
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
             var connectionString = namespacesDefinition.GetConnectionString(namespaceName);
+            
+            NamespaceManager manager;
+            if (settingsFactory != null)
+            {
+                var s = settingsFactory(connectionString);
+                var builder = new ServiceBusConnectionStringBuilder(connectionString);
+                manager = new NamespaceManager(builder.GetAbsoluteRuntimeEndpoints(), s);
+            }
+            else {
+                if (tokenProviderFactory != null)
+                {
+                    var s = new NamespaceManagerSettings()
+                    {
+                        TokenProvider = tokenProviderFactory(connectionString)
+                    };
+                    var builder = new ServiceBusConnectionStringBuilder(connectionString);
+                    manager = new NamespaceManager(builder.GetAbsoluteRuntimeEndpoints(), s);
+                }
+                else
+                {
+                    manager = NamespaceManager.CreateFromConnectionString(connectionString);
+                }
 
-            return new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(connectionString));
+                if (settings.HasExplicitValue(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.RetryPolicy))
+                {
+                    manager.Settings.RetryPolicy = settings.Get<RetryPolicy>(WellKnownConfigurationKeys.Connectivity.NamespaceManagers.RetryPolicy);
+                }
+            }
+            return new NamespaceManagerAdapter(manager);
         }
     }
 }

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Config\ExtensionPoints\AzureServiceBusForwardingTopologySettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusHierarchyCompositionSettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusIndividualizationExtensionPoint.cs" />
+    <Compile Include="Config\ExtensionPoints\AzureServiceBusNamespaceManagersSettings.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusNamespaceRoutingSettings.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusSanitizationExtensionPoint.cs" />
     <Compile Include="Config\TransactionModeSettingsExtensions.cs" />


### PR DESCRIPTION
extended the configuration options of namespace managers to allow the specification of token providers

relates to #276 