### PR TITLE
Control prefetch count

### DIFF
--- a/src/Transport/Config/AzureServiceBusTransport.cs
+++ b/src/Transport/Config/AzureServiceBusTransport.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using AzureServiceBus.Topology.MetaModel;
+    using Logging;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Serialization;
@@ -11,6 +12,8 @@
 
     public class AzureServiceBusTransport : TransportDefinition
     {
+        static ILog logger = LogManager.GetLogger(typeof(AzureServiceBusTransport));
+
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
             // override core default serialization
@@ -67,6 +70,9 @@
                     {
                         // immediately delete after receive
                         settings.Set(WellKnownConfigurationKeys.Connectivity.MessageReceivers.ReceiveMode, ReceiveMode.ReceiveAndDelete);
+                        // override the default for prefetch count, but user code can still take precedence
+                        settings.SetDefault(WellKnownConfigurationKeys.Connectivity.MessageReceivers.PrefetchCount, 0);
+                        logger.Warn("Mesasge receiver PrefetchCount was reduced to zero because to avoid message loss with ReceiveAndDelete receive mode. To enforce prefetch, use configuration API to set the value explicitly.");
                     }
 
                 }

--- a/src/Transport/Config/TransactionModeSettingsExtensions.cs
+++ b/src/Transport/Config/TransactionModeSettingsExtensions.cs
@@ -12,7 +12,7 @@
             var transportType = settings.Get<TransportType>(WellKnownConfigurationKeys.Connectivity.TransportType);
             var receiveMode = settings.Get<ReceiveMode>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.ReceiveMode);
 
-            if (namespaces.Count == 1 && sendVia && transportType == TransportType.NetMessaging)
+            if (namespaces.Count == 1 && sendVia && transportType == TransportType.NetMessaging && receiveMode == ReceiveMode.PeekLock)
                 return TransportTransactionMode.SendsAtomicWithReceive;
 
             return receiveMode == ReceiveMode.PeekLock ? TransportTransactionMode.ReceiveOnly : TransportTransactionMode.None;

--- a/src/Transport/Connectivity/MessageReceiverCreator.cs
+++ b/src/Transport/Connectivity/MessageReceiverCreator.cs
@@ -1,14 +1,12 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
-    using Logging;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Settings;
 
     class MessageReceiverCreator : ICreateMessageReceivers
     {
-        static ILog logger = LogManager.GetLogger(typeof(MessageReceiverCreator));
         IManageMessagingFactoryLifeCycle factories;
         ReadOnlySettings settings;
 
@@ -18,26 +16,15 @@ namespace NServiceBus.Transport.AzureServiceBus
             this.settings = settings;
         }
 
-
         public async Task<IMessageReceiver> Create(string entityPath, string namespaceAlias)
         {
             var factory = factories.Get(namespaceAlias);
             var receiveMode = settings.Get<ReceiveMode>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.ReceiveMode);
 
-            var prefetchCount = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.PrefetchCount);
-            var userHasNotProvidedPrefetchCount = !settings.HasExplicitValue(WellKnownConfigurationKeys.Connectivity.MessageReceivers.PrefetchCount);
-            var transportTransactionMode = settings.HasExplicitValue<TransportTransactionMode>() ? settings.Get<TransportTransactionMode>() : settings.SupportedTransactionMode();
-
-            // do not allow prefetch if user hasn't explicitly instructed to use a prefetch count of a certain size when ReceiveAndDelete mode is used (TransTxMode.None)
-            if (userHasNotProvidedPrefetchCount && (transportTransactionMode == TransportTransactionMode.None || receiveMode == ReceiveMode.ReceiveAndDelete))
-            {
-                prefetchCount = 0;
-                logger.Warn("Mesasge receiver PrefetchCount was reduced to zero because to avoid message loss with ReceiveAndDelete receive mode. To enforce prefetch, use configuration API to set the value explicitly.");
-            }
-
             var receiver = await factory.CreateMessageReceiver(entityPath, receiveMode).ConfigureAwait(false);
-            receiver.PrefetchCount = prefetchCount;
-            
+
+            receiver.PrefetchCount = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.PrefetchCount);
+
             if (settings.HasExplicitValue(WellKnownConfigurationKeys.Connectivity.MessageReceivers.RetryPolicy))
             {
                 receiver.RetryPolicy = settings.Get<RetryPolicy>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.RetryPolicy);

--- a/src/Transport/Connectivity/MessageReceiverCreator.cs
+++ b/src/Transport/Connectivity/MessageReceiverCreator.cs
@@ -1,12 +1,14 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
+    using Logging;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Settings;
 
     class MessageReceiverCreator : ICreateMessageReceivers
     {
+        static ILog logger = LogManager.GetLogger(typeof(MessageReceiverCreator));
         IManageMessagingFactoryLifeCycle factories;
         ReadOnlySettings settings;
 
@@ -30,6 +32,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             if (userHasNotProvidedPrefetchCount && (transportTransactionMode == TransportTransactionMode.None || receiveMode == ReceiveMode.ReceiveAndDelete))
             {
                 prefetchCount = 0;
+                logger.Warn("Mesasge receiver PrefetchCount was reduced to zero because to avoid message loss with ReceiveAndDelete receive mode. To enforce prefetch, use configuration API to set the value explicitly.");
             }
 
             var receiver = await factory.CreateMessageReceiver(entityPath, receiveMode).ConfigureAwait(false);


### PR DESCRIPTION
Connects to #340 

When transport transaction mode is None or receive mode is ReceiveAndDelete, `PrefetchCount` should not be set, unless explicitly configured by  user code.