### PR TITLE
AsyncAutoResetEvent supports now cancellation

### DIFF
--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -21,6 +21,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
         [Test]
         public async Task Can_receive_messages_with_prefetch_fast()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
@@ -84,7 +85,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             var sw = new Stopwatch();
             sw.Start();
             notifier.Start();
-            await completed.WaitOne();
+            await completed.WaitAsync(cts.Token).IgnoreCancellation();
             sw.Stop();
 
             await notifier.Stop();

--- a/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
+++ b/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
@@ -19,6 +19,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
         [Test]
         public async Task AutoRenewTimout_will_extend_lock_for_processing_to_finish()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
@@ -75,7 +76,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             var sw = new Stopwatch();
             sw.Start();
             notifier.Start();
-            await completed.WaitOne();
+            await completed.WaitAsync(cts.Token).IgnoreCancellation();
             await Task.Delay(TimeSpan.FromSeconds(10));
             sw.Stop();
 

--- a/src/Tests/Receiving/When_receiving_brokeredmessages_from_queues.cs
+++ b/src/Tests/Receiving/When_receiving_brokeredmessages_from_queues.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
     using TestUtils;
@@ -15,6 +16,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
         [Test]
         public async Task Can_receive_a_brokered_message()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
@@ -62,13 +64,13 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                 return TaskEx.Completed;
             }, options);
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
             Assert.IsNull(ex);
 
-            //cleanup 
+            //cleanup
             await receiver.CloseAsync();
             await namespaceManager.DeleteQueue("myqueue");
         }

--- a/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
+++ b/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
     using TestUtils;
@@ -89,6 +90,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
         [Test]
         public async Task Can_receive_an_incoming_message()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             // default settings
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var namespacesDefinition = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
@@ -142,7 +144,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
 
             notifier.Start();
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);

--- a/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
+++ b/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
     using Tests;
@@ -23,6 +24,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
         [Test]
         public async Task Should_dispatch_message_in_receive_context()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             // cleanup
             await TestUtility.Delete("sales", "myqueue");
 
@@ -83,7 +85,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var sender = await senderFactory.Create("sales", null, "namespaceName");
             await sender.Send(new BrokeredMessage {MessageId = "id-incoming"});
 
-            await completed.WaitOne();
+            await completed.WaitAsync(cts.Token).IgnoreCancellation();
 
             await Task.Delay(TimeSpan.FromSeconds(3)); //the OnCompleted callbacks are called right before the batch is completed, so give it a second to do that
 
@@ -101,6 +103,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
         [Test]
         public async Task Will_not_rollback_dispatch_message_in_receive_context_when_exception_occurs_on_completion_receive_only_mode()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales", "myqueue");
 
@@ -167,7 +171,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var sender = await senderFactory.Create("sales", null, "namespaceName");
             await sender.Send(new BrokeredMessage());
 
-            await errored.WaitOne();
+            await errored.WaitAsync(cts.Token).IgnoreCancellation();
 
             await Task.Delay(TimeSpan.FromSeconds(3)); //the OnCompleted callbacks are called right before the batch is completed, so give it a second to do that
 
@@ -190,6 +194,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
         [Test]
         public async Task Should_dispatch_message_in_receive_context_via_receive_queue()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales", "myqueue");
 
@@ -255,7 +261,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
                 MessageId = "id-init"
             });
 
-            await completed.WaitOne();
+            await completed.WaitAsync(cts.Token).IgnoreCancellation();
 
             await Task.Delay(TimeSpan.FromSeconds(5)); //the OnCompleted callbacks are called right before the batch is completed, so give it a second to do that
 
@@ -273,6 +279,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
         [Test]
         public async Task Should_rollback_dispatch_message_in_receive_context_via_receive_queue_when_exception_occurs_on_completion()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             // cleanup
             await TestUtility.Delete("sales", "myqueue");
 
@@ -343,7 +350,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var sender = await senderFactory.Create("sales", null, "namespaceName");
             await sender.Send(new BrokeredMessage());
 
-            await errored.WaitOne();
+            await errored.WaitAsync(cts.Token).IgnoreCancellation();
 
             await Task.Delay(TimeSpan.FromSeconds(3)); //the OnCompleted callbacks are called right before the batch is completed, so give it a second to do that
 
@@ -365,6 +372,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
         [Test]
         public async Task Should_retry_after_rollback_in_less_then_thirty_seconds_when_using_via_queue()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales", "myqueue");
 
@@ -445,7 +454,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var sender = await senderFactory.Create("sales", null, "namespaceName");
             await sender.Send(new BrokeredMessage());
 
-            await retried.WaitOne();
+            await retried.WaitAsync(cts.Token).IgnoreCancellation();
 
             await Task.Delay(TimeSpan.FromSeconds(3)); //the OnCompleted callbacks are called right before the batch is completed, so give it a second to do that
 

--- a/src/Tests/Seam/When_receiving_messages.cs
+++ b/src/Tests/Seam/When_receiving_messages.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
     using Tests;
@@ -19,6 +20,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
         [Test]
         public async Task Pushes_received_message_into_pipeline()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             await TestUtility.Delete("sales");
 
             var settings = new SettingsHolder();
@@ -61,7 +64,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var sender = await senderFactory.Create("sales", null, "namespaceName");
             await sender.Send(new BrokeredMessage());
 
-            await completed.WaitOne(); // Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await completed.WaitAsync(cts.Token).IgnoreCancellation(); // Task.WhenAny(completed.WaitOne(), error.WaitOne());
 
             // validate
             Assert.IsTrue(received);

--- a/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
     using Tests;
@@ -19,6 +20,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Receives_incoming_messages_from_endpoint_queue()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -61,7 +64,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
@@ -73,6 +76,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Calls_completion_callbacks_before_completing()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -125,7 +130,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token));
 
             // validate
             Assert.IsTrue(completeCalled);
@@ -138,6 +143,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Does_not_call_completion_when_error_during_processing()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -188,7 +195,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
@@ -200,6 +207,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Calls_on_error_when_error_during_processing()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -250,7 +259,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
@@ -262,6 +271,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Calls_on_error_when_error_during_completion()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -313,7 +324,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
@@ -326,6 +337,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Completes_incoming_message_when_successfully_received()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -368,7 +381,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
@@ -387,6 +400,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Aborts_incoming_message_when_error_during_processing()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -427,7 +442,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);
@@ -446,6 +461,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
         [Test]
         public async Task Aborts_incoming_message_when_error_during_completion()
         {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             // cleanup
             await TestUtility.Delete("sales");
 
@@ -494,7 +511,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
             var sender = await senderFactory.Create("sales", null, "namespace");
             await sender.Send(new BrokeredMessage());
 
-            await Task.WhenAny(completed.WaitOne(), error.WaitOne());
+            await Task.WhenAny(completed.WaitAsync(cts.Token).IgnoreCancellation(), error.WaitAsync(cts.Token).IgnoreCancellation());
 
             // validate
             Assert.IsTrue(received);

--- a/src/Transport/Utils/TaskEx.cs
+++ b/src/Transport/Utils/TaskEx.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AzureServiceBus
 {
+    using System;
     using System.Threading.Tasks;
 
     static class TaskEx
@@ -9,6 +10,17 @@
 
         public static void Ignore(this Task task)
         {
+        }
+
+        public static async Task IgnoreCancellation(this Task task)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Refactored the AsyncAutoResetEvent to support cancellation. All tests that are using that event will now automatically cancel after 60 seconds when the event was not received. Will make sure the tests don't hang indefinitely.

I didn't bother to cleanup more. Arguably those tests could be structured better. The timeout could be controlled in a single place but I think this is outside of the scope of this improvement. 

@Particular/azure-service-bus-maintainers please review and merge