### PR TITLE
Outbox bug issue

### DIFF
--- a/src/Transport/Config/AzureServiceBusTransport.cs
+++ b/src/Transport/Config/AzureServiceBusTransport.cs
@@ -47,7 +47,7 @@
 
         void MatchSettingsToConsistencyRequirements(SettingsHolder settings)
         {
-            if (settings.HasExplicitValue<TransportTransactionMode>())
+            if (settings.HasSetting<TransportTransactionMode>())
             {
                 var required = settings.Get<TransportTransactionMode>();
                 if (required > TransportTransactionMode.SendsAtomicWithReceive)


### PR DESCRIPTION
Fixes #352 

## Issue

When Outbox is enabled, transport transaction mode is set as the [default setting](https://github.com/Particular/NServiceBus/blob/d061342e8ed69da242514a03e9ca9ce1f96db373/src/NServiceBus.Core/Reliability/Outbox/OutboxConfigExtensions.cs#L20). ASB transport was expecting to find an explicit value instead. As a result of that, the setting was ignored and the mode was not lowered as expected.