### PR TITLE
Lower noise when transient exceptions occur with OnMessage callback

### DIFF
--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -72,8 +72,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         void OptionsOnExceptionReceived(object sender, ExceptionReceivedEventArgs exceptionReceivedEventArgs)
         {
-            // todo respond appropriately
-
             // according to blog posts, this method is invoked on
             //- Exceptions raised during the time that the message pump is waiting for messages to arrive on the service bus
             //- Exceptions raised during the time that your code is processing the BrokeredMessage
@@ -81,9 +79,19 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             if (!stopping) //- It is raised when the underlying connection closes because of our close operation
             {
-                logger.InfoFormat("OptionsOnExceptionReceived invoked, action: {0}, exception: {1}", exceptionReceivedEventArgs.Action, exceptionReceivedEventArgs.Exception);
+                var messagingException = (MessagingException)exceptionReceivedEventArgs.Exception;
+                if (messagingException.IsTransient)
+                {
+                    logger.DebugFormat("OptionsOnExceptionReceived invoked, action: '{0}', transient exception with message: {1}", exceptionReceivedEventArgs.Action, messagingException.Detail.Message);
 
-                errorCallback?.Invoke(exceptionReceivedEventArgs.Exception).GetAwaiter().GetResult();
+                    // TODO ideally we'd failover to another space if in a certain period of time there are too many transient errors
+                }
+                else
+                {
+                    logger.InfoFormat("OptionsOnExceptionReceived invoked, action: '{0}', non-transient exception: {1}", exceptionReceivedEventArgs.Action, exceptionReceivedEventArgs.Exception);
+
+                    errorCallback?.Invoke(exceptionReceivedEventArgs.Exception).GetAwaiter().GetResult();
+                }
             }
         }
 

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -79,8 +79,8 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             if (!stopping) //- It is raised when the underlying connection closes because of our close operation
             {
-                var messagingException = (MessagingException)exceptionReceivedEventArgs.Exception;
-                if (messagingException.IsTransient)
+                var messagingException = exceptionReceivedEventArgs.Exception as MessagingException;
+                if (messagingException != null && messagingException.IsTransient)
                 {
                     logger.DebugFormat("OptionsOnExceptionReceived invoked, action: '{0}', transient exception with message: {1}", exceptionReceivedEventArgs.Action, messagingException.Detail.Message);
 


### PR DESCRIPTION
Currently logging non-transient and transient exceptions with INFO threshold.

With the change log
 * Transient exception with DEBUG threshold with full exception
 * Non-transient exception with INFO threshold with message only

@Particular/azure-service-bus-maintainers please review