### PR TITLE
EntityAddress improvements

### DIFF
--- a/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
+++ b/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
@@ -4,11 +4,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
     using System.IO;
     using System.Linq;
     using System.Text;
-    using Microsoft.ServiceBus.Messaging;
     using AzureServiceBus;
     using AzureServiceBus.Topology.MetaModel;
-    using Settings;
+    using Microsoft.ServiceBus.Messaging;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     [Category("AzureServiceBus")]
@@ -20,7 +20,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var brokeredMessage = new BrokeredMessage
             {
@@ -38,7 +38,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var brokeredMessage = new BrokeredMessage();
             brokeredMessage.Properties.Add("my-test-prop", "myvalue");
@@ -56,7 +56,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 
             var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MappedMyQueue"));
 
-            var brokeredMessage = new BrokeredMessage(new byte[] { })
+            var brokeredMessage = new BrokeredMessage(new byte[]
+            {
+            })
             {
                 ReplyTo = "MyQueue"
             };
@@ -75,7 +77,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 
             var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("OtherQueue", "MappedOtherQueue"));
 
-            var brokeredMessage = new BrokeredMessage(new byte[] { })
+            var brokeredMessage = new BrokeredMessage(new byte[]
+            {
+            })
             {
                 ReplyTo = "MyQueue"
             };
@@ -93,9 +97,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("",""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
-            var brokeredMessage = new BrokeredMessage(new byte[] {})
+            var brokeredMessage = new BrokeredMessage(new byte[]
+            {
+            })
             {
                 CorrelationId = "SomeId"
             };
@@ -113,10 +119,12 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var timespan = TimeSpan.FromHours(1);
-            var brokeredMessage = new BrokeredMessage(new byte[] { })
+            var brokeredMessage = new BrokeredMessage(new byte[]
+            {
+            })
             {
                 TimeToLive = timespan
             };
@@ -133,7 +141,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
         {
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var bytes = Encoding.UTF8.GetBytes("Whatever");
             var brokeredMessage = new BrokeredMessage(bytes);
@@ -154,7 +162,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.BrokeredMessageBodyType(SupportedBrokeredMessageBodyTypes.Stream);
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream);
@@ -179,7 +187,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var bytes = Encoding.UTF8.GetBytes("Whatever");
             var brokeredMessage = new BrokeredMessage(bytes);
@@ -199,7 +207,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var brokeredMessage = new BrokeredMessage("non-default-type");
 
@@ -212,7 +220,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var brokeredMessage = new BrokeredMessage("non-default-type");
             brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding] = "unknown";
@@ -230,7 +238,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             var brokeredMessage = new BrokeredMessage(bytes);
             brokeredMessage.Properties[BrokeredMessageHeaders.TransportEncoding] = "wcf/byte-array";
 
-            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("", ""));
+            var converter = new DefaultBrokeredMessagesToIncomingMessagesConverter(settings, new FakeMapper("MyQueue", "MyQueue"));
 
             var incomingMessageDetails = converter.Convert(brokeredMessage);
 
@@ -239,13 +247,10 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 
         class FakeMapper : ICanMapConnectionStringToNamespaceName
         {
-            string input;
-            string output;
-
             public FakeMapper(string input, string output)
             {
-                this.input = input;
-                this.output = output;
+                this.input = new EntityAddress(input);
+                this.output = new EntityAddress(output);
             }
 
             public EntityAddress Map(EntityAddress value)
@@ -257,6 +262,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 
                 return output;
             }
+
+            EntityAddress input;
+            EntityAddress output;
         }
     }
 }

--- a/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
+++ b/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
@@ -298,13 +298,13 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
 
             var brokeredMessage = converter.Convert(batchedOperation, new RoutingOptions());
 
-            Assert.That(brokeredMessage.Properties[BrokeredMessageHeaders.EstimatedMessageSize], Is.GreaterThan(0)); 
+            Assert.That(brokeredMessage.Properties[BrokeredMessageHeaders.EstimatedMessageSize], Is.GreaterThan(0));
         }
 
         class FakeMapper : ICanMapNamespaceNameToConnectionString
         {
-            string input;
-            string output;
+            EntityAddress input;
+            EntityAddress output;
 
             public FakeMapper()
                 : this ("input", "output")
@@ -313,8 +313,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
 
             public FakeMapper(string input, string output)
             {
-                this.input = input;
-                this.output = output;
+                this.input = new EntityAddress(input);
+                this.output = new EntityAddress(output);
             }
 
             public EntityAddress Map(EntityAddress value)

--- a/src/Tests/Topology/MetaModel/When_mapping_connection_string_to_namespace_name.cs
+++ b/src/Tests/Topology/MetaModel/When_mapping_connection_string_to_namespace_name.cs
@@ -30,24 +30,24 @@
         [TestCase("queuename@notAConnectionString")]
         public void Should_return_same_value_if_does_not_contain_connection_string(string value)
         {
-            var mappedValue = mapper.Map(value);
+            var mappedValue = mapper.Map(new EntityAddress(value));
 
-            StringAssert.AreEqualIgnoringCase(value, mappedValue);
+            StringAssert.AreEqualIgnoringCase(value, mappedValue.ToString());
         }
 
         [Test]
         public void Should_throw_if_connection_string_has_not_been_mapped()
         {
-            var exception = Assert.Throws<InvalidOperationException>(() => mapper.Map("queuename@Endpoint=sb://myNamespaceName.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret"));
+            var exception = Assert.Throws<InvalidOperationException>(() => mapper.Map(new EntityAddress("queuename@Endpoint=sb://myNamespaceName.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret")));
             StringAssert.Contains("myNamespaceName", exception.Message);
         }
 
         [Test]
         public void Should_return_mapped_value_with_right_namespace_name()
         {
-            var mappedValue = mapper.Map("queuename@Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret");
+            var mappedValue = mapper.Map(new EntityAddress("queuename@Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret"));
 
-            StringAssert.AreEqualIgnoringCase("queuename@namespace1", mappedValue);
+            StringAssert.AreEqualIgnoringCase("queuename@namespace1", mappedValue.ToString());
         }
     }
 }

--- a/src/Tests/Topology/MetaModel/When_mapping_namespace_name_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_mapping_namespace_name_to_connection_string.cs
@@ -28,24 +28,24 @@
         [Test]
         public void Should_return_same_value_if_does_not_contain_namespace_name()
         {
-            var mappedValue = mapper.Map("queuename");
+            var mappedValue = mapper.Map(new EntityAddress("queuename"));
 
-            StringAssert.AreEqualIgnoringCase("queuename", mappedValue);
+            StringAssert.AreEqualIgnoringCase("queuename", mappedValue.ToString());
         }
 
         [Test]
         public void Should_throw_if_namespace_name_has_not_been_mapped()
         {
-            var exception = Assert.Throws<InvalidOperationException>(() => mapper.Map("queuename@myNamespaceName"));
+            var exception = Assert.Throws<InvalidOperationException>(() => mapper.Map(new EntityAddress("queuename@myNamespaceName")));
             StringAssert.Contains("myNamespaceName", exception.Message);
         }
 
         [Test]
         public void Should_return_mapped_value_with_right_connection_string()
         {
-            var mappedValue = mapper.Map("queuename@namespace1");
+            var mappedValue = mapper.Map(new EntityAddress("queuename@namespace1"));
 
-            StringAssert.AreEqualIgnoringCase("queuename@Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", mappedValue);
+            StringAssert.AreEqualIgnoringCase("queuename@Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", mappedValue.ToString());
         }
     }
 }

--- a/src/Transport/Addressing/AddressingLogic.cs
+++ b/src/Transport/Addressing/AddressingLogic.cs
@@ -16,11 +16,11 @@
         public EntityAddress Apply(string value, EntityType entityType)
         {
             var address = new EntityAddress(value);
-           
+
             var path = composition.GetEntityPath(address.Name, entityType);
             path = sanitizationStrategy.Sanitize(path, entityType);
             return new EntityAddress(path, address.Suffix);
         }
     }
-    
+
 }

--- a/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
+++ b/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
@@ -67,7 +67,7 @@ namespace NServiceBus.AzureServiceBus
 
             if (!string.IsNullOrWhiteSpace(replyToHeaderValue))
             {
-                headers[Headers.ReplyToAddress] = mapper.Map(replyToHeaderValue);
+                headers[Headers.ReplyToAddress] = mapper.Map(new EntityAddress(replyToHeaderValue)).ToString();
             }
 
             if (!string.IsNullOrWhiteSpace(brokeredMessage.CorrelationId) && !headers.ContainsKey(Headers.CorrelationId))

--- a/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
@@ -91,8 +91,9 @@ namespace NServiceBus.AzureServiceBus
                     }
                 }
 
-                outgoingMessage.Headers[Headers.ReplyToAddress] = replyTo;
-                brokeredMessage.ReplyTo = replyTo;
+                var replyToAsString = replyTo.ToString();
+                outgoingMessage.Headers[Headers.ReplyToAddress] = replyToAsString;
+                brokeredMessage.ReplyTo = replyToAsString;
             }
         }
 

--- a/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
+++ b/src/Transport/Topology/MetaModel/PassThroughNamespaceNameToConnectionStringMapper.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.AzureServiceBus.Topology.MetaModel
     {
         public EntityAddress Map(EntityAddress value)
         {
-            return new EntityAddress(value);
+            return value;
         }
     }
 }


### PR DESCRIPTION
* Removed the implicit conversation operators since to lead to unnecessary string allocations. In on one of the tests it even created a side effect because a string was compared to `EntityAddress` with `!=` and the type was boxed to a string and then the string equality was used. Call `ToString` when you need it.
* Removed computed properties and only parse it once and cache the results
* Made it a struct. Currently, it is 24 bytes which is slightly larger than the recommended struct size of 16 bytes but since this type is used during runtime this tradeoff is OK (confirmed with @Scooletz )

While doing this I think I found a bug in the mapping code. Will raise another PR.