### PR TITLE
[WIP][SPIKE] Closing factories only once

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -215,7 +215,7 @@
         public DiscriminatorBasedIndividualization(NServiceBus.Settings.ReadOnlySettings settings) { }
         public string Individualize(string endpointName) { }
     }
-    public class EndpointOrientedTopology : NServiceBus.Transport.AzureServiceBus.ITopology
+    public class EndpointOrientedTopology : NServiceBus.Transport.AzureServiceBus.IStoppableTopology, NServiceBus.Transport.AzureServiceBus.ITopology
     {
         public EndpointOrientedTopology() { }
         public bool HasNativePubSubSupport { get; }
@@ -228,6 +228,7 @@
         public System.Func<NServiceBus.Transport.IManageSubscriptions> GetSubscriptionManagerFactory() { }
         public void Initialize(NServiceBus.Settings.SettingsHolder settings) { }
         public System.Threading.Tasks.Task<NServiceBus.Transport.StartupCheckResult> RunPreStartupChecks() { }
+        public System.Threading.Tasks.Task Stop() { }
     }
     public enum EntityType
     {
@@ -248,7 +249,7 @@
         public FlatComposition() { }
         public string GetEntityPath(string entityname, NServiceBus.EntityType entityType) { }
     }
-    public class ForwardingTopology : NServiceBus.Transport.AzureServiceBus.ITopology
+    public class ForwardingTopology : NServiceBus.Transport.AzureServiceBus.IStoppableTopology, NServiceBus.Transport.AzureServiceBus.ITopology
     {
         public ForwardingTopology() { }
         public bool HasNativePubSubSupport { get; }
@@ -261,6 +262,7 @@
         public System.Func<NServiceBus.Transport.IManageSubscriptions> GetSubscriptionManagerFactory() { }
         public void Initialize(NServiceBus.Settings.SettingsHolder settings) { }
         public async System.Threading.Tasks.Task<NServiceBus.Transport.StartupCheckResult> RunPreStartupChecks() { }
+        public System.Threading.Tasks.Task Stop() { }
     }
     public class HierarchyComposition : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
     {
@@ -555,6 +557,10 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ISanitizationStrategy
     {
         string Sanitize(string entityPathOrName, NServiceBus.EntityType entityType);
+    }
+    public interface IStoppableTopology
+    {
+        System.Threading.Tasks.Task Stop();
     }
     public interface ITopology
     {

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Threading.Tasks;
     using DelayedDelivery;
     using NServiceBus.AzureServiceBus.Topology.MetaModel;
     using Performance.TimeToBeReceived;
@@ -13,6 +14,11 @@
     {
         ITopology topology;
         SatelliteTransportAddressCollection satelliteTransportAddresses;
+
+        public override Task Stop()
+        {
+            return ((IStoppableTopology) topology).Stop();
+        }
 
         public AzureServiceBusTransportInfrastructure(ITopology topology, TransportTransactionMode supportedTransactionMode, SatelliteTransportAddressCollection satelliteTransportAddresses)
         {

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Sending\Time.cs" />
     <Compile Include="Topology\ConventionsAdapter.cs" />
     <Compile Include="Topology\IConventions.cs" />
+    <Compile Include="Topology\IStoppableTopology.cs" />
     <Compile Include="Topology\MetaModel\NamespacePurpose.cs" />
     <Compile Include="Topology\MetaModel\SatelliteTransportAddressCollection.cs" />
     <Compile Include="Utils\MessageReceiverExtensions.cs" />

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -292,7 +292,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             stopping = true;
 
-            logger.Info("Stopping notifier for " + fullPath);
+            logger.Info($"Stopping notifier for '{fullPath}'");
 
             var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
             var allTasks = pipelineInvocationTasks.Values;
@@ -315,7 +315,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             pipelineInvocationTasks.Clear();
 
-            logger.Info("Notifier for " + fullPath + " stopped");
+            logger.Info($"Notifier for '{fullPath}' stopped");
 
             isRunning = false;
         }

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -106,11 +106,11 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public async Task Stop()
         {
-            logger.Info("Stopping messagepump");
+            logger.Info($"Stopping '{inputQueue}' messagepump");
 
             await topologyOperator.Stop().ConfigureAwait(false);
 
-            logger.Info("Messagepump stopped");
+            logger.Info($"Messagepump '{inputQueue}' stopped");
         }
 
         public void Dispose()

--- a/src/Transport/Topology/IStoppableTopology.cs
+++ b/src/Transport/Topology/IStoppableTopology.cs
@@ -1,0 +1,9 @@
+namespace NServiceBus.Transport.AzureServiceBus
+{
+    using System.Threading.Tasks;
+
+    public interface IStoppableTopology
+    {
+        Task Stop();
+    }
+}

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -3,13 +3,15 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using AzureServiceBus;
+    using Logging;
     using Routing;
     using Settings;
     using Transport;
     using Transport.AzureServiceBus;
 
-    public class EndpointOrientedTopology :ITopology
+    public class EndpointOrientedTopology :ITopology, IStoppableTopology
     {
+        ILog logger = LogManager.GetLogger(typeof(EndpointOrientedTopology));
         ITopologySectionManager topologySectionManager;
         ITransportPartsContainer container;
 
@@ -133,6 +135,13 @@ namespace NServiceBus
         public OutboundRoutingPolicy GetOutboundRoutingPolicy()
         {
             return new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
+        }
+
+        public Task Stop()
+        {
+            logger.Info("Closing messaging factories");
+            var factories = container.Resolve<IManageMessagingFactoryLifeCycle>();
+            return factories.CloseAll();
         }
     }
 }

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -5,13 +5,15 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using AzureServiceBus;
+    using Logging;
     using Routing;
     using Settings;
     using Transport;
     using Transport.AzureServiceBus;
 
-    public class ForwardingTopology : ITopology
+    public class ForwardingTopology : ITopology, IStoppableTopology
     {
+        ILog logger = LogManager.GetLogger(typeof(ForwardingTopology));
         ITopologySectionManager topologySectionManager;
         ITransportPartsContainer container;
 
@@ -145,6 +147,13 @@ namespace NServiceBus
         public OutboundRoutingPolicy GetOutboundRoutingPolicy()
         {
             return new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
+        }
+
+        public Task Stop()
+        {
+            logger.Info("Closing messaging factories");
+            var factories = container.Resolve<IManageMessagingFactoryLifeCycle>();
+            return factories.CloseAll();
         }
     }
 }

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -47,14 +47,10 @@ namespace NServiceBus.Transport.AzureServiceBus
             running = true;
         }
 
-        public async Task Stop()
+        public Task Stop()
         {
             logger.Info("Stopping notifiers");
-            await StopNotifiersForAsync(topology.Entities).ConfigureAwait(false);
-
-            logger.Info("Forcing messaging factories to close");
-            var factories = container.Resolve<IManageMessagingFactoryLifeCycle>();
-            await factories.CloseAll().ConfigureAwait(false);
+            return StopNotifiersForAsync(topology.Entities);
         }
 
         public void Start(IEnumerable<EntityInfo> subscriptions)


### PR DESCRIPTION
**WARNING**: Do NOT merge!

Related to #337, ObjectDisposedException thrown during shutdown, (first option described in https://github.com/Particular/NServiceBus.AzureServiceBus/issues/337#issuecomment-253947633).

Added `IStoppableTopology` interface to allow `AzureServiceBusTransport` during `Stop()` operation invoke topology to close factories. Operation that will take place once, after message receivers are closed.

@Particular/azure-service-bus-maintainers this is a breaking change and modification to the design we'll have to analyze and review. A candidate for a minor or next major as a breaking change.