### PR TITLE
Use QueueBindings provided by TransportResourcesCreator (ICreateQueues)

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -354,7 +354,7 @@ namespace NServiceBus.AzureServiceBus
     {
         NServiceBus.AzureServiceBus.TopologySection DeterminePublishDestination(System.Type eventType);
         NServiceBus.AzureServiceBus.TopologySection DetermineReceiveResources(string inputQueue);
-        NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToCreate();
+        NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToCreate(NServiceBus.Transports.QueueBindings queueBindings);
         NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToSubscribeTo(System.Type eventType);
         NServiceBus.AzureServiceBus.TopologySection DetermineResourcesToUnsubscribeFrom(System.Type eventtype);
         NServiceBus.AzureServiceBus.TopologySection DetermineSendDestination(string destination);

--- a/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
+++ b/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
@@ -473,7 +473,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             // create the topologySectionManager
             var topologyCreator = (ICreateTopology)container.Resolve(typeof(TopologyCreator));
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate());
+            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate(new QueueBindings()));
             return sectionManager;
         }
     }

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -66,7 +66,7 @@
                 return new TopologySection();
             }
 
-            public TopologySection DetermineResourcesToCreate()
+            public TopologySection DetermineResourcesToCreate(QueueBindings queueBindings)
             {
                 return new TopologySection();
             }

--- a/src/Tests/Seam/When_receiving_messages.cs
+++ b/src/Tests/Seam/When_receiving_messages.cs
@@ -87,7 +87,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             // create the topologySectionManager
             var topologyCreator = (ICreateTopology)container.Resolve(typeof(TopologyCreator));
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate());
+            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate(new QueueBindings()));
             return sectionManager;
         }
     }

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -125,7 +125,7 @@
             throw new NotImplementedException();
         }
 
-        public TopologySection DetermineResourcesToCreate()
+        public TopologySection DetermineResourcesToCreate(QueueBindings queueBindings)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     using System;
     using System.Linq;
     using AzureServiceBus;
+    using NServiceBus.Transports;
     using Routing;
     using Settings;
     using NUnit.Framework;
@@ -70,7 +71,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(), "Was expected to fail: " + reasonToFail);
+            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings()), "Was expected to fail: " + reasonToFail);
         }
 
 
@@ -100,7 +101,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
 
-            var definition = sectionManager.DetermineResourcesToCreate();
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
             return definition;
         }
     }

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     using System;
     using System.Linq;
     using AzureServiceBus;
+    using NServiceBus.Transports;
     using Routing;
     using Settings;
     using NUnit.Framework;
@@ -31,7 +32,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            var definition = sectionManager.DetermineResourcesToCreate();
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
             // ReSharper disable once RedundantArgumentDefaultValue
             var namespaceInfo = new RuntimeNamespaceInfo(Name, Connectionstring);
@@ -55,7 +56,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            var definition = sectionManager.DetermineResourcesToCreate();
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
             Assert.AreEqual(1, definition.Entities.Count(ei => ei.Path == "sales" && ei.Type == EntityType.Queue && ei.Namespace.ConnectionString == Connectionstring));
         }
@@ -78,7 +79,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(), "Was expected to fail: " + reasonToFail);
+            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings()), "Was expected to fail: " + reasonToFail);
         }
 
         [Test]
@@ -98,7 +99,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            var definition = sectionManager.DetermineResourcesToCreate();
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
             var result = definition.Entities.Where(ei => ei.Type == EntityType.Topic && ei.Namespace.ConnectionString == Connectionstring && ei.Path.StartsWith("bundle-"));
 
@@ -124,7 +125,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            sectionManager.DetermineResourcesToCreate();
+            sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent));
 
@@ -149,7 +150,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            sectionManager.DetermineResourcesToCreate();
+            sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent));
 
@@ -172,7 +173,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            sectionManager.DetermineResourcesToCreate();
+            sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent));
 

--- a/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
     using Receiving;
     using TestUtils;
     using AzureServiceBus;
+    using NServiceBus.Transports;
     using Routing;
     using Settings;
     using NUnit.Framework;
@@ -525,7 +526,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var topologyCreator = (ICreateTopology) container.Resolve(typeof(TopologyCreator));
 
             var sectionManager = container.Resolve<ITopologySectionManager>();
-            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate());
+            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate(new QueueBindings()));
             return sectionManager;
         }
     }

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.AzureServiceBus
 
             if (pushSettings.PurgeOnStartup)
             {
-                throw new InvalidOperationException("Azure Service Bus transport doesn't support PurgeOnStartup behaviour");
+                throw new InvalidOperationException("Azure Service Bus transport doesn't support PurgeOnStartup behavior");
             }
 
             inputQueue = pushSettings.InputQueue;

--- a/src/Transport/Seam/TransportResourcesCreator.cs
+++ b/src/Transport/Seam/TransportResourcesCreator.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.AzureServiceBus
         {
             if (resourcesCreated) return;
 
-            var receiveResources = sections.DetermineResourcesToCreate();
+            var receiveResources = sections.DetermineResourcesToCreate(queueBindings);
             await topologyCreator.Create(receiveResources).ConfigureAwait(false);
 
             resourcesCreated = true;

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -1,12 +1,13 @@
 ﻿namespace NServiceBus.AzureServiceBus
 {
     using System;
+    using Transports;
 
     public interface ITopologySectionManager
     {
 
         TopologySection DetermineReceiveResources(string inputQueue);
-        TopologySection DetermineResourcesToCreate();
+        TopologySection DetermineResourcesToCreate(QueueBindings queueBindings);
 
         TopologySection DeterminePublishDestination(Type eventType);
         TopologySection DetermineSendDestination(string destination);


### PR DESCRIPTION
Connect to https://github.com/Particular/NServiceBus.AzureServiceBus/issues/283

- Changes `TransportResourcesCreator` and `ITopologySectionManager`s (`EndpointOrientedTopologySectionManager` and `ForwardingTopologySectionManager`) to use `QueueBindings` passed in by core into the  `TransportResourceCreator` (`IQueueCreator`)
- Eliminates the need to cheque if `QueueBindings` are defined in the settings

Remaining question - how the `identity` (string) passed into the `IQueueCreator` should be used? Should we resolve it as part of this issue or open a new one?

@Particular/azure-service-bus-maintainers please review
@danielmarbach I sense we might need a help from the core to understand the remaining issue. Thanks.