### PR TITLE
Update Secure Connection Strings API to remove confusion

### DIFF
--- a/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
     public class When_using_multiple_namespaces : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_support_request_reply_across_namespaces_using_names()
+        public async Task Should_support_request_reply_across_namespaces_using_aliases()
         {
             var runSettings = new RunSettings();
             runSettings.TestExecutionTimeout = TimeSpan.FromMinutes(1);
@@ -22,7 +22,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
             {
                 var connectionString = Environment.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
                 var targetConnectionString = Environment.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
-                extensions.UseNamespaceNamesInsteadOfConnectionStrings();
+                extensions.UseNamespaceAliasesInsteadOfConnectionStrings();
 
                 if (endpointName == "UsingMultipleNamespaces.EndpointInTargetNamespace")
                 {
@@ -132,10 +132,10 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
             {
                 public Context Context { get; set; }
 
-                public async Task Handle(MyRequest message, IMessageHandlerContext context)
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
                 {
                     Context.RequestReceived = true;
-                    await context.Reply(new MyResponse());
+                    return context.Reply(new MyResponse());
                 }
             }
         }

--- a/src/AcceptanceTests/Routing/When_using_single_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_using_single_namespace.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
     public class When_using_single_namespace : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_append_namespace_name_to_reply_address_when_using_names()
+        public async Task Should_append_namespace_alias_to_reply_address_when_using_aliases()
         {
             var runSettings = new RunSettings();
             runSettings.TestExecutionTimeout = TimeSpan.FromMinutes(1);
@@ -22,7 +22,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
             {
                 var connectionString = Environment.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
                 extensions.ConnectionString(connectionString);
-                extensions.UseNamespaceNamesInsteadOfConnectionStrings();
+                extensions.UseNamespaceAliasesInsteadOfConnectionStrings();
             };
 
             runSettings.Set("AzureServiceBus.AcceptanceTests.TransportConfigContext", ctx);
@@ -78,11 +78,11 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
             {
                 public Context Context { get; set; }
 
-                public async Task Handle(MyRequest message, IMessageHandlerContext context)
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
                 {
                     Context.RequestReceived = true;
                     Context.ReplyToContainsNamespaceName = context.ReplyToAddress.Contains("@default");
-                    await context.Reply(new MyResponse());
+                    return context.Reply(new MyResponse());
                 }
             }
         }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -178,7 +178,7 @@
         public static void BrokeredMessageBodyType(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, NServiceBus.Transport.AzureServiceBus.SupportedBrokeredMessageBodyTypes type) { }
         public static NServiceBus.AzureServiceBusCompositionSettings Composition(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void ConnectivityMode(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Microsoft.ServiceBus.ConnectivityMode connectivityMode) { }
-        public static void DefaultNamespaceName(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string name) { }
+        public static void DefaultNamespaceAlias(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string alias) { }
         public static NServiceBus.AzureServiceBusIndividualizationSettings Individualization(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusMessageReceiverSettings MessageReceivers(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusMessageSenderSettings MessageSenders(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
@@ -194,7 +194,7 @@
         public static NServiceBus.AzureServiceBusTopicSettings Topics(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void UseBrokeredMessageToIncomingMessageConverter<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.Transport.AzureServiceBus.IConvertBrokeredMessagesToIncomingMessages { }
-        public static void UseNamespaceNamesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static void UseNamespaceAliasesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void UseOutgoingMessageToBrokeredMessageConverter<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.Transport.AzureServiceBus.IConvertOutgoingMessagesToBrokeredMessages { }
         public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
@@ -334,7 +334,6 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
     public class ConnectionString : System.IEquatable<NServiceBus.Transport.AzureServiceBus.ConnectionString>
     {
-        public static readonly string Sample;
         public ConnectionString(string value) { }
         public string NamespaceName { get; }
         public string SharedAccessPolicyName { get; }
@@ -418,7 +417,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
     public interface ICreateMessageReceivers
     {
-        System.Threading.Tasks.Task<NServiceBus.Transport.AzureServiceBus.IMessageReceiver> Create(string entitypath, string namespaceName);
+        System.Threading.Tasks.Task<NServiceBus.Transport.AzureServiceBus.IMessageReceiver> Create(string entityPath, string namespaceAlias);
     }
     public interface ICreateMessageSenders
     {
@@ -446,7 +445,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
     public interface IManageMessageReceiverLifeCycle
     {
-        NServiceBus.Transport.AzureServiceBus.IMessageReceiver Get(string entitypath, string namespaceName);
+        NServiceBus.Transport.AzureServiceBus.IMessageReceiver Get(string entityPath, string namespaceAlias);
     }
     public interface IManageMessageSenderLifeCycle
     {
@@ -459,7 +458,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
     public interface IManageNamespaceManagerLifeCycle
     {
-        NServiceBus.Transport.AzureServiceBus.INamespaceManager Get(string namespaceName);
+        NServiceBus.Transport.AzureServiceBus.INamespaceManager Get(string namespaceAlias);
     }
     public interface IMessageReceiver : NServiceBus.Transport.AzureServiceBus.IClientEntity
     {
@@ -590,15 +589,15 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         public NamespaceConfigurations() { }
         public int Count { get; }
-        public void Add(string name, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose) { }
+        public void Add(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose) { }
         public string GetConnectionString(string name) { }
         public System.Collections.Generic.IEnumerator<NServiceBus.Transport.AzureServiceBus.NamespaceInfo> GetEnumerator() { }
     }
     public class NamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.NamespaceInfo>
     {
-        public NamespaceInfo(string name, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1) { }
+        public NamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1) { }
+        public string Alias { get; }
         public NServiceBus.Transport.AzureServiceBus.ConnectionString ConnectionString { get; }
-        public string Name { get; }
         public NServiceBus.Transport.AzureServiceBus.NamespacePurpose Purpose { get; }
         public bool Equals(NServiceBus.Transport.AzureServiceBus.NamespaceInfo other) { }
         public override bool Equals(object obj) { }
@@ -660,10 +659,10 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
     public class RuntimeNamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo>
     {
-        public RuntimeNamespaceInfo(string name, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1, NServiceBus.Transport.AzureServiceBus.NamespaceMode mode = 0) { }
+        public RuntimeNamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1, NServiceBus.Transport.AzureServiceBus.NamespaceMode mode = 0) { }
+        public string Alias { get; }
         public string ConnectionString { get; }
         public NServiceBus.Transport.AzureServiceBus.NamespaceMode Mode { get; }
-        public string Name { get; }
         public bool Equals(NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/Tests/Connectivity/When_managing_client_entity_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_client_entity_lifecycle.cs
@@ -83,7 +83,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
 
             public int InvocationCount = 0;
 
-            public Task<IMessageReceiver> Create(string entitypath, string namespaceName)
+            public Task<IMessageReceiver> Create(string entityPath, string namespaceAlias)
             {
                 InvocationCount++;
                 return Task.FromResult<IMessageReceiver>(new InterceptedMessageReceiver());

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -167,7 +167,7 @@
     <Compile Include="Topology\MetaModel\When_configuring_entity_address.cs" />
     <Compile Include="Topology\MetaModel\When_configuring_namespace_configurations.cs" />
     <Compile Include="Topology\MetaModel\When_configuring_namespace_info.cs" />
-    <Compile Include="Topology\MetaModel\When_mapping_connection_string_to_namespace_name.cs" />
+    <Compile Include="Topology\MetaModel\When_mapping_connection_string_to_namespace_alias.cs" />
     <Compile Include="Topology\MetaModel\When_parsing_string_to_connection_string.cs" />
     <Compile Include="Topology\MetaModel\When_SqlSubscriptionFilter_is_serializing_an_event.cs" />
     <Compile Include="Topology\Computation\When_computing_ForwardingTopology.cs" />

--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -101,7 +101,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             await namespaceManager.DeleteQueue("myqueue");
         }
 
-        class PassThroughMapper : ICanMapConnectionStringToNamespaceName
+        class PassThroughMapper : ICanMapConnectionStringToNamespaceAlias
         {
             public EntityAddress Map(EntityAddress value)
             {

--- a/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
+++ b/src/Tests/Receiving/When_converting_brokered_messages_to_incoming_messages.cs
@@ -242,7 +242,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             CollectionAssert.DoesNotContain(incomingMessageDetails.Headers, BrokeredMessageHeaders.TransportEncoding, $"Headers should not contain `{BrokeredMessageHeaders.TransportEncoding}`, but it was found.");
         }
 
-        class FakeMapper : ICanMapConnectionStringToNamespaceName
+        class FakeMapper : ICanMapConnectionStringToNamespaceAlias
         {
             public FakeMapper(string input, string output)
             {

--- a/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
+++ b/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
@@ -89,7 +89,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             await namespaceManager.DeleteQueue("autorenewtimeout");
         }
 
-        class PassThroughMapper : ICanMapConnectionStringToNamespaceName
+        class PassThroughMapper : ICanMapConnectionStringToNamespaceAlias
         {
             public EntityAddress Map(EntityAddress value)
             {

--- a/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
+++ b/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
@@ -155,7 +155,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
             await namespaceManager.DeleteQueue("myqueue");
         }
 
-        class PassThroughMapper : ICanMapConnectionStringToNamespaceName
+        class PassThroughMapper : ICanMapConnectionStringToNamespaceAlias
         {
             public EntityAddress Map(EntityAddress value)
             {

--- a/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
+++ b/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
@@ -228,7 +228,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
             };
 
             var brokeredMessage = converter.Convert(batchedOperation, new RoutingOptions());
-
+            // TODO reply-to needs to be tested according to the WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceAliasesInsteadOfConnectionStrings setting
             Assert.IsTrue(brokeredMessage.ReplyTo == "MyQueue"); // the mapper should be ignored, need to respect user's setting
         }
 

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
@@ -22,10 +22,10 @@
         [TestCase("")]
         [TestCase(" ")]
         [TestCase(null)]
-        public void Should_throws_an_exception_if_name_is_not_valid(string name)
+        public void Should_throws_an_exception_if_alias_is_not_valid(string alias)
         {
-            var exception = Assert.Throws<ArgumentException>(() => namespaces.Add(name, ConnectionStringValue.Sample, NamespacePurpose.Partitioning));
-            Assert.AreEqual("name", exception.ParamName);
+            var exception = Assert.Throws<ArgumentException>(() => namespaces.Add(alias, ConnectionStringValue.Sample, NamespacePurpose.Partitioning));
+            Assert.AreEqual("alias", exception.ParamName);
         }
 
         [Test]
@@ -34,24 +34,24 @@
         [TestCase(null)]
         public void Should_throws_an_exception_if_connection_string_is_not_valid(string connectionString)
         {
-            var exception = Assert.Throws<ArgumentException>(() => namespaces.Add("name", connectionString, NamespacePurpose.Partitioning));
+            var exception = Assert.Throws<ArgumentException>(() => namespaces.Add("alias", connectionString, NamespacePurpose.Partitioning));
             Assert.AreEqual("connectionString", exception.ParamName);
         }
 
         [Test]
         public void Should_add_definition_if_it_does_not_exist()
         {
-            namespaces.Add("name", ConnectionStringValue.Sample, NamespacePurpose.Partitioning);
-            var connectionString = namespaces.GetConnectionString("name");
+            namespaces.Add("alias", ConnectionStringValue.Sample, NamespacePurpose.Partitioning);
+            var connectionString = namespaces.GetConnectionString("alias");
 
             Assert.AreEqual(1, namespaces.Count);
             Assert.AreEqual(ConnectionStringValue.Sample, connectionString);
         }
 
         [Test]
-        [TestCase("name", "name")]
-        [TestCase("name", "Name")]
-        [TestCase("name", "NAME")]
+        [TestCase("alias", "alias")]
+        [TestCase("alias", "Alias")]
+        [TestCase("alias", "ALIAS")]
         public void Should_not_add_definition_if_namespace_name_already_exists_with_case_insensitive_check(string name1, string name2)
         {
             namespaces.Add(name1, ConnectionStringValue.Build("namespace1"), NamespacePurpose.Partitioning);
@@ -72,9 +72,9 @@
         [Test]
         public void Should_get_connection_string_by_namespace_name_with_a_case_insensitive_match()
         {
-            namespaces.Add("name", ConnectionStringValue.Sample, NamespacePurpose.Partitioning);
+            namespaces.Add("alias", ConnectionStringValue.Sample, NamespacePurpose.Partitioning);
 
-            var connectionString = namespaces.GetConnectionString("NaMe");
+            var connectionString = namespaces.GetConnectionString("AlIaS");
 
             StringAssert.AreEqualIgnoringCase(ConnectionStringValue.Sample, connectionString);
         }
@@ -82,7 +82,7 @@
         [Test]
         public void Should_throws_an_exception_if_namespace_name_has_not_been_registered()
         {
-            Assert.Throws<KeyNotFoundException>(() => namespaces.GetConnectionString("name"));
+            Assert.Throws<KeyNotFoundException>(() => namespaces.GetConnectionString("alias"));
         }
     }
 }

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
@@ -11,24 +11,24 @@
         [Test]
         [TestCase("name", "name")]
         [TestCase("name", "Name")]
-        public void Two_namespaces_should_be_equal_if_name_and_connection_string_are_case_insensitive_equal(string name1, string name2)
+        public void Two_namespaces_should_be_equal_if_alias_and_connection_string_are_case_insensitive_equal(string alias1, string alias2)
         {
-            var namespace1 = new NamespaceInfo(name1, ConnectionStringValue.Sample);
-            var namespace2 = new NamespaceInfo(name2, ConnectionStringValue.Sample);
+            var namespaceInfo1 = new NamespaceInfo(alias1, ConnectionStringValue.Sample);
+            var namespaceInfo2 = new NamespaceInfo(alias2, ConnectionStringValue.Sample);
 
-            Assert.AreEqual(namespace1, namespace2);
+            Assert.AreEqual(namespaceInfo1, namespaceInfo2);
         }
 
         [Test]
         [TestCase("name", "name")]
         [TestCase("name", "Name")]
-        public void Two_namespaces_should_have_the_same_hash_code_if_name_and_connection_string_are_case_insensitive_equal(string name1, string name2)
+        public void Two_namespaces_should_have_the_same_hash_code_if_alias_and_connection_string_are_case_insensitive_equal(string alias1, string alias2)
         {
-            var namespace1 = new NamespaceInfo(name1, ConnectionStringValue.Sample);
-            var namespace2 = new NamespaceInfo(name2, ConnectionStringValue.Sample);
+            var namespaceInfo1 = new NamespaceInfo(alias1, ConnectionStringValue.Sample);
+            var namespaceInfo2 = new NamespaceInfo(alias2, ConnectionStringValue.Sample);
 
-            var hashCode1 = namespace1.GetHashCode();
-            var hashCode2 = namespace2.GetHashCode();
+            var hashCode1 = namespaceInfo1.GetHashCode();
+            var hashCode2 = namespaceInfo2.GetHashCode();
             Assert.AreEqual(hashCode1, hashCode2);
         }
     }

--- a/src/Tests/Topology/MetaModel/When_mapping_connection_string_to_namespace_alias.cs
+++ b/src/Tests/Topology/MetaModel/When_mapping_connection_string_to_namespace_alias.cs
@@ -7,21 +7,21 @@
 
     [TestFixture]
     [Category("AzureServiceBus")]
-    public class When_mapping_connection_string_to_namespace_name
+    public class When_mapping_connection_string_to_namespace_alias
     {
-        DefaultConnectionStringToNamespaceNameMapper mapper;
+        DefaultConnectionStringToNamespaceAliasMapper mapper;
 
         [SetUp]
         public void SetUp()
         {
             var namespaceConfigurations = new NamespaceConfigurations();
-            namespaceConfigurations.Add("namespace1", "Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", NamespacePurpose.Partitioning);
-            namespaceConfigurations.Add("namespace2", "Endpoint=sb://namespace2.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", NamespacePurpose.Partitioning);
-            namespaceConfigurations.Add("namespace3", "Endpoint=sb://namespace3.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", NamespacePurpose.Partitioning);
+            namespaceConfigurations.Add("alias1", "Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", NamespacePurpose.Partitioning);
+            namespaceConfigurations.Add("alias2", "Endpoint=sb://namespace2.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", NamespacePurpose.Partitioning);
+            namespaceConfigurations.Add("alias3", "Endpoint=sb://namespace3.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret", NamespacePurpose.Partitioning);
             var settings = new SettingsHolder();
             settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaceConfigurations);
 
-            mapper = new DefaultConnectionStringToNamespaceNameMapper(settings);
+            mapper = new DefaultConnectionStringToNamespaceAliasMapper(settings);
         }
 
         [Test]
@@ -46,7 +46,7 @@
         {
             var mappedValue = mapper.Map(new EntityAddress("queuename@Endpoint=sb://namespace1.servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=secret"));
 
-            StringAssert.AreEqualIgnoringCase("queuename@namespace1", mappedValue.ToString());
+            StringAssert.AreEqualIgnoringCase("queuename@alias1", mappedValue.ToString());
         }
     }
 }

--- a/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
@@ -14,18 +14,18 @@
         {
             if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
             {
-                throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces to be configured, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register the namespaces");
+                throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces to be configured, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register the namespaces.");
             }
 
             namespaces = new NamespaceConfigurations(namespaces.Where(n => n.Purpose == NamespacePurpose.Partitioning).ToList());
 
             if (namespaces.Count < 2)
             {
-                throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces for the purpose of partitioning, found {namespaces.Count}, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register additional namespaces");
+                throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces for the purpose of partitioning, found {namespaces.Count}, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register additional namespaces.");
             }
             if (namespaces.Count > 2)
             {
-                throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces for the purpose of partitioning, found {namespaces.Count}, please register less namespaces");
+                throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces for the purpose of partitioning, found {namespaces.Count}, please register less namespaces.");
             }
         }
 
@@ -39,14 +39,14 @@
             if (partitioningIntent == PartitioningIntent.Sending)
             {
                 yield return Mode == FailOverMode.Primary
-                ? new RuntimeNamespaceInfo(primary.Name, primary.ConnectionString, primary.Purpose, NamespaceMode.Active)
-                : new RuntimeNamespaceInfo(secondary.Name, secondary.ConnectionString, secondary.Purpose, NamespaceMode.Active);
+                ? new RuntimeNamespaceInfo(primary.Alias, primary.ConnectionString, primary.Purpose, NamespaceMode.Active)
+                : new RuntimeNamespaceInfo(secondary.Alias, secondary.ConnectionString, secondary.Purpose, NamespaceMode.Active);
             }
 
             if (partitioningIntent == PartitioningIntent.Creating || partitioningIntent == PartitioningIntent.Receiving)
             {
-                yield return new RuntimeNamespaceInfo(primary.Name, primary.ConnectionString, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive);
-                yield return new RuntimeNamespaceInfo(secondary.Name, secondary.ConnectionString, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive);
+                yield return new RuntimeNamespaceInfo(primary.Alias, primary.ConnectionString, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive);
+                yield return new RuntimeNamespaceInfo(secondary.Alias, secondary.ConnectionString, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive);
             }
         }
     }

--- a/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
@@ -35,7 +35,7 @@ namespace NServiceBus
             if (partitioningIntent == PartitioningIntent.Sending)
             {
                 var @namespace = namespaces.Get();
-                yield return new RuntimeNamespaceInfo(@namespace.Name, @namespace.ConnectionString, @namespace.Purpose, NamespaceMode.Active);
+                yield return new RuntimeNamespaceInfo(@namespace.Alias, @namespace.ConnectionString, @namespace.Purpose, NamespaceMode.Active);
             }
 
             if (partitioningIntent == PartitioningIntent.Receiving || partitioningIntent == PartitioningIntent.Creating)
@@ -44,7 +44,7 @@ namespace NServiceBus
                 for (var i = 0; i < namespaces.Size; i++)
                 {
                     var @namespace = namespaces.Get();
-                    yield return new RuntimeNamespaceInfo(@namespace.Name, @namespace.ConnectionString, @namespace.Purpose, mode);
+                    yield return new RuntimeNamespaceInfo(@namespace.Alias, @namespace.ConnectionString, @namespace.Purpose, mode);
                     mode = NamespaceMode.Passive;
                 }
             }

--- a/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
@@ -14,21 +14,21 @@ namespace NServiceBus
         {
             if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
             {
-                throw new ConfigurationErrorsException($"The '{nameof(SingleNamespacePartitioning)}' strategy requires exactly one namespace, please configure the connection string to your azure servicebus namespace");
+                throw new ConfigurationErrorsException($"The '{nameof(SingleNamespacePartitioning)}' strategy requires exactly one namespace, please configure the connection string to your azure servicebus namespace.");
             }
 
             namespaces = new NamespaceConfigurations(namespaces.Where(n => n.Purpose == NamespacePurpose.Partitioning).ToList());
 
             if (namespaces.Count != 1)
             {
-                throw new ConfigurationErrorsException($"The '{nameof(SingleNamespacePartitioning)}' strategy requires exactly one namespace for the purpose of partitioning, found {namespaces.Count}. Please remove additional namespace registrations");
+                throw new ConfigurationErrorsException($"The '{nameof(SingleNamespacePartitioning)}' strategy requires exactly one namespace for the purpose of partitioning, found {namespaces.Count}. Please remove additional namespace registrations.");
             }
         }
 
         public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
         {
             var @namespace = namespaces.First();
-            yield return new RuntimeNamespaceInfo(@namespace.Name, @namespace.ConnectionString, @namespace.Purpose, NamespaceMode.Active);
+            yield return new RuntimeNamespaceInfo(@namespace.Alias, @namespace.ConnectionString, @namespace.Purpose, NamespaceMode.Active);
         }
     }
 }

--- a/src/Transport/Config/AzureServiceBusTransport.cs
+++ b/src/Transport/Config/AzureServiceBusTransport.cs
@@ -80,8 +80,8 @@
         static void RegisterConnectionStringAsNamespace(string connectionString, ReadOnlySettings settings)
         {
             var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-            var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
-            namespaces.Add(defaultName, connectionString, NamespacePurpose.Partitioning);
+            var alias = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias);
+            namespaces.Add(alias, connectionString, NamespacePurpose.Partitioning);
         }
 
         public override bool RequiresConnectionString { get; } = false;

--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -35,8 +35,8 @@
         void ApplyDefaultValuesForAddressing(SettingsHolder settings)
         {
             settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, new NamespaceConfigurations());
-            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceNamesInsteadOfConnectionStrings, false);
-            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName, "default");
+            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceAliasesInsteadOfConnectionStrings, false);
+            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias, "default");
         }
 
         void ApplyDefaultsForConnectivity(SettingsHolder settings)

--- a/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
+++ b/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
@@ -120,21 +120,21 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Force usage of namespace names instead of raw connection strings.
+        /// Force usage of namespace aliases instead of raw connection strings.
         /// </summary>
-        public static void UseNamespaceNamesInsteadOfConnectionStrings(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        public static void UseNamespaceAliasesInsteadOfConnectionStrings(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
         {
             var settings = transportExtensions.GetSettings();
-            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceNamesInsteadOfConnectionStrings, true);
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceAliasesInsteadOfConnectionStrings, true);
         }
 
         /// <summary>
-        /// Choose the name of the default namespace.
+        /// Override default namespace alias.
         /// </summary>
-        public static void DefaultNamespaceName(this TransportExtensions<AzureServiceBusTransport> transportExtensions, string name )
+        public static void DefaultNamespaceAlias(this TransportExtensions<AzureServiceBusTransport> transportExtensions, string alias)
         {
             var settings = transportExtensions.GetSettings();
-            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName, name);
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias, alias);
         }
 
         /// <summary>

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -70,8 +70,8 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             public static class Addressing
             {
-                public const string UseNamespaceNamesInsteadOfConnectionStrings = "AzureServiceBus.Settings.Topology.Addressing.UseNamespaceNamesInsteadOfConnectionStrings";
-                public const string DefaultNamespaceName = "AzureServiceBus.Settings.Topology.Addressing.DefaultNamespaceName";
+                public const string UseNamespaceAliasesInsteadOfConnectionStrings = "AzureServiceBus.Settings.Topology.Addressing.UseNamespaceAliasesInsteadOfConnectionStrings";
+                public const string DefaultNamespaceAlias = "AzureServiceBus.Settings.Topology.Addressing.DefaultNamespaceAlias";
                 public const string Namespaces = "AzureServiceBus.Settings.Topology.Addressing.Namespaces";
 
                 public static class Partitioning

--- a/src/Transport/Connectivity/ICreateMessageReceivers.cs
+++ b/src/Transport/Connectivity/ICreateMessageReceivers.cs
@@ -4,6 +4,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     public interface ICreateMessageReceivers
     {
-        Task<IMessageReceiver> Create(string entitypath, string namespaceName);
+        Task<IMessageReceiver> Create(string entityPath, string namespaceAlias);
     }
 }

--- a/src/Transport/Connectivity/IManageMessageReceiverLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessageReceiverLifeCycle.cs
@@ -2,6 +2,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     public interface IManageMessageReceiverLifeCycle
     {
-        IMessageReceiver Get(string entitypath, string namespaceName);
+        IMessageReceiver Get(string entityPath, string namespaceAlias);
     }
 }

--- a/src/Transport/Connectivity/IManageNamespaceManagerLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageNamespaceManagerLifeCycle.cs
@@ -2,6 +2,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     public interface IManageNamespaceManagerLifeCycle
     {
-        INamespaceManager Get(string namespaceName);
+        INamespaceManager Get(string namespaceAlias);
     }
 }

--- a/src/Transport/Connectivity/MessageReceiverCreator.cs
+++ b/src/Transport/Connectivity/MessageReceiverCreator.cs
@@ -17,12 +17,12 @@ namespace NServiceBus.Transport.AzureServiceBus
         }
 
 
-        public async Task<IMessageReceiver> Create(string entitypath, string namespaceName)
+        public async Task<IMessageReceiver> Create(string entityPath, string namespaceAlias)
         {
-            var factory = factories.Get(namespaceName);
+            var factory = factories.Get(namespaceAlias);
             var receiveMode = settings.Get<ReceiveMode>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.ReceiveMode);
 
-            var receiver = await factory.CreateMessageReceiver(entitypath, receiveMode).ConfigureAwait(false);
+            var receiver = await factory.CreateMessageReceiver(entityPath, receiveMode).ConfigureAwait(false);
 
             if (settings.HasSetting(WellKnownConfigurationKeys.Connectivity.MessageReceivers.PrefetchCount))
             {

--- a/src/Transport/Connectivity/MessageReceiverLifeCycleManager.cs
+++ b/src/Transport/Connectivity/MessageReceiverLifeCycleManager.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    using System;
     using System.Collections.Concurrent;
     using Settings;
 
@@ -16,9 +15,9 @@ namespace NServiceBus.Transport.AzureServiceBus
             numberOfReceiversPerEntity = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.NumberOfClientsPerEntity);
         }
 
-        public IMessageReceiver Get(string entitypath, string namespaceName)
+        public IMessageReceiver Get(string entityPath, string namespaceAlias)
         {
-            var buffer = MessageReceivers.GetOrAdd(entitypath, s =>
+            var buffer = MessageReceivers.GetOrAdd(entityPath, s =>
             {
                 var b = new CircularBuffer<EntityClientEntry>(numberOfReceiversPerEntity);
                 for (var i = 0; i < numberOfReceiversPerEntity; i++)
@@ -26,7 +25,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     var e = new EntityClientEntry();
                     lock (e.Mutex)
                     {
-                        e.ClientEntity = receiveFactory.Create(entitypath, namespaceName).Result;
+                        e.ClientEntity = receiveFactory.Create(entityPath, namespaceAlias).Result;
                     }
                     b.Put(e);
                 }
@@ -41,7 +40,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 {
                     if (entry.ClientEntity.IsClosed)
                     {
-                        entry.ClientEntity = receiveFactory.Create(entitypath, namespaceName).Result;
+                        entry.ClientEntity = receiveFactory.Create(entityPath, namespaceAlias).Result;
                     }
                 }
             }
@@ -52,7 +51,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         class EntityClientEntry
         {
-            internal Object Mutex = new object();
+            internal object Mutex = new object();
             internal IMessageReceiver ClientEntity;
         }
     }

--- a/src/Transport/Connectivity/NamespaceManagerLifeCycleManager.cs
+++ b/src/Transport/Connectivity/NamespaceManagerLifeCycleManager.cs
@@ -12,9 +12,9 @@ namespace NServiceBus.Transport.AzureServiceBus
             this.factory = factory;
         }
 
-        public INamespaceManager Get(string namespaceName)
+        public INamespaceManager Get(string namespaceAlias)
         {
-            return namespaceManagers.GetOrAdd(namespaceName, s => factory.Create(s));
+            return namespaceManagers.GetOrAdd(namespaceAlias, s => factory.Create(s));
         }
 
     }

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -132,10 +132,10 @@
     <Compile Include="Topology\TypesScanner\ITypesScanner.cs" />
     <Compile Include="Topology\TypesScanner\SingleTypeScanner.cs" />
     <Compile Include="Topology\MetaModel\ConnectionString.cs" />
-    <Compile Include="Topology\MetaModel\DefaultConnectionStringToNamespaceNameMapper.cs" />
+    <Compile Include="Topology\MetaModel\DefaultConnectionStringToNamespaceAliasMapper.cs" />
     <Compile Include="Topology\MetaModel\EntityAddress.cs" />
     <Compile Include="Topology\MetaModel\ForwardingTopologySubscriptionMetadata.cs" />
-    <Compile Include="Topology\MetaModel\ICanMapConnectionStringToNamespaceName.cs" />
+    <Compile Include="Topology\MetaModel\ICanMapConnectionStringToNamespaceAlias.cs" />
     <Compile Include="Topology\MetaModel\NamespaceInfo.cs" />
     <Compile Include="Topology\MetaModel\NamespaceConfigurations.cs" />
     <Compile Include="Topology\MetaModel\SubscriptionMetadata.cs" />

--- a/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
+++ b/src/Transport/Receiving/DefaultBrokeredMessagesToIncomingMessagesConverter.cs
@@ -12,10 +12,10 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         ILog logger = LogManager.GetLogger<DefaultBrokeredMessagesToIncomingMessagesConverter>();
         ReadOnlySettings settings;
-        ICanMapConnectionStringToNamespaceName mapper;
+        ICanMapConnectionStringToNamespaceAlias mapper;
         static byte[] EmptyBody = new byte[0];
 
-        public DefaultBrokeredMessagesToIncomingMessagesConverter(ReadOnlySettings settings, ICanMapConnectionStringToNamespaceName mapper)
+        public DefaultBrokeredMessagesToIncomingMessagesConverter(ReadOnlySettings settings, ICanMapConnectionStringToNamespaceAlias mapper)
         {
             this.settings = settings;
             this.mapper = mapper;

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -92,7 +92,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             stopping = false;
             pipelineInvocationTasks = new ConcurrentDictionary<Task, Task>();
 
-            internalReceiver = clientEntities.Get(fullPath, entity.Namespace.Name);
+            internalReceiver = clientEntities.Get(fullPath, entity.Namespace.Alias);
 
             if (internalReceiver == null)
             {

--- a/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
+++ b/src/Transport/Sending/DefaultBatchedOperationsToBrokeredMessagesConverter.cs
@@ -68,9 +68,9 @@ namespace NServiceBus.Transport.AzureServiceBus
                 if (!replyTo.HasSuffix)
                 {
                     var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-                    var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
-                    var useNames = settings.Get<bool>(WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceNamesInsteadOfConnectionStrings);
-                    var selected = namespaces.FirstOrDefault(ns => ns.Name == defaultName);
+                    var defaultAlias = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias);
+                    var useAliases = settings.Get<bool>(WellKnownConfigurationKeys.Topology.Addressing.UseNamespaceAliasesInsteadOfConnectionStrings);
+                    var selected = namespaces.FirstOrDefault(ns => ns.Alias == defaultAlias);
                     if (selected == null)
                     {
                         selected = namespaces.FirstOrDefault(ns => ns.Purpose == NamespacePurpose.Partitioning);
@@ -78,13 +78,13 @@ namespace NServiceBus.Transport.AzureServiceBus
 
                     if (selected != null)
                     {
-                        if (useNames)
+                        if (useAliases)
                         {
                             replyTo = new EntityAddress(replyTo.Name, selected.ConnectionString);
                         }
                         else
                         {
-                            replyTo = new EntityAddress(replyTo.Name, selected.Name);
+                            replyTo = new EntityAddress(replyTo.Name, selected.Alias);
                         }
                     }
                 }

--- a/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
+++ b/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
@@ -66,14 +66,14 @@ namespace NServiceBus.Transport.AzureServiceBus
                 }
 
                 // don't use via on fallback, not supported across namespaces
-                var fallbacks = passiveNamespaces.Select(ns => senders.Get(entity.Path, null, ns.Name)).ToList();
+                var fallbacks = passiveNamespaces.Select(ns => senders.Get(entity.Path, null, ns.Alias)).ToList();
 
                 foreach (var ns in activeNamespaces)
                 {
                     // only use via if the destination and via namespace are the same
                     var via = routingOptions.SendVia && ns.ConnectionString ==  routingOptions.ViaConnectionString ? routingOptions.ViaEntityPath : null;
                     var suppressTransaction = via == null;
-                    var messageSender = senders.Get(entity.Path, via, ns.Name);
+                    var messageSender = senders.Get(entity.Path, via, ns.Alias);
 
                     var brokeredMessages = outgoingMessageConverter.Convert(outgoingBatches, routingOptions).ToList();
 

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -5,7 +5,7 @@
 
     public class ConnectionString : IEquatable<ConnectionString>
     {
-        public static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
+        static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
         static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
 
         string value;

--- a/src/Transport/Topology/MetaModel/DefaultConnectionStringToNamespaceAliasMapper.cs
+++ b/src/Transport/Topology/MetaModel/DefaultConnectionStringToNamespaceAliasMapper.cs
@@ -4,11 +4,11 @@
     using System.Linq;
     using Settings;
 
-    class DefaultConnectionStringToNamespaceNameMapper : ICanMapConnectionStringToNamespaceName
+    class DefaultConnectionStringToNamespaceAliasMapper : ICanMapConnectionStringToNamespaceAlias
     {
         ReadOnlySettings settings;
 
-        public DefaultConnectionStringToNamespaceNameMapper(ReadOnlySettings settings)
+        public DefaultConnectionStringToNamespaceAliasMapper(ReadOnlySettings settings)
         {
             this.settings = settings;
         }
@@ -25,12 +25,12 @@
             var namespaceInfo = namespaces.SingleOrDefault(x => x.ConnectionString == value.Suffix);
             if (namespaceInfo != null)
             {
-                return new EntityAddress($"{value.Name}@{namespaceInfo.Name}");
+                return new EntityAddress($"{value.Name}@{namespaceInfo.Alias}");
             }
 
             var namespaceName = new ConnectionString(value.Suffix).NamespaceName;
             throw new InvalidOperationException($"Connection string for {namespaceName} hasn't been configured. {Environment.NewLine}" +
-                                                "Use `AddNamespace` configuration API to map connection string to namespace name.");
+                                                "Use `AddNamespace` configuration API to map connection string to namespace alias.");
         }
     }
 }

--- a/src/Transport/Topology/MetaModel/ICanMapConnectionStringToNamespaceAlias.cs
+++ b/src/Transport/Topology/MetaModel/ICanMapConnectionStringToNamespaceAlias.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
-    interface ICanMapConnectionStringToNamespaceName
+    interface ICanMapConnectionStringToNamespaceAlias
     {
         EntityAddress Map(EntityAddress value);
     }

--- a/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
@@ -24,21 +24,20 @@
 
         public int Count => inner.Count;
 
-        public void Add(string name, string connectionString, NamespacePurpose purpose)
+        public void Add(string alias, string connectionString, NamespacePurpose purpose)
         {
-            var definition = new NamespaceInfo(name, connectionString, purpose);
+            var definition = new NamespaceInfo(alias, connectionString, purpose);
 
             var namespaceInfo = inner.SingleOrDefault(x => x.ConnectionString == definition.ConnectionString);
             if (namespaceInfo != null)
             {
-                Log.Info($"Duplicated connection string for `{namespaceInfo.Name}` and `{name}` namespaces." + Environment.NewLine +
-                         $"`{name}` namespace not registered");
+                Log.Info($"Duplicated connection string for namespace `{namespaceInfo.Alias}` and alias `{alias}.`  + {Environment.NewLine} + `{alias}` namespace alias was not registered.");
                 return;
             }
 
-            if (inner.Any(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase)))
+            if (inner.Any(x => string.Equals(x.Alias, alias, StringComparison.OrdinalIgnoreCase)))
             {
-                Log.Info($"Duplicated namespace name `{name}` configuration detected. Registered only once");
+                Log.Info($"Duplicated namespace alias `{alias}` configuration detected. Registered only once");
                 return;
             }
 
@@ -49,12 +48,12 @@
         {
             try
             {
-                var selected = inner.Single(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                var selected = inner.Single(x => x.Alias.Equals(name, StringComparison.OrdinalIgnoreCase));
                 return selected.ConnectionString;
             }
             catch (InvalidOperationException ex)
             {
-                throw new KeyNotFoundException($"Namespace with name `{name}` hasn't been registered", ex);
+                throw new KeyNotFoundException($"Namespace with alias `{name}` hasn't been registered", ex);
             }
         }
 

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -4,15 +4,15 @@
     
     public class NamespaceInfo : IEquatable<NamespaceInfo>
     {
-        public string Name { get; }
+        public string Alias { get; }
         public ConnectionString ConnectionString { get; }
         public NamespacePurpose Purpose { get; }
 
-        public NamespaceInfo(string name, string connectionString, NamespacePurpose purpose = NamespacePurpose.Partitioning)
+        public NamespaceInfo(string alias, string connectionString, NamespacePurpose purpose = NamespacePurpose.Partitioning)
         {
-            if (string.IsNullOrWhiteSpace(name))
+            if (string.IsNullOrWhiteSpace(alias))
             {
-                throw new ArgumentException("Namespace name can't be null or empty", nameof(name));
+                throw new ArgumentException("Namespace alias can't be null or empty", nameof(alias));
             }
 
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -20,7 +20,7 @@
                 throw new ArgumentException("Namespace connection string can't be null or empty", nameof(connectionString));
             }
 
-            Name = name;
+            Alias = alias;
             ConnectionString = new ConnectionString(connectionString);
             Purpose = purpose;
         }
@@ -28,7 +28,7 @@
         public bool Equals(NamespaceInfo other)
         {
             return other != null
-                   && Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase)
+                   && Alias.Equals(other.Alias, StringComparison.OrdinalIgnoreCase)
                    && ConnectionString.Equals(other.ConnectionString);
         }
 
@@ -40,7 +40,7 @@
 
         public override int GetHashCode()
         {
-            var name = Name.ToLower();
+            var name = Alias.ToLower();
             return string.Concat(name, "#", ConnectionString).GetHashCode();
         }
     }

--- a/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
@@ -4,15 +4,15 @@
 
     public class RuntimeNamespaceInfo : IEquatable<RuntimeNamespaceInfo>
     {
-        NamespaceInfo info;
+        readonly NamespaceInfo info;
 
-        public RuntimeNamespaceInfo(string name, string connectionString, NamespacePurpose purpose = NamespacePurpose.Partitioning, NamespaceMode mode = NamespaceMode.Active)
+        public RuntimeNamespaceInfo(string alias, string connectionString, NamespacePurpose purpose = NamespacePurpose.Partitioning, NamespaceMode mode = NamespaceMode.Active)
         {
-            info = new NamespaceInfo(name, connectionString, purpose);
+            info = new NamespaceInfo(alias, connectionString, purpose);
             Mode = mode;
         }
 
-        public string Name => info.Name;
+        public string Alias => info.Alias;
         public string ConnectionString => info.ConnectionString;
         public NamespaceMode Mode { get; }
 

--- a/src/Transport/Topology/PreStartupChecks/ManageRightsCheck.cs
+++ b/src/Transport/Topology/PreStartupChecks/ManageRightsCheck.cs
@@ -29,12 +29,12 @@ namespace NServiceBus.Transport.AzureServiceBus
             var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
             foreach (var @namespace in namespaces)
             {
-                var namespaceManager = manageNamespaceManagerLifeCycle.Get(@namespace.Name);
+                var namespaceManager = manageNamespaceManagerLifeCycle.Get(@namespace.Alias);
                 var canManageEntities = await namespaceManager.CanManageEntities().ConfigureAwait(false);
 
                 if (!canManageEntities)
                 {
-                    namespacesWithoutManageRights.Add(@namespace.Name);
+                    namespacesWithoutManageRights.Add(@namespace.Alias);
                 }
             }
 
@@ -43,7 +43,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 return StartupCheckResult.Success;
             }
 
-            return StartupCheckResult.Failed($"Configured to create topology, but have no manage rights for the following namespace(s): {string.Join(", ", namespacesWithoutManageRights.Select(name => $"`{name}`"))}.");
+            return StartupCheckResult.Failed($"Configured to create topology, but have no manage rights for the following namespace(s): {string.Join(", ", namespacesWithoutManageRights.Select(alias => $"`{alias}`"))}.");
         }
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -57,7 +57,7 @@ namespace NServiceBus
             container.RegisterSingleton<AzureServiceBusTopicCreator>();
             container.RegisterSingleton<AzureServiceBusSubscriptionCreatorV6>();
 
-            container.RegisterSingleton<DefaultConnectionStringToNamespaceNameMapper>();
+            container.RegisterSingleton<DefaultConnectionStringToNamespaceAliasMapper>();
 
             var brokeredMessagesToIncomingMessagesConverterType = settings.Get<Type>(WellKnownConfigurationKeys.BrokeredMessageConventions.ToIncomingMessageConverter);
             container.Register(brokeredMessagesToIncomingMessagesConverterType);

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -103,7 +103,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             var partitioningStrategy = (INamespacePartitioningStrategy)container.Resolve(typeof(INamespacePartitioningStrategy));
             var addressingLogic = (AddressingLogic)container.Resolve(typeof(AddressingLogic));
-            var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
+            var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias);
 
             var inputQueueAddress = addressingLogic.Apply(destination, EntityType.Queue);
 
@@ -121,12 +121,12 @@ namespace NServiceBus.Transport.AzureServiceBus
                     NamespaceConfigurations configuredNamespaces;
                     if (settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out configuredNamespaces))
                     {
-                        var configured = configuredNamespaces.FirstOrDefault(n => n.Name == inputQueueAddress.Suffix);
+                        var configured = configuredNamespaces.FirstOrDefault(n => n.Alias == inputQueueAddress.Suffix);
                         if (configured != null)
                         {
                             namespaces = new[]
                             {
-                                new RuntimeNamespaceInfo(configured.Name, configured.ConnectionString, configured.Purpose, NamespaceMode.Active)
+                                new RuntimeNamespaceInfo(configured.Alias, configured.ConnectionString, configured.Purpose, NamespaceMode.Active)
                             };
                         }
                     }

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -61,7 +61,7 @@ namespace NServiceBus
             container.RegisterSingleton<AzureServiceBusTopicCreator>();
             container.RegisterSingleton<AzureServiceBusForwardingSubscriptionCreator>();
 
-            container.RegisterSingleton<DefaultConnectionStringToNamespaceNameMapper>();
+            container.RegisterSingleton<DefaultConnectionStringToNamespaceAliasMapper>();
 
             var brokeredMessagesToIncomingMessagesConverterType = settings.Get<Type>(WellKnownConfigurationKeys.BrokeredMessageConventions.ToIncomingMessageConverter);
             container.Register(brokeredMessagesToIncomingMessagesConverterType);

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -115,12 +115,12 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             var partitioningStrategy = (INamespacePartitioningStrategy)container.Resolve(typeof(INamespacePartitioningStrategy));
             var addressingLogic = (AddressingLogic)container.Resolve(typeof(AddressingLogic));
-            var defaultName = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceName);
+            var defaultAlias = settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias);
 
             var inputQueueAddress = addressingLogic.Apply(destination, EntityType.Queue);
 
             RuntimeNamespaceInfo[] namespaces = null;
-            if (inputQueueAddress.HasSuffix && inputQueueAddress.Suffix != defaultName) // sending to specific namespace
+            if (inputQueueAddress.HasSuffix && inputQueueAddress.Suffix != defaultAlias) // sending to specific namespace
             {
                 if (inputQueueAddress.HasConnectionString)
                 {
@@ -133,12 +133,12 @@ namespace NServiceBus.Transport.AzureServiceBus
                     NamespaceConfigurations configuredNamespaces;
                     if (settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out configuredNamespaces))
                     {
-                        var configured = configuredNamespaces.FirstOrDefault(n => n.Name == inputQueueAddress.Suffix);
+                        var configured = configuredNamespaces.FirstOrDefault(n => n.Alias == inputQueueAddress.Suffix);
                         if (configured != null)
                         {
                             namespaces = new[]
                             {
-                                new RuntimeNamespaceInfo(configured.Name, configured.ConnectionString, configured.Purpose, NamespaceMode.Active)
+                                new RuntimeNamespaceInfo(configured.Alias, configured.ConnectionString, configured.Purpose, NamespaceMode.Active)
                             };
                         }
                     }
@@ -151,7 +151,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             if (namespaces == null)
             {
-                throw new Exception($"Could not determine namespace for destination {destination}");
+                throw new Exception($"Could not determine namespace for destination `{destination}`.");
             }
             var inputQueues = namespaces.Select(n => new EntityInfo { Path = inputQueueAddress.Name, Type = EntityType.Queue, Namespace = n }).ToArray();
 

--- a/src/Transport/Topology/TopologyCreator.cs
+++ b/src/Transport/Topology/TopologyCreator.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 var queueCreator = (ICreateAzureServiceBusQueues)container.Resolve(typeof(ICreateAzureServiceBusQueues));
                 foreach (var queue in queues)
                 {
-                    await queueCreator.Create(queue.Path, namespaces.Get(queue.Namespace.Name)).ConfigureAwait(false);
+                    await queueCreator.Create(queue.Path, namespaces.Get(queue.Namespace.Alias)).ConfigureAwait(false);
                 }
             }
 
@@ -34,7 +34,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 var topicCreator = (ICreateAzureServiceBusTopics)container.Resolve(typeof(ICreateAzureServiceBusTopics));
                 foreach (var topic in topics)
                 {
-                    await topicCreator.Create(topic.Path, namespaces.Get(topic.Namespace.Name)).ConfigureAwait(false);
+                    await topicCreator.Create(topic.Path, namespaces.Get(topic.Namespace.Alias)).ConfigureAwait(false);
                 }
             }
 
@@ -47,7 +47,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     var forwardTo = subscription.RelationShips.FirstOrDefault(r => r.Type == EntityRelationShipType.Forward);
                     var sqlFilter = (subscription as SubscriptionInfo)?.BrokerSideFilter.Serialize();
                     var metadata = (subscription as SubscriptionInfo)?.Metadata ?? new SubscriptionMetadata();
-                    await subscriptionCreator.Create(topic.Target.Path, subscription.Path, metadata, sqlFilter, namespaces.Get(subscription.Namespace.Name), forwardTo?.Target.Path).ConfigureAwait(false);
+                    await subscriptionCreator.Create(topic.Target.Path, subscription.Path, metadata, sqlFilter, namespaces.Get(subscription.Namespace.Alias), forwardTo?.Target.Path).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
Connects to #304 

Replaces "namespace name" with "alias" to remove confusion.