### PR TITLE
Send via scope approach

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -109,7 +109,6 @@ namespace NServiceBus.AzureServiceBus
     public class BrokeredMessageReceiveContext : NServiceBus.AzureServiceBus.ReceiveContext
     {
         public BrokeredMessageReceiveContext(Microsoft.ServiceBus.Messaging.BrokeredMessage message, NServiceBus.AzureServiceBus.EntityInfo entity, Microsoft.ServiceBus.Messaging.ReceiveMode receiveMode) { }
-        public bool CompletionCanBeBatched { get; set; }
         public NServiceBus.AzureServiceBus.EntityInfo Entity { get; }
         public Microsoft.ServiceBus.Messaging.BrokeredMessage IncomingBrokeredMessage { get; }
         public Microsoft.ServiceBus.Messaging.ReceiveMode ReceiveMode { get; }
@@ -263,7 +262,7 @@ namespace NServiceBus.AzureServiceBus
     public interface IMessageSender : NServiceBus.AzureServiceBus.IClientEntity
     {
         System.Threading.Tasks.Task Send(Microsoft.ServiceBus.Messaging.BrokeredMessage message);
-        System.Threading.Tasks.Task SendBatch(System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> messages, System.Transactions.CommittableTransaction transaction);
+        System.Threading.Tasks.Task SendBatch(System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> messages);
     }
     public interface IMessagingFactory : NServiceBus.AzureServiceBus.IClientEntity
     {

--- a/src/Tests/Connectivity/When_creating_message_senders.cs
+++ b/src/Tests/Connectivity/When_creating_message_senders.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System.Transactions;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using TestUtils;
@@ -120,7 +119,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
                 throw new NotImplementedException();
             }
 
-            public Task SendBatch(IEnumerable<BrokeredMessage> messages, CommittableTransaction transaction)
+            public Task SendBatch(IEnumerable<BrokeredMessage> messages)
             {
                 throw new NotImplementedException();
             }

--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -62,7 +62,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                     batch.Add(new BrokeredMessage(Encoding.UTF8.GetBytes("Whatever" + counter)));
                     counter++;
                 }
-                tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch, null), s => s.SendBatch(batch.Select(x => x.Clone()), null), TimeSpan.FromSeconds(10), 5));
+                tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch), s => s.SendBatch(batch.Select(x => x.Clone())), TimeSpan.FromSeconds(10), 5));
             }
             await Task.WhenAll(tasks);
             var faulted = tasks.Count(task => task.IsFaulted);

--- a/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
+++ b/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
@@ -121,7 +121,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
                     counter++;
                 }
                 var sender = entityLifecycleManager.Get("myqueue", null, "namespace");
-                tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch, null), s => s.SendBatch(batch.Select(x => x.Clone()), null), TimeSpan.FromSeconds(10), 5));
+                tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch), s => s.SendBatch(batch.Select(x => x.Clone())), TimeSpan.FromSeconds(10), 5));
             }
             await Task.WhenAll(tasks);
 

--- a/src/Tests/Sending/When_retrying_on_throttle.cs
+++ b/src/Tests/Sending/When_retrying_on_throttle.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Threading.Tasks;
-    using System.Transactions;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using AzureServiceBus;
@@ -106,7 +105,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
                 return TaskEx.Completed;
             }
 
-            public Task SendBatch(IEnumerable<BrokeredMessage> messages, CommittableTransaction transaction)
+            public Task SendBatch(IEnumerable<BrokeredMessage> messages)
             {
                 IsInvoked = true;
                 InvocationCount++;

--- a/src/Transport/Connectivity/IMessageSender.cs
+++ b/src/Transport/Connectivity/IMessageSender.cs
@@ -2,13 +2,12 @@ namespace NServiceBus.AzureServiceBus
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System.Transactions;
     using Microsoft.ServiceBus.Messaging;
 
     public interface IMessageSender : IClientEntity
     {
         Task Send(BrokeredMessage message);
 
-        Task SendBatch(IEnumerable<BrokeredMessage> messages, CommittableTransaction transaction);
+        Task SendBatch(IEnumerable<BrokeredMessage> messages);
     }
 }

--- a/src/Transport/Connectivity/MessageSenderAdapter.cs
+++ b/src/Transport/Connectivity/MessageSenderAdapter.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.AzureServiceBus
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System.Transactions;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
 
@@ -28,24 +27,9 @@ namespace NServiceBus.AzureServiceBus
           return sender.SendAsync(message);
         }
 
-        public async Task SendBatch(IEnumerable<BrokeredMessage> messages, CommittableTransaction transaction)
+        public Task SendBatch(IEnumerable<BrokeredMessage> messages)
         {
-            try
-            {
-                // as Transaction.Current is static, there is a high risk of transferring the
-                // state into other threads that use Transaction.Current
-                Transaction.Current = transaction;
-                // the AsyncResult created inside the ASB sdk copies over the references from Transaction.Current
-                var task = sender.SendBatchAsync(messages);
-                // now we can get rid of it again
-                Transaction.Current = null;
-                // and await the result
-                await task.ConfigureAwait(false);
-            }
-            finally
-            {
-                Transaction.Current = null;
-            }
+            return sender.SendBatchAsync(messages);
         }
 
         public Task CloseAsync()

--- a/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
+++ b/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
@@ -52,8 +52,13 @@ namespace NServiceBus.AzureServiceBus
         }
     }
 
-    class TransactionScopeUnitOfWork : Feature
+    class TransactionScopeSuppress : Feature
     {
+        public TransactionScopeSuppress()
+        {
+            EnableByDefault();
+        }
+
         protected override void Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent(b => new TransactionScopeSuppressBehavior(), DependencyLifecycle.InstancePerCall);

--- a/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
+++ b/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.AzureServiceBus
     {
         public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
-            if (Transaction.Current != null) // todo: should be checked using send with atomic receive
+            if (Transaction.Current != null)
             {
                 using (var tx = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
                 {
@@ -40,6 +40,10 @@ namespace NServiceBus.AzureServiceBus
 
                     tx.Complete();
                 }
+            }
+            else
+            {
+                await next().ConfigureAwait(false);
             }
         }
 

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -176,7 +176,7 @@ namespace NServiceBus.AzureServiceBus
 
             var context = new BrokeredMessageReceiveContext(message, entity, internalReceiver.Mode);
 
-            var transportTransactionMode = settings.Get<TransportTransactionMode>();
+            var transportTransactionMode = settings.HasExplicitValue<TransportTransactionMode>() ? settings.Get<TransportTransactionMode>() : TransportTransactionMode.SendsAtomicWithReceive;
             var wrapInScope = transportTransactionMode == TransportTransactionMode.SendsAtomicWithReceive;
             var completionCanBeBatched = !wrapInScope;
             try

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -175,27 +175,24 @@ namespace NServiceBus.AzureServiceBus
             }
 
             var context = new BrokeredMessageReceiveContext(message, entity, internalReceiver.Mode);
-
+            // todo: better would be to test against required transaction mode
+            var wrapInScope = settings.Get<bool>(WellKnownConfigurationKeys.Connectivity.SendViaReceiveQueue);
+            var completionCanBeBatched = !wrapInScope;
             try
             {
-                // create a transaction to which the message sender can attach
-                // any outbound sends that travel via the transfer queue
-                var tx = new CommittableTransaction(new TransactionOptions
+                var scope = wrapInScope ? new TransactionScope(TransactionScopeOption.RequiresNew, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }, TransactionScopeAsyncFlowOption.Enabled) : null;
                 {
-                    IsolationLevel = IsolationLevel.Serializable
-                });
-                context.Transaction = tx;
+                    using (scope)
+                    {
+                        await incomingCallback(incomingMessage, context).ConfigureAwait(false);
 
-                await incomingCallback(incomingMessage, context).ConfigureAwait(false);
-
-                await HandleCompletion(message, context).ConfigureAwait(false);
+                        await HandleCompletion(message, context, completionCanBeBatched).ConfigureAwait(false);
+                        scope?.Complete();
+                    }
+                }
             }
             catch (Exception exception)
             {
-                // rollback any outbound message that are pending on the transfer queue
-                context.Transaction.Rollback(exception);
-                context.Transaction.Dispose();
-                context.Transaction = null;
                 // and go into recovery mode so that no new messages are added to the transfer queue
                 context.Recovering = true;
 
@@ -213,7 +210,7 @@ namespace NServiceBus.AzureServiceBus
                     }
                     else 
                     {
-                        await HandleCompletion(message, context).ConfigureAwait(false);
+                        await HandleCompletion(message, context, completionCanBeBatched).ConfigureAwait(false);
                     }
                 }
                 catch (Exception onErrorException)
@@ -223,52 +220,23 @@ namespace NServiceBus.AzureServiceBus
             }
         }
 
-        async Task HandleCompletion(BrokeredMessage message, BrokeredMessageReceiveContext context)
+        async Task HandleCompletion(BrokeredMessage message, BrokeredMessageReceiveContext context, bool canbeBatched)
         {
             if (context.CancellationToken.IsCancellationRequested)
             {
                 await AbandonAsyncOnCancellation(message).ConfigureAwait(false);
-                context.Transaction?.Rollback();
-                context.Transaction?.Dispose();
-                context.Transaction = null;
             }
             else
             {
                 if (receiveMode == ReceiveMode.PeekLock)
                 {
-                    if (context.CompletionCanBeBatched)
+                    if (canbeBatched)
                     {
                         locksTokensToComplete.Push(message.LockToken);
-                        context.Transaction?.Dispose();
-                        context.Transaction = null;
                     }
                     else
                     {
-                        //using scope seems to undo pending operations, which would result in no messages sent out when committing the transaction
-                        //using (var scope = new TransactionScope(context.Transaction, TransactionScopeAsyncFlowOption.Enabled))
-                        //{
-                        try
-                        {
-                            // as Transaction.Current is static, there is a high risk of transferring the
-                            // state into other threads that use Transaction.Current
-                            Transaction.Current = context.Transaction;
-                            // the AsyncResult created inside the ASB sdk copies over the references from Transaction.Current
-                            var t = context.IncomingBrokeredMessage.CompleteAsync();
-                            // now we can get rid of it again
-                            Transaction.Current = null;
-                            // and await the result
-                            await t.ConfigureAwait(false);
-                            // then we can commit the tx
-                            context.Transaction.Commit();
-                        }
-                        finally
-                        {
-                            Transaction.Current = null;
-                            context.Transaction = null;
-                        }
-                        
-                        //    scope.Complete();
-                        //}
+                        await context.IncomingBrokeredMessage.CompleteAsync().ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -175,8 +175,9 @@ namespace NServiceBus.AzureServiceBus
             }
 
             var context = new BrokeredMessageReceiveContext(message, entity, internalReceiver.Mode);
-            // todo: better would be to test against required transaction mode
-            var wrapInScope = settings.Get<bool>(WellKnownConfigurationKeys.Connectivity.SendViaReceiveQueue);
+
+            var transportTransactionMode = settings.Get<TransportTransactionMode>();
+            var wrapInScope = transportTransactionMode == TransportTransactionMode.SendsAtomicWithReceive;
             var completionCanBeBatched = !wrapInScope;
             try
             {

--- a/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
+++ b/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
@@ -121,7 +121,7 @@ namespace NServiceBus.AzureServiceBus
         {
             try
             {
-                var scope = suppressTransaction ? null : new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+                var scope = suppressTransaction ? new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled) : null;
                 using (scope)
                 {
                     await RouteBatchWithEnforcedBatchSizeAsync(messageSender, messagesToSend).ConfigureAwait(false);

--- a/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
+++ b/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
@@ -73,13 +73,12 @@ namespace NServiceBus.AzureServiceBus
                 {
                     // only use via if the destination and via namespace are the same
                     var via = routingOptions.SendVia && ns.ConnectionString ==  routingOptions.ViaConnectionString ? routingOptions.ViaEntityPath : null;
-                    var useTransaction = via != null;
+                    var suppressTransaction = via == null;
                     var messageSender = senders.Get(entity.Path, via, ns.Name);
 
                     var brokeredMessages = outgoingMessageConverter.Convert(outgoingBatches, routingOptions).ToList();
 
-                    if(context != null) context.CompletionCanBeBatched &= !useTransaction;
-                    pendingSends.Add(RouteOutBatchesWithFallbackAndLogExceptionsAsync(messageSender, fallbacks, brokeredMessages, context, useTransaction));
+                    pendingSends.Add(RouteOutBatchesWithFallbackAndLogExceptionsAsync(messageSender, fallbacks, brokeredMessages, suppressTransaction));
                 }
             }
             return Task.WhenAll(pendingSends);
@@ -118,11 +117,16 @@ namespace NServiceBus.AzureServiceBus
             return null;
         }
 
-        async Task RouteOutBatchesWithFallbackAndLogExceptionsAsync(IMessageSender messageSender, IList<IMessageSender> fallbacks, IList<BrokeredMessage> messagesToSend, BrokeredMessageReceiveContext context, bool useTransaction)
+        async Task RouteOutBatchesWithFallbackAndLogExceptionsAsync(IMessageSender messageSender, IList<IMessageSender> fallbacks, IList<BrokeredMessage> messagesToSend,bool suppressTransaction)
         {
             try
             {
-                await RouteBatchWithEnforcedBatchSizeAsync(messageSender, messagesToSend, context, useTransaction).ConfigureAwait(false);
+                var scope = suppressTransaction ? null : new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+                using (scope)
+                {
+                    await RouteBatchWithEnforcedBatchSizeAsync(messageSender, messagesToSend).ConfigureAwait(false);
+                    scope?.Complete();
+                }
             }
             catch (Exception exception)
             {
@@ -143,7 +147,11 @@ namespace NServiceBus.AzureServiceBus
                         var clones = messagesToSend.Select(x => x.Clone()).ToList();
                         try
                         {
-                            await RouteBatchWithEnforcedBatchSizeAsync(fallback, clones, context, false).ConfigureAwait(false);
+                            using (var scope = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
+                            {
+                                await RouteBatchWithEnforcedBatchSizeAsync(fallback, clones).ConfigureAwait(false);
+                                scope.Complete();
+                            }
                             logger.Info("Successfully dispatched a batch with the following message IDs: " + string.Join(", ", clones.Select(x => x.MessageId) + " to fallback namespace"));
                             fallBackSucceeded = true;
                             break;
@@ -159,14 +167,11 @@ namespace NServiceBus.AzureServiceBus
             }
         }
 
-        async Task RouteBatchWithEnforcedBatchSizeAsync(IMessageSender messageSender, IEnumerable<BrokeredMessage> messagesToSend, ReceiveContext context, bool useTransaction)
+        async Task RouteBatchWithEnforcedBatchSizeAsync(IMessageSender messageSender, IEnumerable<BrokeredMessage> messagesToSend)
         {
             var chunk = new List<BrokeredMessage>();
             long batchSize = 0;
             var chunkNumber = 1;
-
-            CommittableTransaction tx = null;
-            if (useTransaction) tx = context?.Transaction;
 
             foreach (var message in messagesToSend)
             {
@@ -183,7 +188,7 @@ namespace NServiceBus.AzureServiceBus
                     {
                         logger.Debug($"Routing batched messages, chunk #{chunkNumber++}.");
                         var currentChunk = chunk;
-                        await messageSender.RetryOnThrottleAsync(s => s.SendBatch(currentChunk, tx), s => s.SendBatch(currentChunk.Select(x => x.Clone()), tx), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
+                        await messageSender.RetryOnThrottleAsync(s => s.SendBatch(currentChunk), s => s.SendBatch(currentChunk.Select(x => x.Clone())), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
                     }
 
                     chunk = new List<BrokeredMessage> { message };
@@ -199,7 +204,7 @@ namespace NServiceBus.AzureServiceBus
             if (chunk.Any())
             {
                 logger.Debug($"Routing batched messages, chunk #{chunkNumber}.");
-                await messageSender.RetryOnThrottleAsync(s => s.SendBatch(chunk, tx), s => s.SendBatch(chunk.Select(x => x.Clone()), tx), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
+                await messageSender.RetryOnThrottleAsync(s => s.SendBatch(chunk), s => s.SendBatch(chunk.Select(x => x.Clone())), backOffTimeOnThrottle, maxRetryAttemptsOnThrottle).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
The approach suggest by @danielmarbach  works as follows

- wrap pipeline invocation in transaction scope if SendAtomicReceive mode, so that scope flows through the pipeline into the dispatcher
- insert suppress transaction scope in the stage branch of TransportReceiveToPhysicalMessageProcessingConnector (first element in stage before ExecuteUnitOfWork), so that transaction does not flow into the handlers or persisters, but it does flow into the fork section of the connector.
- put a suppress scope around sends that do not involve send via (immediate dispatch, cross namespace routes, failover attempts, etc...)
- complete brokered message in the transaction scope around the pipeline invocation (do not a to add it to the batch)

Open question: does it work with transactional persister (f.e. sql database)
