### PR TITLE
Close message factories once and fix race on internal receivers

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -215,7 +215,7 @@
         public DiscriminatorBasedIndividualization(NServiceBus.Settings.ReadOnlySettings settings) { }
         public string Individualize(string endpointName) { }
     }
-    public class EndpointOrientedTopology : NServiceBus.Transport.AzureServiceBus.ITopology
+    public class EndpointOrientedTopology : NServiceBus.Transport.AzureServiceBus.IStoppableTopology, NServiceBus.Transport.AzureServiceBus.ITopology
     {
         public EndpointOrientedTopology() { }
         public bool HasNativePubSubSupport { get; }
@@ -228,6 +228,7 @@
         public System.Func<NServiceBus.Transport.IManageSubscriptions> GetSubscriptionManagerFactory() { }
         public void Initialize(NServiceBus.Settings.SettingsHolder settings) { }
         public System.Threading.Tasks.Task<NServiceBus.Transport.StartupCheckResult> RunPreStartupChecks() { }
+        public System.Threading.Tasks.Task Stop() { }
     }
     public enum EntityType
     {
@@ -248,7 +249,7 @@
         public FlatComposition() { }
         public string GetEntityPath(string entityname, NServiceBus.EntityType entityType) { }
     }
-    public class ForwardingTopology : NServiceBus.Transport.AzureServiceBus.ITopology
+    public class ForwardingTopology : NServiceBus.Transport.AzureServiceBus.IStoppableTopology, NServiceBus.Transport.AzureServiceBus.ITopology
     {
         public ForwardingTopology() { }
         public bool HasNativePubSubSupport { get; }
@@ -261,6 +262,7 @@
         public System.Func<NServiceBus.Transport.IManageSubscriptions> GetSubscriptionManagerFactory() { }
         public void Initialize(NServiceBus.Settings.SettingsHolder settings) { }
         public async System.Threading.Tasks.Task<NServiceBus.Transport.StartupCheckResult> RunPreStartupChecks() { }
+        public System.Threading.Tasks.Task Stop() { }
     }
     public class HierarchyComposition : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
     {

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -60,7 +60,6 @@
             // validate
             Assert.IsTrue(criticalErrorWasRaised, "Expected critical error to be raised, but it wasn't");
             Assert.AreEqual(exceptionThrownByMessagePump, exceptionReceivedByCircuitBreaker, "Exception circuit breaker got should be the same as the one raised by message pump");
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(30).TotalMilliseconds));
         }
 
         class FakeReceiveContext : ReceiveContext

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -3,7 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Threading.Tasks;
     using DelayedDelivery;
+    using NServiceBus.AzureServiceBus;
     using NServiceBus.AzureServiceBus.Topology.MetaModel;
     using Performance.TimeToBeReceived;
     using Routing;
@@ -19,6 +21,17 @@
             this.topology = topology;
             TransactionMode = supportedTransactionMode;
             this.satelliteTransportAddresses = satelliteTransportAddresses;
+        }
+
+        public override Task Stop()
+        {
+            var stoppableTopology = topology as IStoppableTopology;
+            if (stoppableTopology != null)
+            {
+                return stoppableTopology.Stop();
+            }
+
+            return TaskEx.Completed;
         }
 
         public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Sending\Time.cs" />
     <Compile Include="Topology\ConventionsAdapter.cs" />
     <Compile Include="Topology\IConventions.cs" />
+    <Compile Include="Topology\IStoppableTopology.cs" />
     <Compile Include="Topology\MetaModel\NamespacePurpose.cs" />
     <Compile Include="Topology\MetaModel\SatelliteTransportAddressCollection.cs" />
     <Compile Include="Utils\MessageReceiverExtensions.cs" />

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -303,7 +303,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             stopping = true;
 
-            logger.Info("Stopping notifier for " + fullPath);
+            logger.Info($"Stopping notifier for '{fullPath}'");
 
             var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
             var allTasks = pipelineInvocationTasks.Values;
@@ -326,7 +326,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             pipelineInvocationTasks.Clear();
 
-            logger.Info("Notifier for " + fullPath + " stopped");
+            logger.Info($"Notifier for '{fullPath}' stopped");
 
             isRunning = false;
         }

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         IManageMessageReceiverLifeCycle clientEntities;
         IConvertBrokeredMessagesToIncomingMessages brokeredMessageConverter;
         ReadOnlySettings settings;
-        IList<IMessageReceiver> internalReceivers = new List<IMessageReceiver>();
+        IMessageReceiver[] internalReceivers;
         ReceiveMode receiveMode;
         OnMessageOptions options;
         Func<IncomingMessageDetails, ReceiveContext, Task> incomingCallback;
@@ -82,6 +82,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             options.ExceptionReceived += OptionsOnExceptionReceived;
 
             batchedCompletionTasks = new Task[numberOfClients];
+            internalReceivers = new IMessageReceiver[numberOfClients];
         }
 
         void OptionsOnExceptionReceived(object sender, ExceptionReceivedEventArgs exceptionReceivedEventArgs)
@@ -141,9 +142,9 @@ namespace NServiceBus.Transport.AzureServiceBus
                     isRunning = true;
 
                     internalReceiver.OnMessage(callback, options);
-                PerformBatchedCompletionTask(internalReceiver, i);
+                    PerformBatchedCompletionTask(internalReceiver, i);
 
-                    internalReceivers.Add(internalReceiver);
+                    internalReceivers[i] = internalReceiver;
                 }
                 catch (Exception ex)
                 {

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -138,22 +138,20 @@ namespace NServiceBus.Transport.AzureServiceBus
                         }, TaskContinuationOptions.ExecuteSynchronously);
                         return processTask;
                     };
-
-                    isRunning = true;
-
+                    
                     internalReceiver.OnMessage(callback, options);
                     PerformBatchedCompletionTask(internalReceiver, i);
 
                     internalReceivers[i] = internalReceiver;
+
+                    isRunning = true;
                 }
                 catch (Exception ex)
                 {
                     exceptions.Enqueue(ex);
                 }
-
             });
             if (exceptions.Count > 0) throw new AggregateException(exceptions);
-
         }
 
         void PerformBatchedCompletionTask(IMessageReceiver internalReceiver, int index)

--- a/src/Transport/Topology/IStoppableTopology.cs
+++ b/src/Transport/Topology/IStoppableTopology.cs
@@ -1,0 +1,10 @@
+namespace NServiceBus.Transport.AzureServiceBus
+{
+    using System.Threading.Tasks;
+
+    // For now let's make this an internal interface in order to be able to hotfix the shutdown problem
+    interface IStoppableTopology
+    {
+        Task Stop();
+    }
+}

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -3,13 +3,15 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using AzureServiceBus;
+    using Logging;
     using Routing;
     using Settings;
     using Transport;
     using Transport.AzureServiceBus;
 
-    public class EndpointOrientedTopology :ITopology
+    public class EndpointOrientedTopology :ITopology, IStoppableTopology
     {
+        ILog logger = LogManager.GetLogger(typeof(EndpointOrientedTopology));
         ITopologySectionManager topologySectionManager;
         ITransportPartsContainer container;
 
@@ -133,6 +135,13 @@ namespace NServiceBus
         public OutboundRoutingPolicy GetOutboundRoutingPolicy()
         {
             return new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
+        }
+
+        public Task Stop()
+        {
+            logger.Info("Closing messaging factories");
+            var factories = container.Resolve<IManageMessagingFactoryLifeCycle>();
+            return factories.CloseAll();
         }
     }
 }

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -5,13 +5,15 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using AzureServiceBus;
+    using Logging;
     using Routing;
     using Settings;
     using Transport;
     using Transport.AzureServiceBus;
 
-    public class ForwardingTopology : ITopology
+    public class ForwardingTopology : ITopology, IStoppableTopology
     {
+        ILog logger = LogManager.GetLogger(typeof(ForwardingTopology));
         ITopologySectionManager topologySectionManager;
         ITransportPartsContainer container;
 
@@ -145,6 +147,13 @@ namespace NServiceBus
         public OutboundRoutingPolicy GetOutboundRoutingPolicy()
         {
             return new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Multicast, OutboundRoutingType.Unicast);
+        }
+
+        public Task Stop()
+        {
+            logger.Info("Closing messaging factories");
+            var factories = container.Resolve<IManageMessagingFactoryLifeCycle>();
+            return factories.CloseAll();
         }
     }
 }

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -47,21 +47,10 @@ namespace NServiceBus.Transport.AzureServiceBus
             running = true;
         }
 
-        public async Task Stop()
+        public Task Stop()
         {
             logger.Info("Stopping notifiers");
-            await StopNotifiersForAsync(topology.Entities).ConfigureAwait(false);
-
-            try
-            {
-                logger.Info("Forcing messaging factories to close");
-                var factories = container.Resolve<IManageMessagingFactoryLifeCycle>();
-                await factories.CloseAll().ConfigureAwait(false);
-            }
-            catch
-            {
-                logger.Debug("Factories already closed, skipping");
-            }
+            return StopNotifiersForAsync(topology.Entities);
         }
 
         public void Start(IEnumerable<EntityInfo> subscriptions)


### PR DESCRIPTION
Replaces https://github.com/Particular/NServiceBus.AzureServiceBus/pull/377/files
Closes #337
Closes #381

This PR takes @SeanFeldman changes from the above PR and brings them into hotfix-7.0.2 branch. The trade off is the following:

The stoppable topology interface is made internal. Inheriting internal interfaces on public types is a-non breaking change. The infrastructure checks whether the topology implements this internal type and then calls stop on it, if not it is a no-op.

This allows us to hotfix it since the object disposed bug can be reproduced with any of our samples out there. The downside of this is that any customer implementing a custom topology will potentially "leak" message factories. For cloud hosted scenarios outside the samples this is probably not a big deal since there is no such thing as a shutdown phase (the process would be started new).

This PR contains also a fix for a race condition in the message receive notifier which could lead to `NullReferenceExceptions` during shutdown (I'll raise an issue).