### PR TITLE
[WIP] Fixed ToTransportAddress by making the translation explicit

### DIFF
--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    
+    using System.Text;
     using DelayedDelivery;
     using Performance.TimeToBeReceived;
     using Routing;
@@ -27,7 +27,19 @@
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            return logicalAddress.ToString();
+            var queue = new StringBuilder(logicalAddress.QueueName);
+
+            if (logicalAddress.Discriminator != null)
+            {
+                queue.Append("-" + logicalAddress.Discriminator);
+            }
+
+            if (logicalAddress.Qualifier != null)
+            {
+                queue.Append("." + logicalAddress.Qualifier);
+            }
+
+            return queue.ToString();
         }
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()


### PR DESCRIPTION
The previous version with `ToString` would include all instance properties (if provided) which is not something we want in the address.