### PR TITLE
Make IStoppableTopology public

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -558,6 +558,10 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         string Sanitize(string entityPathOrName, NServiceBus.EntityType entityType);
     }
+    public interface IStoppableTopology
+    {
+        System.Threading.Tasks.Task Stop();
+    }
     public interface ITopology
     {
         bool HasNativePubSubSupport { get; }

--- a/src/Transport/Topology/IStoppableTopology.cs
+++ b/src/Transport/Topology/IStoppableTopology.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
 
     // For now let's make this an internal interface in order to be able to hotfix the shutdown problem
-    interface IStoppableTopology
+    public interface IStoppableTopology
     {
         Task Stop();
     }


### PR DESCRIPTION
## Who's affected

- Anyone implementing a custom topology with Azure Service Bus

## Symptoms

- `ForwardingTopology` and `EndpointOrientedTopology` introduced `Stop()` in a hotfix w/o a taking into consideration custom topologies. Therefore, custom topologies 

## Original issue

In version 7.0.2 both topologies introduced a public `Stop()` method which was a breaking SemVer change. In case a topology has special needs when a transport is stopping, there should be a contract to allow so. As `ITopology` cannot be modified until the next major, `IStoppableTopology` is introduced to allow the required behaviour.