### PR TITLE
Concurrency set to zero

### DIFF
--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -67,11 +67,12 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             numberOfClients = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.NumberOfClientsPerEntity);
             var concurrency = maximumConcurrency / (double)numberOfClients;
+            var maxConcurrentCalls = concurrency > 0 ? (int) Math.Round(concurrency, MidpointRounding.AwayFromZero) : 1;
             options = new OnMessageOptions
             {
                 AutoComplete = false,
                 AutoRenewTimeout = settings.Get<TimeSpan>(WellKnownConfigurationKeys.Connectivity.MessageReceivers.AutoRenewTimeout),
-                MaxConcurrentCalls = (int)Math.Round(concurrency, MidpointRounding.AwayFromZero)
+                MaxConcurrentCalls = maxConcurrentCalls
             };
 
             options.ExceptionReceived += OptionsOnExceptionReceived;

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -67,7 +67,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             numberOfClients = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.NumberOfClientsPerEntity);
             var concurrency = maximumConcurrency / (double)numberOfClients;
-            var maxConcurrentCalls = concurrency > 0 ? (int) Math.Round(concurrency, MidpointRounding.AwayFromZero) : 1;
+            var maxConcurrentCalls = concurrency > 1 ? (int) Math.Round(concurrency, MidpointRounding.AwayFromZero) : 1;
             options = new OnMessageOptions
             {
                 AutoComplete = false,

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         ILog logger = LogManager.GetLogger(typeof(MessagePump));
         string inputQueue;
         SatelliteTransportAddressCollection satelliteTransportAddresses;
-        SemaphoreSlim throttler = new SemaphoreSlim(1);
+        SemaphoreSlim throttler;
 
         public MessagePump(ITopologySectionManager topologySectionManager, ITransportPartsContainer container, ReadOnlySettings settings)
         {


### PR DESCRIPTION
## Who's affected

Any user specifying concurrency limit on NServiceBus endpoint and number of client per entity for Azure Service Bus transport.

## Symptoms

When concurrency limit was lower then number of clients, concurrency could be set to zero and result in exception.