### PR TITLE
Internalizing public types

### DIFF
--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -36,11 +36,11 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
 
         if (topology == nameof(ForwardingTopology))
         {
-            transportConfig.UseTopology<ForwardingTopology>();
+            transportConfig.UseForwardingTopology();
         }
         else
         {
-            transportConfig.UseTopology<EndpointOrientedTopology>()
+            transportConfig.UseEndpointOrientedTopology()
                 .RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V1Event), NameForEndpoint<When_multiple_versions_of_a_message_is_published.V2Publisher>())
                 .RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V2Event), NameForEndpoint<When_multiple_versions_of_a_message_is_published.V2Publisher>())
                 .RegisterPublisher(typeof(When_replies_to_message_published_by_a_saga.DidSomething), NameForEndpoint<When_replies_to_message_published_by_a_saga.SagaEndpoint>())

--- a/src/AcceptanceTests/Publishing/When_using_a_signle_bundle.cs
+++ b/src/AcceptanceTests/Publishing/When_using_a_signle_bundle.cs
@@ -31,7 +31,7 @@
                 EndpointSetup<DefaultServer>(config =>
                 {
                     var transport = config.UseTransport<AzureServiceBusTransport>();
-                    transport.UseTopology<ForwardingTopology>().NumberOfEntitiesInBundle(1);
+                    transport.UseForwardingTopology().NumberOfEntitiesInBundle(1);
                 });
             }
         }
@@ -43,7 +43,7 @@
                 EndpointSetup<DefaultServer>(config =>
                 {
                     var transport = config.UseTransport<AzureServiceBusTransport>();
-                    transport.UseTopology<ForwardingTopology>().NumberOfEntitiesInBundle(1);
+                    transport.UseForwardingTopology().NumberOfEntitiesInBundle(1);
                 })
                 .AddMapping<MyEvent>(typeof(Publisher));
             }

--- a/src/AcceptanceTests/Routing/When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs
+++ b/src/AcceptanceTests/Routing/When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs
@@ -99,7 +99,9 @@
 
                 protected override Task OnStart(IMessageSession session)
                 {
+#pragma warning disable 618
                     context.IsForwardingTopology = settings.Get<ITopology>() is ForwardingTopology;
+#pragma warning restore 618
                     return TaskEx.Completed;
                 }
 

--- a/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
+++ b/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
@@ -42,7 +42,9 @@
                 await Task.Delay(TimeSpan.FromSeconds(10));
 
                 var connectionString = Environment.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+#pragma warning disable 618
                 var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(connectionString));
+#pragma warning restore 618
                 var factory = MessagingFactory.CreateAsync(namespaceManager.Address, namespaceManager.Settings.TokenProvider).GetAwaiter().GetResult();
                 var dlqPath = Conventions.EndpointNamingConvention(typeof(Receiver)) + "/$DeadLetterQueue";
                 var receiver = await factory.CreateMessageReceiverAsync(dlqPath, ReceiveMode.ReceiveAndDelete).ConfigureAwait(false);

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -313,6 +313,8 @@ namespace NServiceBus.Config
 namespace NServiceBus.Transport.AzureServiceBus
 {
     
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class Batch
     {
         public Batch() { }
@@ -320,6 +322,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public System.Collections.Generic.IList<NServiceBus.Transport.AzureServiceBus.BatchedOperation> Operations { get; set; }
         public NServiceBus.Transport.DispatchConsistency RequiredDispatchConsistency { get; set; }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class BatchedOperation
     {
         public BatchedOperation(int messageSizePaddingPercentage = 0) { }
@@ -327,6 +331,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public NServiceBus.Transport.OutgoingMessage Message { get; set; }
         public long GetEstimatedSize() { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class BrokeredMessageReceiveContext : NServiceBus.Transport.AzureServiceBus.ReceiveContext
     {
         public BrokeredMessageReceiveContext(Microsoft.ServiceBus.Messaging.BrokeredMessage message, NServiceBus.Transport.AzureServiceBus.EntityInfo entity, Microsoft.ServiceBus.Messaging.ReceiveMode receiveMode) { }
@@ -348,6 +354,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public override string ToString() { }
         public static bool TryParse(string value, out NServiceBus.Transport.AzureServiceBus.ConnectionString connectionString) { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class EntityInfo
     {
         public EntityInfo() { }
@@ -377,14 +385,20 @@ namespace NServiceBus.Transport.AzureServiceBus
         Primary = 0,
         Secondary = 1,
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IBatcher
     {
         System.Collections.Generic.IList<NServiceBus.Transport.AzureServiceBus.Batch> ToBatches(NServiceBus.Transport.TransportOperations operations);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IBrokerSideSubscriptionFilter
     {
         string Serialize();
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IClientEntity
     {
         bool IsClosed { get; }
@@ -400,18 +414,26 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         string GetEntityPath(string entityname, NServiceBus.EntityType entityType);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IConvertBrokeredMessagesToIncomingMessages
     {
         NServiceBus.Transport.AzureServiceBus.IncomingMessageDetails Convert(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IConvertOutgoingMessagesToBrokeredMessages
     {
         System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> Convert(System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.BatchedOperation> outgoingOperations, NServiceBus.Transport.AzureServiceBus.RoutingOptions routingOptions);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateAzureServiceBusQueues
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> Create(string queuePath, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateAzureServiceBusSubscriptions
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> Create(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
@@ -420,22 +442,32 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> Create(string topicPath, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateMessageReceivers
     {
         System.Threading.Tasks.Task<NServiceBus.Transport.AzureServiceBus.IMessageReceiver> Create(string entityPath, string namespaceAlias);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateMessageSenders
     {
         System.Threading.Tasks.Task<NServiceBus.Transport.AzureServiceBus.IMessageSender> Create(string entitypath, string viaEntityPath, string namespaceName);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateMessagingFactories
     {
         NServiceBus.Transport.AzureServiceBus.IMessagingFactory Create(string namespaceName);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateNamespaceManagers
     {
         NServiceBus.Transport.AzureServiceBus.INamespaceManager Create(string namespaceName);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateTopology
     {
         System.Threading.Tasks.Task Create(NServiceBus.Transport.AzureServiceBus.TopologySection topology);
@@ -448,23 +480,33 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         string Individualize(string endpointName);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IManageMessageReceiverLifeCycle
     {
         NServiceBus.Transport.AzureServiceBus.IMessageReceiver Get(string entityPath, string namespaceAlias);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IManageMessageSenderLifeCycle
     {
         NServiceBus.Transport.AzureServiceBus.IMessageSender Get(string entitypath, string viaEntityPath, string namespaceName);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IManageMessagingFactoryLifeCycle
     {
         System.Threading.Tasks.Task CloseAll();
         NServiceBus.Transport.AzureServiceBus.IMessagingFactory Get(string namespaceName);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IManageNamespaceManagerLifeCycle
     {
         NServiceBus.Transport.AzureServiceBus.INamespaceManager Get(string namespaceAlias);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IMessageReceiver : NServiceBus.Transport.AzureServiceBus.IClientEntity
     {
         Microsoft.ServiceBus.Messaging.ReceiveMode Mode { get; }
@@ -473,11 +515,15 @@ namespace NServiceBus.Transport.AzureServiceBus
         System.Threading.Tasks.Task CompleteBatchAsync(System.Collections.Generic.IEnumerable<System.Guid> lockTokens);
         void OnMessage(System.Func<Microsoft.ServiceBus.Messaging.BrokeredMessage, System.Threading.Tasks.Task> callback, Microsoft.ServiceBus.Messaging.OnMessageOptions options);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IMessageSender : NServiceBus.Transport.AzureServiceBus.IClientEntity
     {
         System.Threading.Tasks.Task Send(Microsoft.ServiceBus.Messaging.BrokeredMessage message);
         System.Threading.Tasks.Task SendBatch(System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.BrokeredMessage> messages);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IMessagingFactory : NServiceBus.Transport.AzureServiceBus.IClientEntity
     {
         System.Threading.Tasks.Task CloseAsync();
@@ -485,6 +531,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         System.Threading.Tasks.Task<NServiceBus.Transport.AzureServiceBus.IMessageSender> CreateMessageSender(string entitypath);
         System.Threading.Tasks.Task<NServiceBus.Transport.AzureServiceBus.IMessageSender> CreateMessageSender(string entitypath, string viaEntityPath);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface INamespaceManager
     {
         System.Uri Address { get; }
@@ -511,6 +559,8 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class IncomingMessageDetails
     {
         public IncomingMessageDetails(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body) { }
@@ -528,6 +578,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         void Start();
         System.Threading.Tasks.Task Stop();
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IOperateTopology
     {
         void OnError(System.Func<System.Exception, System.Threading.Tasks.Task> func);
@@ -558,6 +610,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         System.Collections.Generic.IEnumerable<T> ResolveAll<T>();
         System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type typeToBuild);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IRouteOutgoingBatches
     {
         System.Threading.Tasks.Task RouteBatches(System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.Batch> outgoingBatches, NServiceBus.Transport.AzureServiceBus.ReceiveContext receiveContext, NServiceBus.Transport.DispatchConsistency consistency);
@@ -566,10 +620,8 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         string Sanitize(string entityPathOrName, NServiceBus.EntityType entityType);
     }
-    public interface IStoppableTopology
-    {
-        System.Threading.Tasks.Task Stop();
-    }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ITopology
     {
         bool HasNativePubSubSupport { get; }
@@ -583,6 +635,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         void Initialize(NServiceBus.Settings.SettingsHolder settings);
         System.Threading.Tasks.Task<NServiceBus.Transport.StartupCheckResult> RunPreStartupChecks();
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ITopologySectionManager
     {
         NServiceBus.Transport.AzureServiceBus.TopologySection DeterminePublishDestination(System.Type eventType);
@@ -661,6 +715,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         Sending = 1,
         Creating = 2,
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public abstract class ReceiveContext
     {
         protected ReceiveContext() { }
@@ -669,6 +725,8 @@ namespace NServiceBus.Transport.AzureServiceBus
             "version 9.0.0.", false)]
         public System.Transactions.CommittableTransaction Transaction { get; set; }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class RoutingOptions
     {
         public RoutingOptions() { }
@@ -679,6 +737,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public string ViaEntityPath { get; set; }
         public string ViaPartitionKey { get; set; }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class RuntimeNamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo>
     {
         public RuntimeNamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1, NServiceBus.Transport.AzureServiceBus.NamespaceMode mode = 0) { }
@@ -714,6 +774,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public ThrowOnOversizedBrokeredMessages() { }
         public System.Threading.Tasks.Task Handle(Microsoft.ServiceBus.Messaging.BrokeredMessage brokeredMessage) { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class TopologySection
     {
         public TopologySection() { }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -390,6 +390,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         bool IsClosed { get; }
         Microsoft.ServiceBus.RetryPolicy RetryPolicy { get; set; }
     }
+    [System.ObsoleteAttribute("Internal unutilized contract that shouldn\'t be exposed. Will be treated as an err" +
+        "or from version 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IClientSideSubscriptionFilter
     {
         bool Execute(object message);
@@ -691,6 +693,8 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         public SubscriptionInfo() { }
         public NServiceBus.Transport.AzureServiceBus.IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.Transport.AzureServiceBus.IClientSideSubscriptionFilter ClientSideFilter { get; set; }
         public NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata Metadata { get; set; }
     }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -534,6 +534,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         System.Threading.Tasks.Task Stop();
         System.Threading.Tasks.Task Stop(System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.EntityInfo> subscriptions);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IRegisterTransportParts
     {
         void Register<T>();
@@ -543,6 +545,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         void RegisterSingleton<T>();
         void RegisterSingleton(System.Type t);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IResolveTransportParts
     {
         object Resolve(System.Type typeToBuild);
@@ -584,6 +588,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         NServiceBus.Transport.AzureServiceBus.TopologySection DetermineResourcesToUnsubscribeFrom(System.Type eventtype);
         NServiceBus.Transport.AzureServiceBus.TopologySection DetermineSendDestination(string destination);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ITransportPartsContainer : NServiceBus.Transport.AzureServiceBus.IRegisterTransportParts, NServiceBus.Transport.AzureServiceBus.IResolveTransportParts { }
     public class MessageTooLargeException : System.Exception
     {

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -516,6 +516,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface INotifyIncomingMessages
     {
         bool IsRunning { get; }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -505,6 +505,8 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> Create(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ICreateAzureServiceBusTopics
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> Create(string topicPath, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager);

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -193,15 +193,30 @@
         public static NServiceBus.AzureServiceBusSubscriptionSettings Subscriptions(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.AzureServiceBusTopicSettings Topics(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void TransportType(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Microsoft.ServiceBus.Messaging.TransportType transportType) { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static void UseBrokeredMessageToIncomingMessageConverter<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.Transport.AzureServiceBus.IConvertBrokeredMessagesToIncomingMessages { }
+        public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.EndpointOrientedTopology> UseEndpointOrientedTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.ForwardingTopology> UseForwardingTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void UseNamespaceAliasesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static void UseOutgoingMessageToBrokeredMessageConverter<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.Transport.AzureServiceBus.IConvertOutgoingMessagesToBrokeredMessages { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Use `transport.UseForwardingTopology" +
+            "() or transport.UseEndpointOrientedTopology()` instead. Will be treated as an er" +
+            "ror from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.Transport.AzureServiceBus.ITopology, new () { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Use `transport.UseForwardingTopology" +
+            "() or transport.UseEndpointOrientedTopology()` instead. Will be treated as an er" +
+            "ror from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<T> factory)
             where T : NServiceBus.Transport.AzureServiceBus.ITopology { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Use `transport.UseForwardingTopology" +
+            "() or transport.UseEndpointOrientedTopology()` instead. Will be treated as an er" +
+            "ror from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<T> UseTopology<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, T topology)
             where T : NServiceBus.Transport.AzureServiceBus.ITopology { }
     }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -341,6 +341,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public Microsoft.ServiceBus.Messaging.ReceiveMode ReceiveMode { get; }
         public bool Recovering { get; set; }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class ConnectionString : System.IEquatable<NServiceBus.Transport.AzureServiceBus.ConnectionString>
     {
         public ConnectionString(string value) { }
@@ -368,6 +370,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class EntityRelationShipInfo
     {
         public EntityRelationShipInfo() { }
@@ -656,6 +660,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public MessageTooLargeException(string message, System.Exception inner) { }
         protected MessageTooLargeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class NamespaceConfigurations : System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.NamespaceInfo>, System.Collections.IEnumerable
     {
         public NamespaceConfigurations() { }
@@ -664,6 +670,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public string GetConnectionString(string name) { }
         public System.Collections.Generic.IEnumerator<NServiceBus.Transport.AzureServiceBus.NamespaceInfo> GetEnumerator() { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class NamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.NamespaceInfo>
     {
         public NamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1) { }
@@ -674,6 +682,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class NamespaceManagerAdapter : NServiceBus.Transport.AzureServiceBus.INamespaceManager, NServiceBus.Transport.AzureServiceBus.INamespaceManagerAbleToDeleteSubscriptions
     {
         public NamespaceManagerAdapter(Microsoft.ServiceBus.NamespaceManager manager) { }
@@ -749,6 +759,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class SubscriptionInfo : NServiceBus.Transport.AzureServiceBus.EntityInfo
     {
         public SubscriptionInfo() { }
@@ -758,6 +770,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public NServiceBus.Transport.AzureServiceBus.IClientSideSubscriptionFilter ClientSideFilter { get; set; }
         public NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata Metadata { get; set; }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class SubscriptionMetadata
     {
         public SubscriptionMetadata() { }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -4,10 +4,14 @@
     public class AzureServiceBusCompositionExtensionPoint<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
         where T : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusCompositionExtensionPoint(NServiceBus.Settings.SettingsHolder settings) { }
     }
     public class AzureServiceBusCompositionSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusCompositionSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusCompositionExtensionPoint<T> UseStrategy<T>()
             where T : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy { }
@@ -33,16 +37,22 @@
     public class AzureServiceBusIndividualizationExtensionPoint<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
         where T : NServiceBus.Transport.AzureServiceBus.IIndividualizationStrategy
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusIndividualizationExtensionPoint(NServiceBus.Settings.SettingsHolder settings) { }
     }
     public class AzureServiceBusIndividualizationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusIndividualizationSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusIndividualizationExtensionPoint<T> UseStrategy<T>()
             where T : NServiceBus.Transport.AzureServiceBus.IIndividualizationStrategy { }
     }
     public class AzureServiceBusMessageReceiverSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusMessageReceiverSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusMessageReceiverSettings AutoRenewTimeout(System.TimeSpan autoRenewTimeout) { }
         public NServiceBus.AzureServiceBusMessageReceiverSettings PrefetchCount(int prefetchCount) { }
@@ -51,6 +61,8 @@
     }
     public class AzureServiceBusMessageSenderSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusMessageSenderSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusMessageSenderSettings BackOffTimeOnThrottle(System.TimeSpan backoffTime) { }
         public NServiceBus.AzureServiceBusMessageSenderSettings MaximuMessageSizeInKilobytes(int sizeInKilobytes) { }
@@ -62,6 +74,8 @@
     }
     public class AzureServiceBusMessagingFactoriesSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusMessagingFactoriesSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusMessagingFactoriesSettings BatchFlushInterval(System.TimeSpan batchFlushInterval) { }
         public NServiceBus.AzureServiceBusMessagingFactoriesSettings MessagingFactorySettingsFactory(System.Func<string, Microsoft.ServiceBus.Messaging.MessagingFactorySettings> factory) { }
@@ -70,6 +84,8 @@
     }
     public class AzureServiceBusNamespaceManagersSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusNamespaceManagersSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusNamespaceManagersSettings NamespaceManagerSettingsFactory(System.Func<string, Microsoft.ServiceBus.NamespaceManagerSettings> factory) { }
         public NServiceBus.AzureServiceBusNamespaceManagersSettings RetryPolicy(Microsoft.ServiceBus.RetryPolicy retryPolicy) { }
@@ -77,6 +93,8 @@
     }
     public class AzureServiceBusNamespacePartitioningSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusNamespacePartitioningSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public void AddNamespace(string name, string connectionString) { }
         public NServiceBus.AzureServiceBusNamespacePartitioningSettings UseStrategy<T>()
@@ -84,11 +102,15 @@
     }
     public class AzureServiceBusNamespaceRoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusNamespaceRoutingSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public void AddNamespace(string name, string connectionString) { }
     }
     public class AzureServiceBusQueueSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusQueueSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusQueueSettings AutoDeleteOnIdle(System.TimeSpan autoDeleteOnIdle) { }
         public NServiceBus.AzureServiceBusQueueSettings DefaultMessageTimeToLive(System.TimeSpan defaultMessageTimeToLive) { }
@@ -110,6 +132,8 @@
     public class AzureServiceBusSanitizationExtensionPoint<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
         where T : NServiceBus.Transport.AzureServiceBus.ISanitizationStrategy
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusSanitizationExtensionPoint(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusSanitizationExtensionPoint<T> Hash(System.Func<string, string> hash) { }
         public NServiceBus.AzureServiceBusSanitizationExtensionPoint<T> QueuePathSanitization(System.Func<string, string> queuePathSanitizer) { }
@@ -123,6 +147,8 @@
     }
     public class AzureServiceBusSanitizationSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusSanitizationSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusSanitizationSettings UseQueuePathMaximumLength(int queuePathMaximumLength) { }
         public NServiceBus.AzureServiceBusSanitizationSettings UseRulePathMaximumLength(int rulePathMaximumLength) { }
@@ -133,6 +159,8 @@
     }
     public class AzureServiceBusSubscriptionSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusSubscriptionSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusSubscriptionSettings AutoDeleteOnIdle(System.TimeSpan autoDeleteOnIdle) { }
         public NServiceBus.AzureServiceBusSubscriptionSettings DefaultMessageTimeToLive(System.TimeSpan expiryTimespan) { }
@@ -147,6 +175,8 @@
     }
     public class AzureServiceBusTopicSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusTopicSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.AzureServiceBusTopicSettings AutoDeleteOnIdle(System.TimeSpan autoDeleteOnIdle) { }
         public NServiceBus.AzureServiceBusTopicSettings DefaultMessageTimeToLive(System.TimeSpan timeToLive) { }
@@ -164,6 +194,8 @@
     public class AzureServiceBusTopologySettings<T> : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport>
         where T : NServiceBus.Transport.AzureServiceBus.ITopology
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public AzureServiceBusTopologySettings(NServiceBus.Settings.SettingsHolder settings) { }
     }
     public class AzureServiceBusTransport : NServiceBus.Transport.TransportDefinition

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -20,15 +20,29 @@
     {
         public static NServiceBus.AzureServiceBusIndividualizationExtensionPoint<NServiceBus.DiscriminatorBasedIndividualization> DiscriminatorGenerator(this NServiceBus.AzureServiceBusIndividualizationExtensionPoint<NServiceBus.DiscriminatorBasedIndividualization> individualizationStrategy, System.Func<string, string> discriminatorGenerator) { }
     }
+    public class AzureServiceBusEndpointOrientedTopologySettings : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> { }
     public class static AzureServiceBusEndpointOrientedTopologySettingsExtensions
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.EndpointOrientedTopology> RegisterPublisher(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.EndpointOrientedTopology> topologySettings, System.Type type, string publisherName) { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.EndpointOrientedTopology> RegisterPublisher(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.EndpointOrientedTopology> topologySettings, System.Reflection.Assembly assembly, string publisherName) { }
+        public static NServiceBus.AzureServiceBusEndpointOrientedTopologySettings RegisterPublisher(this NServiceBus.AzureServiceBusEndpointOrientedTopologySettings topologySettings, System.Type type, string publisherName) { }
+        public static NServiceBus.AzureServiceBusEndpointOrientedTopologySettings RegisterPublisher(this NServiceBus.AzureServiceBusEndpointOrientedTopologySettings topologySettings, System.Reflection.Assembly assembly, string publisherName) { }
     }
+    public class AzureServiceBusForwardingTopologySettings : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> { }
     public class static AzureServiceBusForwardingTopologySettingsExtensions
     {
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.ForwardingTopology> BundlePrefix(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.ForwardingTopology> topologySettings, string prefix) { }
+        public static NServiceBus.AzureServiceBusForwardingTopologySettings BundlePrefix(this NServiceBus.AzureServiceBusForwardingTopologySettings topologySettings, string prefix) { }
+        [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+            "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.ForwardingTopology> NumberOfEntitiesInBundle(this NServiceBus.AzureServiceBusTopologySettings<NServiceBus.ForwardingTopology> topologySettings, int number) { }
+        public static NServiceBus.AzureServiceBusForwardingTopologySettings NumberOfEntitiesInBundle(this NServiceBus.AzureServiceBusForwardingTopologySettings topologySettings, int number) { }
     }
     public class static AzureServiceBusHierarchyCompositionSettingsExtensions
     {
@@ -191,6 +205,8 @@
         public NServiceBus.AzureServiceBusTopicSettings RequiresDuplicateDetection(bool requiresDuplicateDetection) { }
         public NServiceBus.AzureServiceBusTopicSettings SupportOrdering(bool supported) { }
     }
+    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
+        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class AzureServiceBusTopologySettings<T> : NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport>
         where T : NServiceBus.Transport.AzureServiceBus.ITopology
     {
@@ -229,8 +245,8 @@
             "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public static void UseBrokeredMessageToIncomingMessageConverter<T>(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions)
             where T : NServiceBus.Transport.AzureServiceBus.IConvertBrokeredMessagesToIncomingMessages { }
-        public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.EndpointOrientedTopology> UseEndpointOrientedTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
-        public static NServiceBus.AzureServiceBusTopologySettings<NServiceBus.ForwardingTopology> UseForwardingTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusEndpointOrientedTopologySettings UseEndpointOrientedTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.AzureServiceBusForwardingTopologySettings UseForwardingTopology(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static void UseNamespaceAliasesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
             "sion 8.0.0. Will be removed in version 9.0.0.", false)]

--- a/src/Tests/Addressing/Individualization/When_using_discriminator_individualization_strategy.cs
+++ b/src/Tests/Addressing/Individualization/When_using_discriminator_individualization_strategy.cs
@@ -15,7 +15,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Individualiz
             const string discriminator = "-mydiscriminator";
 
             var settingsHolder = new SettingsHolder();
+#pragma warning disable 618
             var config = new AzureServiceBusIndividualizationSettings(settingsHolder);
+#pragma warning restore 618
             config.UseStrategy<DiscriminatorBasedIndividualization>().DiscriminatorGenerator(endpointName => discriminator);
 
             var strategy = new DiscriminatorBasedIndividualization(settingsHolder);
@@ -29,7 +31,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Individualiz
             const string endpointname = "myendpoint";
 
             var settingsHolder = new SettingsHolder();
+#pragma warning disable 618
             var config = new AzureServiceBusIndividualizationSettings(settingsHolder);
+#pragma warning restore 618
             config.UseStrategy<DiscriminatorBasedIndividualization>();
 
             var strategy = new DiscriminatorBasedIndividualization(settingsHolder);

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_failover_namespace_strategy.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_failover_namespace_strategy.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
     using NUnit.Framework;
     using Transport.AzureServiceBus;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_using_failover_namespace_strategy

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_roundrobin_strategy_on_multiple_namespaces.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_roundrobin_strategy_on_multiple_namespaces.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
     using Transport.AzureServiceBus;
     using NUnit.Framework;
 
+    #pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_using_roundrobin_strategy_on_multiple_namespaces

--- a/src/Tests/Addressing/NamespacePartitioning/When_using_single_namespace_strategy.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_single_namespace_strategy.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_using_single_namespace_strategy

--- a/src/Tests/Configuration/When_configuring.cs
+++ b/src/Tests/Configuration/When_configuring.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 {
-    using FakeItEasy;
-    using Transport.AzureServiceBus;
     using Settings;
     using NUnit.Framework;
 
@@ -14,9 +12,9 @@
         {
             var settings = new SettingsHolder();
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-#pragma warning disable 618
-            var topologySettings = extensions.UseTopology(A.Fake<ITopology>);
-#pragma warning restore 618
+
+            var topologySettings = extensions.UseForwardingTopology();
+
             Assert.IsInstanceOf<TransportExtensions<AzureServiceBusTransport>>(topologySettings);
         }
 

--- a/src/Tests/Configuration/When_configuring.cs
+++ b/src/Tests/Configuration/When_configuring.cs
@@ -14,9 +14,9 @@
         {
             var settings = new SettingsHolder();
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
+#pragma warning disable 618
             var topologySettings = extensions.UseTopology(A.Fake<ITopology>);
-
+#pragma warning restore 618
             Assert.IsInstanceOf<TransportExtensions<AzureServiceBusTransport>>(topologySettings);
         }
 

--- a/src/Tests/Configuration/When_configuring_custom_brokered_message_to_incoming_message_converter.cs
+++ b/src/Tests/Configuration/When_configuring_custom_brokered_message_to_incoming_message_converter.cs
@@ -25,9 +25,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         {
             var settings = new SettingsHolder();
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
+#pragma warning disable 618
             extensions.UseBrokeredMessageToIncomingMessageConverter<ConvertBrokeredMessagesToIncomingMessages>();
-
+#pragma warning restore 618
             Assert.AreEqual(typeof(ConvertBrokeredMessagesToIncomingMessages), settings.Get<Type>(WellKnownConfigurationKeys.BrokeredMessageConventions.ToIncomingMessageConverter));
         }
 

--- a/src/Tests/Configuration/When_configuring_custom_brokered_message_to_incoming_message_converter.cs
+++ b/src/Tests/Configuration/When_configuring_custom_brokered_message_to_incoming_message_converter.cs
@@ -31,6 +31,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
             Assert.AreEqual(typeof(ConvertBrokeredMessagesToIncomingMessages), settings.Get<Type>(WellKnownConfigurationKeys.BrokeredMessageConventions.ToIncomingMessageConverter));
         }
 
+#pragma warning disable 618
         class ConvertBrokeredMessagesToIncomingMessages : IConvertBrokeredMessagesToIncomingMessages
         {
             public IncomingMessageDetails Convert(BrokeredMessage brokeredMessage)
@@ -38,5 +39,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
                 throw new NotImplementedException();
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Configuration/When_configuring_custom_outgoing_message_to_brokered_message_converter.cs
+++ b/src/Tests/Configuration/When_configuring_custom_outgoing_message_to_brokered_message_converter.cs
@@ -32,6 +32,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
             Assert.AreEqual(typeof(ConvertOutgoingMessagesToBrokeredMessages), settings.Get<Type>(WellKnownConfigurationKeys.BrokeredMessageConventions.FromOutgoingMessageConverter));
         }
 
+#pragma warning disable 618
         class ConvertOutgoingMessagesToBrokeredMessages : IConvertOutgoingMessagesToBrokeredMessages
         {
             public IEnumerable<BrokeredMessage> Convert(IEnumerable<BatchedOperation> outgoingOperations, RoutingOptions routingOptions)
@@ -39,5 +40,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
                 throw new NotImplementedException();
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Configuration/When_configuring_custom_outgoing_message_to_brokered_message_converter.cs
+++ b/src/Tests/Configuration/When_configuring_custom_outgoing_message_to_brokered_message_converter.cs
@@ -26,9 +26,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
         {
             var settings = new SettingsHolder();
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
+#pragma warning disable 618
             extensions.UseOutgoingMessageToBrokeredMessageConverter<ConvertOutgoingMessagesToBrokeredMessages>();
-
+#pragma warning restore 618
             Assert.AreEqual(typeof(ConvertOutgoingMessagesToBrokeredMessages), settings.Get<Type>(WellKnownConfigurationKeys.BrokeredMessageConventions.FromOutgoingMessageConverter));
         }
 

--- a/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
+++ b/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
@@ -37,6 +37,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
             CollectionAssert.Contains(namespacesDefinition, new NamespaceInfo(name, connectionString));
         }
 
+#pragma warning disable 618
         class MyNamespacePartitioningStrategy : INamespacePartitioningStrategy
         {
             public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
@@ -44,7 +45,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
                 throw new NotImplementedException(); // not relevant for the test
             }
         }
-
-
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
+++ b/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_configuring_namespace_partitioning
@@ -37,7 +38,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
             CollectionAssert.Contains(namespacesDefinition, new NamespaceInfo(name, connectionString));
         }
 
-#pragma warning disable 618
         class MyNamespacePartitioningStrategy : INamespacePartitioningStrategy
         {
             public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
@@ -45,6 +45,5 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
                 throw new NotImplementedException(); // not relevant for the test
             }
         }
-#pragma warning restore 618
     }
 }

--- a/src/Tests/Configuration/When_configuring_publishers.cs
+++ b/src/Tests/Configuration/When_configuring_publishers.cs
@@ -23,7 +23,7 @@
         [Test]
         public void Should_be_able_to_add_a_publisher_for_a_specific_event()
         {
-            extensions.UseTopology<EndpointOrientedTopology>()
+            extensions.UseEndpointOrientedTopology()
                 .RegisterPublisher(typeof(MyType), "publisherName");
 
             var publishers = settings.Get<IDictionary<string, List<ITypesScanner>>>(WellKnownConfigurationKeys.Topology.Publishers);
@@ -35,7 +35,7 @@
         [Test]
         public void Should_be_able_to_add_a_publisher_for_the_events_contained_in_an_assembly()
         {
-            extensions.UseTopology<EndpointOrientedTopology>()
+            extensions.UseEndpointOrientedTopology()
                 .RegisterPublisher(Assembly.GetExecutingAssembly(), "publisherName");
 
             var publishers = settings.Get<IDictionary<string, List<ITypesScanner>>>(WellKnownConfigurationKeys.Topology.Publishers);

--- a/src/Tests/Connectivity/When_creating_message_receivers.cs
+++ b/src/Tests/Connectivity/When_creating_message_receivers.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_message_receivers
@@ -52,6 +53,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             Assert.AreEqual(1000, receiver.PrefetchCount);
         }
 
+#pragma warning disable 618
         class InterceptedMessagingFactoryFactory : IManageMessagingFactoryLifeCycle
         {
             readonly IMessagingFactory factory;
@@ -135,5 +137,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
                 throw new NotImplementedException();
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Connectivity/When_creating_message_senders.cs
+++ b/src/Tests/Connectivity/When_creating_message_senders.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_message_senders
@@ -48,6 +49,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             Assert.IsInstanceOf<NoRetry>(sender.RetryPolicy);
         }
 
+#pragma warning disable 618
         class InterceptedMessagingFactoryFactory : IManageMessagingFactoryLifeCycle
         {
             readonly IMessagingFactory factory;
@@ -125,5 +127,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
                 throw new NotImplementedException();
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Connectivity/When_creating_messaging_factories.cs
+++ b/src/Tests/Connectivity/When_creating_messaging_factories.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_messaging_factories

--- a/src/Tests/Connectivity/When_creating_namespace_managers.cs
+++ b/src/Tests/Connectivity/When_creating_namespace_managers.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_namespace_managers

--- a/src/Tests/Connectivity/When_executing_task_with_retry.cs
+++ b/src/Tests/Connectivity/When_executing_task_with_retry.cs
@@ -8,6 +8,7 @@
     using Transport.AzureServiceBus;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
 

--- a/src/Tests/Connectivity/When_managing_client_entity_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_client_entity_lifecycle.cs
@@ -78,6 +78,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             Assert.AreNotEqual(first, second);
         }
 
+#pragma warning disable 618
         class InterceptedMessageReceiverCreator : ICreateMessageReceivers
         {
 
@@ -122,5 +123,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
                 isClosed = true;
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Connectivity/When_managing_factory_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_factory_lifecycle.cs
@@ -76,6 +76,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             Assert.AreNotEqual(first, second);
         }
 
+#pragma warning disable 618
         class InterceptedFactoryCreator : ICreateMessagingFactories
         {
             public int InvocationCount = 0;
@@ -125,5 +126,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
                 throw new System.NotImplementedException();
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Connectivity/When_managing_namespace_manager_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_namespace_manager_lifecycle.cs
@@ -39,6 +39,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             Assert.AreEqual(first, second);
         }
 
+#pragma warning disable 618
         class InterceptingCreator : ICreateNamespaceManagers
         {
             public bool HasBeenInvoked;
@@ -155,5 +156,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
                 throw new NotImplementedException();
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Creation/When_creating_forwarding_subscription.cs
+++ b/src/Tests/Creation/When_creating_forwarding_subscription.cs
@@ -106,7 +106,7 @@
                 LockDuration = TimeSpan.FromMinutes(3)
             };
 
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().DescriptionFactory((x, y, z) => subscriptionDescription);
+            extensions.UseForwardingTopology().Subscriptions().DescriptionFactory((x, y, z) => subscriptionDescription);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -127,7 +127,7 @@
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var autoDeleteTime = TimeSpan.FromDays(1);
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().AutoDeleteOnIdle(autoDeleteTime);
+            extensions.UseForwardingTopology().Subscriptions().AutoDeleteOnIdle(autoDeleteTime);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -154,7 +154,7 @@
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var timeToLive = TimeSpan.FromDays(10);
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().DefaultMessageTimeToLive(timeToLive);
+            extensions.UseForwardingTopology().Subscriptions().DefaultMessageTimeToLive(timeToLive);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -176,7 +176,7 @@
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().EnableBatchedOperations(false);
+            extensions.UseForwardingTopology().Subscriptions().EnableBatchedOperations(false);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -198,7 +198,7 @@
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().EnableDeadLetteringOnFilterEvaluationExceptions(true);
+            extensions.UseForwardingTopology().Subscriptions().EnableDeadLetteringOnFilterEvaluationExceptions(true);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -220,7 +220,7 @@
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().EnableDeadLetteringOnMessageExpiration(true);
+            extensions.UseForwardingTopology().Subscriptions().EnableDeadLetteringOnMessageExpiration(true);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -243,7 +243,7 @@
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             var lockDuration = TimeSpan.FromMinutes(2);
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().LockDuration(lockDuration);
+            extensions.UseForwardingTopology().Subscriptions().LockDuration(lockDuration);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -266,7 +266,7 @@
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             const int deliveryCount = 10;
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().MaxDeliveryCount(deliveryCount);
+            extensions.UseForwardingTopology().Subscriptions().MaxDeliveryCount(deliveryCount);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -314,7 +314,7 @@
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().ForwardDeadLetteredMessagesTo(topicToForwardTo.Path);
+            extensions.UseForwardingTopology().Subscriptions().ForwardDeadLetteredMessagesTo(topicToForwardTo.Path);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -341,7 +341,7 @@
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().ForwardDeadLetteredMessagesTo(subName => subName == "endpoint14", notUsedEntity.Path);
+            extensions.UseForwardingTopology().Subscriptions().ForwardDeadLetteredMessagesTo(subName => subName == "endpoint14", notUsedEntity.Path);
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -390,7 +390,7 @@
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().DescriptionFactory((topic, subName, readOnlySettings) => new SubscriptionDescription(topic, subName)
+            extensions.UseForwardingTopology().Subscriptions().DescriptionFactory((topic, subName, readOnlySettings) => new SubscriptionDescription(topic, subName)
             {
                 MaxDeliveryCount = 100,
                 EnableDeadLetteringOnMessageExpiration = true,
@@ -415,7 +415,7 @@
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().DescriptionFactory((topic, sub, readOnlySettings) => new SubscriptionDescription(topic, sub)
+            extensions.UseForwardingTopology().Subscriptions().DescriptionFactory((topic, sub, readOnlySettings) => new SubscriptionDescription(topic, sub)
             {
                 EnableDeadLetteringOnFilterEvaluationExceptions = false,
                 RequiresSession = false,
@@ -432,7 +432,7 @@
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-            extensions.UseTopology<ForwardingTopology>().Subscriptions().DescriptionFactory((topic, subName, readOnlySettings) => new SubscriptionDescription(topic, subName)
+            extensions.UseForwardingTopology().Subscriptions().DescriptionFactory((topic, subName, readOnlySettings) => new SubscriptionDescription(topic, subName)
             {
                 MaxDeliveryCount = 100,
                 EnableDeadLetteringOnMessageExpiration = true,
@@ -463,7 +463,7 @@
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-            extensions.UseTopology<ForwardingTopology>().Topics().EnablePartitioning(true);
+            extensions.UseForwardingTopology().Topics().EnablePartitioning(true);
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);

--- a/src/Tests/Creation/When_creating_forwarding_subscription.cs
+++ b/src/Tests/Creation/When_creating_forwarding_subscription.cs
@@ -11,6 +11,7 @@
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_forwarding_subscription

--- a/src/Tests/Creation/When_creating_queues.cs
+++ b/src/Tests/Creation/When_creating_queues.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
     using NUnit.Framework;
     using Transport;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_queues

--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -11,6 +11,7 @@
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_subscription

--- a/src/Tests/Creation/When_creating_subscription_backward_compatible_with_v6.cs
+++ b/src/Tests/Creation/When_creating_subscription_backward_compatible_with_v6.cs
@@ -10,6 +10,7 @@
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_subscription_backward_compatible_with_v6

--- a/src/Tests/Creation/When_creating_topics.cs
+++ b/src/Tests/Creation/When_creating_topics.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_creating_topics

--- a/src/Tests/PreStartupChecks/When_all_pre_startup_checks_for_forwarding_topology_fail.cs
+++ b/src/Tests/PreStartupChecks/When_all_pre_startup_checks_for_forwarding_topology_fail.cs
@@ -8,6 +8,7 @@
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_all_pre_startup_checks_for_forwarding_topology_fail

--- a/src/Tests/PreStartupChecks/When_execute_manage_rights_startup_check.cs
+++ b/src/Tests/PreStartupChecks/When_execute_manage_rights_startup_check.cs
@@ -7,6 +7,7 @@
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_execute_manage_rights_startup_check

--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -14,6 +14,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_comparing_performance_for_prefetch

--- a/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
+++ b/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_incoming_message_processing_takes_longer_than_LockDuration

--- a/src/Tests/Receiving/When_receiving_brokeredmessages_from_queues.cs
+++ b/src/Tests/Receiving/When_receiving_brokeredmessages_from_queues.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_receiving_brokeredmessages_from_queues

--- a/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
+++ b/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_receiving_incomingmessages_from_queues

--- a/src/Tests/Seam/When_dispatching_messages.cs
+++ b/src/Tests/Seam/When_dispatching_messages.cs
@@ -87,7 +87,7 @@
             Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () => await dispatcher.Dispatch(new TransportOperations(), new TransportTransaction(), new ContextBag()));
         }
 
-
+#pragma warning disable 618
         class FakeBatcher : IBatcher
         {
             public IList<Batch> ToBatches(TransportOperations operations)
@@ -174,5 +174,6 @@
                 };
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Seam/When_dispatching_messages.cs
+++ b/src/Tests/Seam/When_dispatching_messages.cs
@@ -14,6 +14,7 @@
     using NUnit.Framework;
     using Transport;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_dispatching_messages

--- a/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
+++ b/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
@@ -17,6 +17,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_dispatching_messages_in_receive_context

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -11,6 +11,7 @@
     using Transport;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_message_pump_is_failing_to_receive_messages
@@ -62,6 +63,7 @@
             Assert.AreEqual(exceptionThrownByMessagePump, exceptionReceivedByCircuitBreaker, "Exception circuit breaker got should be the same as the one raised by message pump");
         }
 
+#pragma warning disable 618
         class FakeReceiveContext : ReceiveContext
         {
         }
@@ -143,6 +145,7 @@
 
             }
         }
+#pragma warning restore 618
 
         class FakeEndpoint : IEndpointInstance
         {

--- a/src/Tests/Seam/When_receiving_messages.cs
+++ b/src/Tests/Seam/When_receiving_messages.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
     using Transport;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_receiving_messages

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -119,6 +119,7 @@
     {
     }
 
+#pragma warning disable 618
     public class FakeTopolySectionManager : ITopologySectionManager
     {
         public TopologySection DetermineReceiveResources(string inputQueue)
@@ -163,5 +164,6 @@
         {
             throw new NotImplementedException();
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
+++ b/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_comparing_performance_between_built_in_batching_and_manual

--- a/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
+++ b/src/Tests/Sending/When_converting_outgoing_messages_to_brokered_messages.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
     using Transport;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_converting_outgoing_messages_to_brokered_messages

--- a/src/Tests/Sending/When_retrying_on_throttle.cs
+++ b/src/Tests/Sending/When_retrying_on_throttle.cs
@@ -84,6 +84,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
             Assert.IsTrue(sw.ElapsedMilliseconds > TimeSpan.FromSeconds(4).TotalMilliseconds);
         }
 
+#pragma warning disable 618
         class FakeMessageSender : IMessageSender
         {
             public bool IsClosed { get; } = false;
@@ -116,5 +117,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
                 return TaskEx.Completed;
             }
         }
+#pragma warning restore 618
     }
 }

--- a/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints.cs
+++ b/src/Tests/Sending/When_routing_outgoingmessages_to_endpoints.cs
@@ -13,6 +13,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
     using Transport;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_routing_outgoingmessages_to_endpoints

--- a/src/Tests/Sending/When_sending_brokeredmessages_to_queues.cs
+++ b/src/Tests/Sending/When_sending_brokeredmessages_to_queues.cs
@@ -8,6 +8,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_sending_brokeredmessages_to_queues

--- a/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     using NUnit.Framework;
     using Transport;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_computing_EndpointOrientedTopology
@@ -92,6 +93,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             Assert.AreEqual(1, definition.Entities.Count(ei => ei.Path == "sales.events" && ei.Type == EntityType.Topic && ei.Namespace.ConnectionString == Connectionstring));
         }
 
+#pragma warning disable 618
         static TopologySection DetermineResourcesToCreate(SettingsHolder settings, TransportPartsContainer container)
         {
             var topology = new EndpointOrientedTopology(container);
@@ -103,6 +105,6 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
             return definition;
         }
+#pragma warning restore 618
     }
-
 }

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -118,7 +118,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
-            extensions.UseTopology<ForwardingTopology>().NamespacePartitioning().AddNamespace(Name, Connectionstring);
+            extensions.UseForwardingTopology().NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTopology(container);
 
@@ -143,7 +143,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
-            extensions.UseTopology<ForwardingTopology>().NamespacePartitioning().AddNamespace(Name, Connectionstring);
+            extensions.UseForwardingTopology().NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTopology(container);
 
@@ -167,7 +167,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
 
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
-            extensions.UseTopology<ForwardingTopology>().NamespacePartitioning().AddNamespace(Name, Connectionstring);
+            extensions.UseForwardingTopology().NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTopology(container);
             topology.Initialize(settings);

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     using NUnit.Framework;
     using Transport;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_computing_ForwardingTopology

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_configurations.cs
@@ -6,6 +6,7 @@
     using Transport.AzureServiceBus;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_configuring_namespace_configurations

--- a/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
+++ b/src/Tests/Topology/MetaModel/When_configuring_namespace_info.cs
@@ -4,6 +4,7 @@
     using Transport.AzureServiceBus;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_configuring_namespace_info

--- a/src/Tests/Topology/MetaModel/When_mapping_connection_string_to_namespace_alias.cs
+++ b/src/Tests/Topology/MetaModel/When_mapping_connection_string_to_namespace_alias.cs
@@ -4,6 +4,7 @@
     using Settings;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_mapping_connection_string_to_namespace_alias

--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -3,6 +3,7 @@
     using Transport.AzureServiceBus;
     using NUnit.Framework;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_parsing_string_to_connection_string

--- a/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
     using NUnit.Framework;
     using Transport;
 
+#pragma warning disable 618
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_operating_EndpointOrientedTopology

--- a/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
@@ -37,6 +37,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
             Assert.IsTrue(destination.Entities.Single().Path == "sales.events");
         }
 
+#pragma warning disable 618
         ITopologySectionManager SetupEndpointOrientedTopology(TransportPartsContainer container, string enpointname)
         {
             var settings = new SettingsHolder();
@@ -52,6 +53,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
 
             return container.Resolve<ITopologySectionManager>();
         }
+#pragma warning restore 618
 
         class SomeMessageType
         {

--- a/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
@@ -37,6 +37,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
             Assert.IsTrue(destination.Entities.Single().Path.StartsWith("bundle"));
         }
 
+#pragma warning disable 618
         ITopologySectionManager SetupForwardingTopology(TransportPartsContainer container, string enpointname)
         {
             var settings = new SettingsHolder();
@@ -51,6 +52,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
 
             return container.Resolve<ITopologySectionManager>();
         }
+#pragma warning restore 618
 
         class SomeMessageType
         {

--- a/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
+++ b/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
@@ -31,18 +31,18 @@ namespace NServiceBus
             return new AzureServiceBusTopologySettings<T>(settings);
         }
 
-        public static AzureServiceBusTopologySettings<ForwardingTopology> UseForwardingTopology(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        public static AzureServiceBusForwardingTopologySettings UseForwardingTopology(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
         {
             var settings = transportExtensions.GetSettings();
             settings.Set<ITopology>(new ForwardingTopology());
-            return new AzureServiceBusTopologySettings<ForwardingTopology>(settings);
+            return new AzureServiceBusForwardingTopologySettings(settings);
         }
 
-        public static AzureServiceBusTopologySettings<EndpointOrientedTopology> UseEndpointOrientedTopology(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        public static AzureServiceBusEndpointOrientedTopologySettings UseEndpointOrientedTopology(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
         {
             var settings = transportExtensions.GetSettings();
             settings.Set<ITopology>(new EndpointOrientedTopology());
-            return new AzureServiceBusTopologySettings<EndpointOrientedTopology>(settings);
+            return new AzureServiceBusEndpointOrientedTopologySettings(settings);
         }
 
         /// <summary>

--- a/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
+++ b/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
@@ -8,22 +8,41 @@ namespace NServiceBus
 
     public static class AzureServiceBusTransportExtensions
     {
+        // TODO: replace topology registration
+
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0", ReplacementTypeOrMember = "transport.UseForwardingTopology() or transport.UseEndpointOrientedTopology()")]
         public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions) where T : ITopology, new()
         {
             var topology = Activator.CreateInstance<T>();
             return UseTopology(transportExtensions, topology);
         }
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0", ReplacementTypeOrMember = "transport.UseForwardingTopology() or transport.UseEndpointOrientedTopology()")]
         public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions, Func<T> factory) where T : ITopology
         {
             return UseTopology(transportExtensions, factory());
         }
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0", ReplacementTypeOrMember = "transport.UseForwardingTopology() or transport.UseEndpointOrientedTopology()")]
         public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions, T topology) where T : ITopology
         {
             var settings = transportExtensions.GetSettings();
             settings.Set<ITopology>(topology);
             return new AzureServiceBusTopologySettings<T>(settings);
+        }
+
+        public static AzureServiceBusTopologySettings<ForwardingTopology> UseForwardingTopology(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        {
+            var settings = transportExtensions.GetSettings();
+            settings.Set<ITopology>(new ForwardingTopology());
+            return new AzureServiceBusTopologySettings<ForwardingTopology>(settings);
+        }
+
+        public static AzureServiceBusTopologySettings<EndpointOrientedTopology> UseEndpointOrientedTopology(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        {
+            var settings = transportExtensions.GetSettings();
+            settings.Set<ITopology>(new EndpointOrientedTopology());
+            return new AzureServiceBusTopologySettings<EndpointOrientedTopology>(settings);
         }
 
         /// <summary>
@@ -39,8 +58,8 @@ namespace NServiceBus
         /// <summary>
         /// Provide custom implementation to convert brokered message to incoming message
         /// </summary>
-        public static void UseBrokeredMessageToIncomingMessageConverter<T>(this TransportExtensions<AzureServiceBusTransport>  transportExtensions)
-            where T : IConvertBrokeredMessagesToIncomingMessages
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public static void UseBrokeredMessageToIncomingMessageConverter<T>(this TransportExtensions<AzureServiceBusTransport>  transportExtensions) where T : IConvertBrokeredMessagesToIncomingMessages
         {
             var settings = transportExtensions.GetSettings();
             settings.Set(WellKnownConfigurationKeys.BrokeredMessageConventions.ToIncomingMessageConverter, typeof(T));
@@ -49,8 +68,8 @@ namespace NServiceBus
         /// <summary>
         /// Provide custom implementation to convert outgoing message to brokered message
         /// </summary>
-        public static void UseOutgoingMessageToBrokeredMessageConverter<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
-            where T : IConvertOutgoingMessagesToBrokeredMessages
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public static void UseOutgoingMessageToBrokeredMessageConverter<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions) where T : IConvertOutgoingMessagesToBrokeredMessages
         {
             var settings = transportExtensions.GetSettings();
             settings.Set(WellKnownConfigurationKeys.BrokeredMessageConventions.FromOutgoingMessageConverter, typeof(T));

--- a/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
+++ b/src/Transport/Config/ExtensionMethods/AzureServiceBusTransportExtensions.cs
@@ -8,8 +8,6 @@ namespace NServiceBus
 
     public static class AzureServiceBusTransportExtensions
     {
-        // TODO: replace topology registration
-
         [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0", ReplacementTypeOrMember = "transport.UseForwardingTopology() or transport.UseEndpointOrientedTopology()")]
         public static AzureServiceBusTopologySettings<T> UseTopology<T>(this TransportExtensions<AzureServiceBusTransport> transportExtensions) where T : ITopology, new()
         {

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionExtensionPoint.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionExtensionPoint.cs
@@ -6,6 +6,7 @@
 
     public class AzureServiceBusCompositionExtensionPoint<T> : ExposeSettings where T : ICompositionStrategy
     {
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusCompositionExtensionPoint(SettingsHolder settings) : base(settings)
         {
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusCompositionSettings.cs
@@ -8,6 +8,7 @@
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusCompositionSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettings.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus
+{
+    using Settings;
+
+    public class AzureServiceBusEndpointOrientedTopologySettings : TransportExtensions<AzureServiceBusTransport>
+    {
+        internal AzureServiceBusEndpointOrientedTopologySettings(SettingsHolder settings) : base(settings)
+        {
+        }
+    }
+}

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs
@@ -9,13 +9,27 @@
 
     public static class AzureServiceBusEndpointOrientedTopologySettingsExtensions
     {
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public static AzureServiceBusTopologySettings<EndpointOrientedTopology> RegisterPublisher(this AzureServiceBusTopologySettings<EndpointOrientedTopology> topologySettings, Type type, string publisherName)
         {
             AddScannerForPublisher(topologySettings.GetSettings(), publisherName, new SingleTypeScanner(type));
             return topologySettings;
         }
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public static AzureServiceBusTopologySettings<EndpointOrientedTopology> RegisterPublisher(this AzureServiceBusTopologySettings<EndpointOrientedTopology> topologySettings, Assembly assembly, string publisherName)
+        {
+            AddScannerForPublisher(topologySettings.GetSettings(), publisherName, new AssemblyTypesScanner(assembly));
+            return topologySettings;
+        }
+
+        public static AzureServiceBusEndpointOrientedTopologySettings RegisterPublisher(this AzureServiceBusEndpointOrientedTopologySettings topologySettings, Type type, string publisherName)
+        {
+            AddScannerForPublisher(topologySettings.GetSettings(), publisherName, new SingleTypeScanner(type));
+            return topologySettings;
+        }
+
+        public static AzureServiceBusEndpointOrientedTopologySettings RegisterPublisher(this AzureServiceBusEndpointOrientedTopologySettings topologySettings, Assembly assembly, string publisherName)
         {
             AddScannerForPublisher(topologySettings.GetSettings(), publisherName, new AssemblyTypesScanner(assembly));
             return topologySettings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusForwardingTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusForwardingTopologySettings.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus
+{
+    using Settings;
+
+    public class AzureServiceBusForwardingTopologySettings : TransportExtensions<AzureServiceBusTransport>
+    {
+        internal AzureServiceBusForwardingTopologySettings(SettingsHolder settings) : base(settings)
+        {
+        }
+    }
+}

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusForwardingTopologySettingsExtensions.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusForwardingTopologySettingsExtensions.cs
@@ -5,6 +5,7 @@
 
     public static class AzureServiceBusForwardingTopologySettingsExtensions
     {
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public static AzureServiceBusTopologySettings<ForwardingTopology> NumberOfEntitiesInBundle(this AzureServiceBusTopologySettings<ForwardingTopology> topologySettings, int number)
         {
             var settings = topologySettings.GetSettings();
@@ -12,7 +13,22 @@
             return topologySettings;
         }
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public static AzureServiceBusTopologySettings<ForwardingTopology> BundlePrefix(this AzureServiceBusTopologySettings<ForwardingTopology> topologySettings, string prefix)
+        {
+            var settings = topologySettings.GetSettings();
+            settings.Set(WellKnownConfigurationKeys.Topology.Bundling.BundlePrefix, prefix);
+            return topologySettings;
+        }
+
+        public static AzureServiceBusForwardingTopologySettings NumberOfEntitiesInBundle(this AzureServiceBusForwardingTopologySettings topologySettings, int number)
+        {
+            var settings = topologySettings.GetSettings();
+            settings.Set(WellKnownConfigurationKeys.Topology.Bundling.NumberOfEntitiesInBundle, number);
+            return topologySettings;
+        }
+
+        public static AzureServiceBusForwardingTopologySettings BundlePrefix(this AzureServiceBusForwardingTopologySettings topologySettings, string prefix)
         {
             var settings = topologySettings.GetSettings();
             settings.Set(WellKnownConfigurationKeys.Topology.Bundling.BundlePrefix, prefix);

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusIndividualizationExtensionPoint.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusIndividualizationExtensionPoint.cs
@@ -6,6 +6,7 @@
 
     public class AzureServiceBusIndividualizationExtensionPoint<T> : ExposeSettings where T : IIndividualizationStrategy
     {
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusIndividualizationExtensionPoint(SettingsHolder settings) : base(settings)
         {
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusIndividualizationSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusIndividualizationSettings.cs
@@ -8,6 +8,7 @@
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusIndividualizationSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageReceiverSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageReceiverSettings.cs
@@ -11,8 +11,8 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusMessageReceiverSettings(SettingsHolder settings)
-            : base(settings)
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public AzureServiceBusMessageReceiverSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageSenderSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusMessageSenderSettings.cs
@@ -10,8 +10,8 @@ namespace NServiceBus
     {
         SettingsHolder settings;
 
-        public AzureServiceBusMessageSenderSettings(SettingsHolder settings)
-            : base(settings)
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public AzureServiceBusMessageSenderSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusMessagingFactoriesSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusMessagingFactoriesSettings.cs
@@ -11,8 +11,8 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusMessagingFactoriesSettings(SettingsHolder settings)
-            : base(settings)
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public AzureServiceBusMessagingFactoriesSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceManagersSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceManagersSettings.cs
@@ -10,6 +10,7 @@
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusNamespaceManagersSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceManagersSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceManagersSettings.cs
@@ -10,8 +10,7 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusNamespaceManagersSettings(SettingsHolder settings)
-            : base(settings)
+        public AzureServiceBusNamespaceManagersSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespacePartitioningSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespacePartitioningSettings.cs
@@ -8,8 +8,7 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusNamespacePartitioningSettings(SettingsHolder settings)
-            : base(settings)
+        public AzureServiceBusNamespacePartitioningSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespacePartitioningSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespacePartitioningSettings.cs
@@ -8,6 +8,7 @@
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusNamespacePartitioningSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
@@ -8,6 +8,7 @@ namespace NServiceBus
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusNamespaceRoutingSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
@@ -8,8 +8,7 @@ namespace NServiceBus
     {
         SettingsHolder settings;
 
-        public AzureServiceBusNamespaceRoutingSettings(SettingsHolder settings)
-            : base(settings)
+        public AzureServiceBusNamespaceRoutingSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusQueueSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusQueueSettings.cs
@@ -10,8 +10,7 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusQueueSettings(SettingsHolder settings)
-            : base(settings)
+        public AzureServiceBusQueueSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusQueueSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusQueueSettings.cs
@@ -10,6 +10,7 @@
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusQueueSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusSanitizationExtensionPoint.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusSanitizationExtensionPoint.cs
@@ -9,6 +9,7 @@ namespace NServiceBus
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusSanitizationExtensionPoint(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusSanitizationSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusSanitizationSettings.cs
@@ -8,6 +8,7 @@ namespace NServiceBus
     {
         SettingsHolder settings;
 
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusSanitizationSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusSubscriptionSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusSubscriptionSettings.cs
@@ -10,8 +10,8 @@ namespace NServiceBus
     {
         SettingsHolder settings;
 
-        public AzureServiceBusSubscriptionSettings(SettingsHolder settings)
-           : base(settings)
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public AzureServiceBusSubscriptionSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusTopicSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusTopicSettings.cs
@@ -10,8 +10,8 @@
     {
         SettingsHolder settings;
 
-        public AzureServiceBusTopicSettings(SettingsHolder settings)
-            : base(settings)
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        public AzureServiceBusTopicSettings(SettingsHolder settings) : base(settings)
         {
             this.settings = settings;
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
@@ -3,7 +3,7 @@
     using Settings;
     using Transport.AzureServiceBus;
 
-    // TODO: review how we deal with this. Either break out into two topology specific settings classes or leave as one
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class AzureServiceBusTopologySettings<T> : TransportExtensions<AzureServiceBusTransport> where T : ITopology
     {
         [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
@@ -6,6 +6,7 @@
     // TODO: review how we deal with this. Either break out into two topology specific settings classes or leave as one
     public class AzureServiceBusTopologySettings<T> : TransportExtensions<AzureServiceBusTransport> where T : ITopology
     {
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public AzureServiceBusTopologySettings(SettingsHolder settings) : base(settings)
         {
         }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusTopologySettings.cs
@@ -3,6 +3,7 @@
     using Settings;
     using Transport.AzureServiceBus;
 
+    // TODO: review how we deal with this. Either break out into two topology specific settings classes or leave as one
     public class AzureServiceBusTopologySettings<T> : TransportExtensions<AzureServiceBusTransport> where T : ITopology
     {
         public AzureServiceBusTopologySettings(SettingsHolder settings) : base(settings)

--- a/src/Transport/Connectivity/IClientEntity.cs
+++ b/src/Transport/Connectivity/IClientEntity.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using Microsoft.ServiceBus;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IClientEntity
     {
         bool IsClosed { get; }

--- a/src/Transport/Connectivity/IClientEntity.cs
+++ b/src/Transport/Connectivity/IClientEntity.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using Microsoft.ServiceBus;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IClientEntity
     {
         bool IsClosed { get; }

--- a/src/Transport/Connectivity/ICreateMessageReceivers.cs
+++ b/src/Transport/Connectivity/ICreateMessageReceivers.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateMessageReceivers
     {
         Task<IMessageReceiver> Create(string entityPath, string namespaceAlias);

--- a/src/Transport/Connectivity/ICreateMessageReceivers.cs
+++ b/src/Transport/Connectivity/ICreateMessageReceivers.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateMessageReceivers
     {
         Task<IMessageReceiver> Create(string entityPath, string namespaceAlias);

--- a/src/Transport/Connectivity/ICreateMessageSenders.cs
+++ b/src/Transport/Connectivity/ICreateMessageSenders.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateMessageSenders
     {
         Task<IMessageSender> Create(string entitypath, string viaEntityPath, string namespaceName);

--- a/src/Transport/Connectivity/ICreateMessageSenders.cs
+++ b/src/Transport/Connectivity/ICreateMessageSenders.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateMessageSenders
     {
         Task<IMessageSender> Create(string entitypath, string viaEntityPath, string namespaceName);

--- a/src/Transport/Connectivity/ICreateMessagingFactories.cs
+++ b/src/Transport/Connectivity/ICreateMessagingFactories.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateMessagingFactories
     {
         IMessagingFactory Create(string namespaceName);

--- a/src/Transport/Connectivity/ICreateMessagingFactories.cs
+++ b/src/Transport/Connectivity/ICreateMessagingFactories.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateMessagingFactories
     {
         IMessagingFactory Create(string namespaceName);

--- a/src/Transport/Connectivity/IManageMessageReceiverLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessageReceiverLifeCycle.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageMessageReceiverLifeCycle
     {
         IMessageReceiver Get(string entityPath, string namespaceAlias);

--- a/src/Transport/Connectivity/IManageMessageReceiverLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessageReceiverLifeCycle.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageMessageReceiverLifeCycle
     {
         IMessageReceiver Get(string entityPath, string namespaceAlias);

--- a/src/Transport/Connectivity/IManageMessageSenderLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessageSenderLifeCycle.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageMessageSenderLifeCycle
     {
         IMessageSender Get(string entitypath, string viaEntityPath, string namespaceName);

--- a/src/Transport/Connectivity/IManageMessageSenderLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessageSenderLifeCycle.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageMessageSenderLifeCycle
     {
         IMessageSender Get(string entitypath, string viaEntityPath, string namespaceName);

--- a/src/Transport/Connectivity/IManageMessagingFactoryLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessagingFactoryLifeCycle.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageMessagingFactoryLifeCycle
     {
         IMessagingFactory Get(string namespaceName);

--- a/src/Transport/Connectivity/IManageMessagingFactoryLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageMessagingFactoryLifeCycle.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageMessagingFactoryLifeCycle
     {
         IMessagingFactory Get(string namespaceName);

--- a/src/Transport/Connectivity/IManageNamespaceManagerLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageNamespaceManagerLifeCycle.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageNamespaceManagerLifeCycle
     {
         INamespaceManager Get(string namespaceAlias);

--- a/src/Transport/Connectivity/IManageNamespaceManagerLifeCycle.cs
+++ b/src/Transport/Connectivity/IManageNamespaceManagerLifeCycle.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IManageNamespaceManagerLifeCycle
     {
         INamespaceManager Get(string namespaceAlias);

--- a/src/Transport/Connectivity/IMessageReceiver.cs
+++ b/src/Transport/Connectivity/IMessageReceiver.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IMessageReceiver : IClientEntity
     {
         int PrefetchCount { get; set; }

--- a/src/Transport/Connectivity/IMessageReceiver.cs
+++ b/src/Transport/Connectivity/IMessageReceiver.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IMessageReceiver : IClientEntity
     {
         int PrefetchCount { get; set; }

--- a/src/Transport/Connectivity/IMessageSender.cs
+++ b/src/Transport/Connectivity/IMessageSender.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IMessageSender : IClientEntity
     {
         Task Send(BrokeredMessage message);

--- a/src/Transport/Connectivity/IMessageSender.cs
+++ b/src/Transport/Connectivity/IMessageSender.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IMessageSender : IClientEntity
     {
         Task Send(BrokeredMessage message);

--- a/src/Transport/Connectivity/IMessagingFactory.cs
+++ b/src/Transport/Connectivity/IMessagingFactory.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IMessagingFactory : IClientEntity
     {
         Task<IMessageReceiver> CreateMessageReceiver(string entitypath, ReceiveMode receiveMode);

--- a/src/Transport/Connectivity/IMessagingFactory.cs
+++ b/src/Transport/Connectivity/IMessagingFactory.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IMessagingFactory : IClientEntity
     {
         Task<IMessageReceiver> CreateMessageReceiver(string entitypath, ReceiveMode receiveMode);

--- a/src/Transport/Connectivity/INamespaceManager.cs
+++ b/src/Transport/Connectivity/INamespaceManager.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface INamespaceManager
     {
         NamespaceManagerSettings Settings { get; }

--- a/src/Transport/Connectivity/INamespaceManager.cs
+++ b/src/Transport/Connectivity/INamespaceManager.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface INamespaceManager
     {
         NamespaceManagerSettings Settings { get; }

--- a/src/Transport/Connectivity/NamespaceManagerAdapter.cs
+++ b/src/Transport/Connectivity/NamespaceManagerAdapter.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceManagerAdapter : INamespaceManager, INamespaceManagerAbleToDeleteSubscriptions
     {
         NamespaceManager manager;

--- a/src/Transport/Connectivity/NamespaceManagerAdapter.cs
+++ b/src/Transport/Connectivity/NamespaceManagerAdapter.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceManagerAdapter : INamespaceManager, INamespaceManagerAbleToDeleteSubscriptions
     {
         NamespaceManager manager;

--- a/src/Transport/Creation/ICreateAzureServiceBusQueues.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusQueues.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateAzureServiceBusQueues
     {
         Task<QueueDescription> Create(string queuePath, INamespaceManager namespaceManager);

--- a/src/Transport/Creation/ICreateAzureServiceBusQueues.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusQueues.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateAzureServiceBusQueues
     {
         Task<QueueDescription> Create(string queuePath, INamespaceManager namespaceManager);

--- a/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
@@ -3,6 +3,7 @@
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateAzureServiceBusSubscriptions
     {
         Task<SubscriptionDescription> Create(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo);

--- a/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
@@ -3,7 +3,7 @@
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateAzureServiceBusSubscriptions
     {
         Task<SubscriptionDescription> Create(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo);

--- a/src/Transport/Creation/ICreateAzureServiceBusTopics.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusTopics.cs
@@ -3,6 +3,7 @@
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateAzureServiceBusTopics
     {
         Task<TopicDescription> Create(string topicPath, INamespaceManager namespaceManager);

--- a/src/Transport/Creation/ICreateAzureServiceBusTopics.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusTopics.cs
@@ -3,7 +3,7 @@
     using System.Threading.Tasks;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateAzureServiceBusTopics
     {
         Task<TopicDescription> Create(string topicPath, INamespaceManager namespaceManager);

--- a/src/Transport/Creation/ICreateNamespaceManagers.cs
+++ b/src/Transport/Creation/ICreateNamespaceManagers.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateNamespaceManagers
     {
         INamespaceManager Create(string namespaceName);

--- a/src/Transport/Creation/ICreateNamespaceManagers.cs
+++ b/src/Transport/Creation/ICreateNamespaceManagers.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateNamespaceManagers
     {
         INamespaceManager Create(string namespaceName);

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -95,7 +95,9 @@
     <Compile Include="Config\AzureServiceBusTransportInfrastructure.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusCompositionExtensionPoint.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusDiscriminatorBasedIndividualizationSettingsExtensions.cs" />
+    <Compile Include="Config\ExtensionPoints\AzureServiceBusEndpointOrientedTopologySettings.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs" />
+    <Compile Include="Config\ExtensionPoints\AzureServiceBusForwardingTopologySettings.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusForwardingTopologySettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusHierarchyCompositionSettingsExtensions.cs" />
     <Compile Include="Config\ExtensionPoints\AzureServiceBusIndividualizationExtensionPoint.cs" />

--- a/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
+++ b/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class BrokeredMessageReceiveContext : ReceiveContext
     {
         public BrokeredMessageReceiveContext(BrokeredMessage message, EntityInfo entity, ReceiveMode receiveMode)

--- a/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
+++ b/src/Transport/Receiving/BrokeredMessageReceiveContext.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class BrokeredMessageReceiveContext : ReceiveContext
     {
         public BrokeredMessageReceiveContext(BrokeredMessage message, EntityInfo entity, ReceiveMode receiveMode)

--- a/src/Transport/Receiving/IConvertBrokeredMessagesToIncomingMessages.cs
+++ b/src/Transport/Receiving/IConvertBrokeredMessagesToIncomingMessages.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IConvertBrokeredMessagesToIncomingMessages
     {
         IncomingMessageDetails Convert(BrokeredMessage brokeredMessage);

--- a/src/Transport/Receiving/IConvertBrokeredMessagesToIncomingMessages.cs
+++ b/src/Transport/Receiving/IConvertBrokeredMessagesToIncomingMessages.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IConvertBrokeredMessagesToIncomingMessages
     {
         IncomingMessageDetails Convert(BrokeredMessage brokeredMessage);

--- a/src/Transport/Receiving/INotifyIncomingMessages.cs
+++ b/src/Transport/Receiving/INotifyIncomingMessages.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Transport;
 
+    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface INotifyIncomingMessages
     {
         bool IsRunning { get; }

--- a/src/Transport/Receiving/INotifyIncomingMessages.cs
+++ b/src/Transport/Receiving/INotifyIncomingMessages.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Transport;
 
-    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface INotifyIncomingMessages
     {
         bool IsRunning { get; }

--- a/src/Transport/Receiving/INotifyIncomingMessages.cs
+++ b/src/Transport/Receiving/INotifyIncomingMessages.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface INotifyIncomingMessages
     {
         bool IsRunning { get; }

--- a/src/Transport/Receiving/IncomingMessageDetails.cs
+++ b/src/Transport/Receiving/IncomingMessageDetails.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class IncomingMessageDetails
     {
         public IncomingMessageDetails(string messageId, Dictionary<string, string> headers, byte[] body)

--- a/src/Transport/Receiving/IncomingMessageDetails.cs
+++ b/src/Transport/Receiving/IncomingMessageDetails.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class IncomingMessageDetails
     {
         public IncomingMessageDetails(string messageId, Dictionary<string, string> headers, byte[] body)

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -145,8 +145,6 @@ namespace NServiceBus.Transport.AzureServiceBus
             if (messagingException != null && messagingException.IsTransient)
             {
                 logger.DebugFormat("OptionsOnExceptionReceived invoked, action: '{0}', transient exception with message: {1}", exceptionReceivedEventArgs.Action, messagingException.Detail.Message);
-
-                // TODO ideally we'd failover to another space if in a certain period of time there are too many transient errors
             }
             else
             {

--- a/src/Transport/Receiving/ReceiveContext.cs
+++ b/src/Transport/Receiving/ReceiveContext.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     /// - the original message so that it can be completed or abandoned when processing is done
     /// - the queue where it came from, so that sends can go via that queue to emulate send transactions
     /// </summary>
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public abstract class ReceiveContext
     {
         protected ReceiveContext()

--- a/src/Transport/Receiving/ReceiveContext.cs
+++ b/src/Transport/Receiving/ReceiveContext.cs
@@ -8,6 +8,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     /// - the original message so that it can be completed or abandoned when processing is done
     /// - the queue where it came from, so that sends can go via that queue to emulate send transactions
     /// </summary>
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public abstract class ReceiveContext
     {
         protected ReceiveContext()

--- a/src/Transport/Sending/Batch.cs
+++ b/src/Transport/Sending/Batch.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Collections.Generic;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class Batch
     {
         public Batch()

--- a/src/Transport/Sending/Batch.cs
+++ b/src/Transport/Sending/Batch.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Collections.Generic;
     using Transport;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class Batch
     {
         public Batch()

--- a/src/Transport/Sending/BatchedOperation.cs
+++ b/src/Transport/Sending/BatchedOperation.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using DeliveryConstraints;
     using Transport;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class BatchedOperation
     {
         int messageSizePaddingPercentage;

--- a/src/Transport/Sending/BatchedOperation.cs
+++ b/src/Transport/Sending/BatchedOperation.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using DeliveryConstraints;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class BatchedOperation
     {
         int messageSizePaddingPercentage;

--- a/src/Transport/Sending/IBatcher.cs
+++ b/src/Transport/Sending/IBatcher.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Collections.Generic;
     using Transport;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IBatcher
     {
         IList<Batch> ToBatches(TransportOperations operations);

--- a/src/Transport/Sending/IBatcher.cs
+++ b/src/Transport/Sending/IBatcher.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Collections.Generic;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IBatcher
     {
         IList<Batch> ToBatches(TransportOperations operations);

--- a/src/Transport/Sending/IConvertOutgoingMessagesToBrokeredMessages.cs
+++ b/src/Transport/Sending/IConvertOutgoingMessagesToBrokeredMessages.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Collections.Generic;
     using Microsoft.ServiceBus.Messaging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IConvertOutgoingMessagesToBrokeredMessages
     {
         IEnumerable<BrokeredMessage> Convert(IEnumerable<BatchedOperation> outgoingOperations, RoutingOptions routingOptions);

--- a/src/Transport/Sending/IConvertOutgoingMessagesToBrokeredMessages.cs
+++ b/src/Transport/Sending/IConvertOutgoingMessagesToBrokeredMessages.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Collections.Generic;
     using Microsoft.ServiceBus.Messaging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IConvertOutgoingMessagesToBrokeredMessages
     {
         IEnumerable<BrokeredMessage> Convert(IEnumerable<BatchedOperation> outgoingOperations, RoutingOptions routingOptions);

--- a/src/Transport/Sending/IRouteOutgoingBatches.cs
+++ b/src/Transport/Sending/IRouteOutgoingBatches.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IRouteOutgoingBatches
     {
         Task RouteBatches(IEnumerable<Batch> outgoingBatches, ReceiveContext receiveContext, DispatchConsistency consistency);

--- a/src/Transport/Sending/IRouteOutgoingBatches.cs
+++ b/src/Transport/Sending/IRouteOutgoingBatches.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Transport;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IRouteOutgoingBatches
     {
         Task RouteBatches(IEnumerable<Batch> outgoingBatches, ReceiveContext receiveContext, DispatchConsistency consistency);

--- a/src/Transport/Sending/RoutingOptions.cs
+++ b/src/Transport/Sending/RoutingOptions.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class RoutingOptions
     {
         public string DestinationEntityPath { get; set; }

--- a/src/Transport/Sending/RoutingOptions.cs
+++ b/src/Transport/Sending/RoutingOptions.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
-{ 
+{
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class RoutingOptions
     {
         public string DestinationEntityPath { get; set; }

--- a/src/Transport/Topology/ICreateTopology.cs
+++ b/src/Transport/Topology/ICreateTopology.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     // note there is some creation logic elsewhere already, those calls should be removed and centralized here
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateTopology
     {
         Task Create(TopologySection topology);

--- a/src/Transport/Topology/ICreateTopology.cs
+++ b/src/Transport/Topology/ICreateTopology.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     // note there is some creation logic elsewhere already, those calls should be removed and centralized here
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ICreateTopology
     {
         Task Create(TopologySection topology);

--- a/src/Transport/Topology/IOperateTopology.cs
+++ b/src/Transport/Topology/IOperateTopology.cs
@@ -13,7 +13,7 @@
     /// So is the list of notifiers etc...
     /// etc..
     /// </summary>
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IOperateTopology
     {
         //invoked for static parts of the topology

--- a/src/Transport/Topology/IOperateTopology.cs
+++ b/src/Transport/Topology/IOperateTopology.cs
@@ -13,6 +13,7 @@
     /// So is the list of notifiers etc...
     /// etc..
     /// </summary>
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IOperateTopology
     {
         //invoked for static parts of the topology

--- a/src/Transport/Topology/IStoppableTopology.cs
+++ b/src/Transport/Topology/IStoppableTopology.cs
@@ -2,8 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Threading.Tasks;
 
-    // For now let's make this an internal interface in order to be able to hotfix the shutdown problem
-    public interface IStoppableTopology
+    interface IStoppableTopology
     {
         Task Stop();
     }

--- a/src/Transport/Topology/ITopology.cs
+++ b/src/Transport/Topology/ITopology.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Settings;
     using Transport;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ITopology
     {
         void Initialize(SettingsHolder settings);

--- a/src/Transport/Topology/ITopology.cs
+++ b/src/Transport/Topology/ITopology.cs
@@ -6,7 +6,12 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Settings;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    static class ObsoleteMessages
+    {
+        public const string WillBeInternalized = "Internal contract that shouldn't be exposed.";
+    }
+
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ITopology
     {
         void Initialize(SettingsHolder settings);

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -3,6 +3,7 @@
     using System;
     using Transport;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ITopologySectionManager
     {
         TopologySection DetermineReceiveResources(string inputQueue);

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -3,7 +3,7 @@
     using System;
     using Transport;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ITopologySectionManager
     {
         TopologySection DetermineReceiveResources(string inputQueue);

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -4,7 +4,7 @@
     using System.Collections.Concurrent;
     using System.Text.RegularExpressions;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class ConnectionString : IEquatable<ConnectionString>
     {
         static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -4,6 +4,7 @@
     using System.Collections.Concurrent;
     using System.Text.RegularExpressions;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class ConnectionString : IEquatable<ConnectionString>
     {
         static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";

--- a/src/Transport/Topology/MetaModel/EntityInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityInfo.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityInfo
     {
         public string Path { get; set; }

--- a/src/Transport/Topology/MetaModel/EntityInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityInfo.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityInfo
     {
         public string Path { get; set; }

--- a/src/Transport/Topology/MetaModel/EntityRelationShipInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityRelationShipInfo.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityRelationShipInfo
     {
         public EntityInfo Source { get; set; }

--- a/src/Transport/Topology/MetaModel/EntityRelationShipInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityRelationShipInfo.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityRelationShipInfo
     {
         public EntityInfo Source { get; set; }

--- a/src/Transport/Topology/MetaModel/IBrokerSideSubscriptionFilter.cs
+++ b/src/Transport/Topology/MetaModel/IBrokerSideSubscriptionFilter.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IBrokerSideSubscriptionFilter
     {
         /// <summary>

--- a/src/Transport/Topology/MetaModel/IBrokerSideSubscriptionFilter.cs
+++ b/src/Transport/Topology/MetaModel/IBrokerSideSubscriptionFilter.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IBrokerSideSubscriptionFilter
     {
         /// <summary>

--- a/src/Transport/Topology/MetaModel/IClientSideSubscriptionFilter.cs
+++ b/src/Transport/Topology/MetaModel/IClientSideSubscriptionFilter.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal unutilized contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IClientSideSubscriptionFilter
     {
         /// <summary>

--- a/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using Logging;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceConfigurations : IEnumerable<NamespaceInfo>
     {
         static ILog Log = LogManager.GetLogger(typeof(NamespaceConfigurations));

--- a/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
@@ -6,7 +6,7 @@
     using System.Linq;
     using Logging;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceConfigurations : IEnumerable<NamespaceInfo>
     {
         static ILog Log = LogManager.GetLogger(typeof(NamespaceConfigurations));

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceInfo : IEquatable<NamespaceInfo>
     {
         public string Alias { get; }

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -1,7 +1,8 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
-    
+
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceInfo : IEquatable<NamespaceInfo>
     {
         public string Alias { get; }

--- a/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
@@ -2,6 +2,7 @@
 {
     using System;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class RuntimeNamespaceInfo : IEquatable<RuntimeNamespaceInfo>
     {
         readonly NamespaceInfo info;

--- a/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class RuntimeNamespaceInfo : IEquatable<RuntimeNamespaceInfo>
     {
         readonly NamespaceInfo info;

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -4,6 +4,7 @@
     {
         public IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }
 
+        [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public IClientSideSubscriptionFilter ClientSideFilter { get; set; }
 
         public SubscriptionMetadata Metadata { get; set; }

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class SubscriptionInfo : EntityInfo
     {
         public IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -1,11 +1,11 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class SubscriptionInfo : EntityInfo
     {
         public IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }
 
-        [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
         public IClientSideSubscriptionFilter ClientSideFilter { get; set; }
 
         public SubscriptionMetadata Metadata { get; set; }

--- a/src/Transport/Topology/MetaModel/SubscriptionMetadata.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionMetadata.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class SubscriptionMetadata
     {
         public string Description { get; set; }

--- a/src/Transport/Topology/MetaModel/SubscriptionMetadata.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionMetadata.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 
 {
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class SubscriptionMetadata
     {
         public string Description { get; set; }

--- a/src/Transport/Topology/MetaModel/TopologySection.cs
+++ b/src/Transport/Topology/MetaModel/TopologySection.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
 
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class TopologySection
     {
         public IEnumerable<RuntimeNamespaceInfo> Namespaces { get; set; }

--- a/src/Transport/Topology/MetaModel/TopologySection.cs
+++ b/src/Transport/Topology/MetaModel/TopologySection.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class TopologySection
     {
         public IEnumerable<RuntimeNamespaceInfo> Namespaces { get; set; }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -64,7 +64,6 @@ namespace NServiceBus.Transport.AzureServiceBus
                 }));
 
                 // assumed errorq and auditq are in here
-                // TODO: in the future, if queueBindings.SendingAddresses containts system only queues, we shouldn't include in the list of queues to be created by the endpoint
                 entities.AddRange(queueBindings.SendingAddresses.Select(p => new EntityInfo
                 {
                     Path = addressingLogic.Apply(p, EntityType.Queue).Name,

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -72,7 +72,6 @@ namespace NServiceBus.Transport.AzureServiceBus
                     Namespace = n
                 }));
 
-                // TODO: in the future, if queueBindings.SendingAddresses containts system only queues, we shouldn't include in the list of queues to be created by the endpoint
                 inputQueues.AddRange(queueBindings.SendingAddresses.Select(p => new EntityInfo
                 {
                     Path = addressingLogic.Apply(p, EntityType.Queue).Name,

--- a/src/Transport/Utils/IRegisterTransportParts.cs
+++ b/src/Transport/Utils/IRegisterTransportParts.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
 
+    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IRegisterTransportParts
     {
         void Register<T>();

--- a/src/Transport/Utils/IRegisterTransportParts.cs
+++ b/src/Transport/Utils/IRegisterTransportParts.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
 
-    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IRegisterTransportParts
     {
         void Register<T>();

--- a/src/Transport/Utils/IRegisterTransportParts.cs
+++ b/src/Transport/Utils/IRegisterTransportParts.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IRegisterTransportParts
     {
         void Register<T>();

--- a/src/Transport/Utils/IResolveTransportParts.cs
+++ b/src/Transport/Utils/IResolveTransportParts.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System;
     using System.Collections.Generic;
 
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IResolveTransportParts
     {
         object Resolve(Type typeToBuild);

--- a/src/Transport/Utils/IResolveTransportParts.cs
+++ b/src/Transport/Utils/IResolveTransportParts.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System;
     using System.Collections.Generic;
 
-    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface IResolveTransportParts
     {
         object Resolve(Type typeToBuild);

--- a/src/Transport/Utils/IResolveTransportParts.cs
+++ b/src/Transport/Utils/IResolveTransportParts.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System;
     using System.Collections.Generic;
 
+    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface IResolveTransportParts
     {
         object Resolve(Type typeToBuild);

--- a/src/Transport/Utils/ITransportPartsContainer.cs
+++ b/src/Transport/Utils/ITransportPartsContainer.cs
@@ -1,5 +1,5 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ITransportPartsContainer : IRegisterTransportParts, IResolveTransportParts { }
 }

--- a/src/Transport/Utils/ITransportPartsContainer.cs
+++ b/src/Transport/Utils/ITransportPartsContainer.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    using System;
-
-    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
+    [ObsoleteEx(Message = "Internal contract that shouldn't be exposed.", TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public interface ITransportPartsContainer : IRegisterTransportParts, IResolveTransportParts { }
 }

--- a/src/Transport/Utils/ITransportPartsContainer.cs
+++ b/src/Transport/Utils/ITransportPartsContainer.cs
@@ -1,4 +1,7 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    using System;
+
+    [Obsolete("Internal contract that shouldn't be exposed. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
     public interface ITransportPartsContainer : IRegisterTransportParts, IResolveTransportParts { }
 }

--- a/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
+++ b/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
@@ -21,13 +21,16 @@ class ConfigureAzureServiceBusTransportInfrastructure : IConfigureTransportInfra
         if (topologyName == nameof(ForwardingTopology))
         {
             var topology = Activator.CreateInstance<ForwardingTopology>();
+#pragma warning disable 618
             settings.Set<ITopology>(topology);
+#pragma warning restore 618
         }
         else
         {
             var topology = Activator.CreateInstance<EndpointOrientedTopology>();
+#pragma warning disable 618
             settings.Set<ITopology>(topology);
-
+#pragma warning restore 618
         }
 
         var transport = new AzureServiceBusTransport();


### PR DESCRIPTION
## Who's affected
- Anyone extending and customizing Azure Service Bus transport version 7 and above
## Symptoms

Version 7.0 of the ASB transport has exposed internal types that shouldn't have been exposed.
## Original issue

<details><summary>

Details</summary>


The following types have been exposed and broken down into several categories for a review.

**Types that should be exposed**

✔️ IIndividualizationStrategy
✔️ IHandleOversizedBrokeredMessages
✔️ ISanitizationStrategy
✔️ ICompositionStrategy
✔️ INamespacePartitioningStrategy

**Types that should NOT have been exposes at all**

❌ ITopology
❌ IStoppableTopology
❌ ITransportPartsContainer
❌ IResolveTransportParts  
❌ IRegisterTransportParts
❌ INotifyIncomingMessages
❌ IClientSideSubscriptionFilter
❌ INamespaceManager ==|> NamespaceManagerAdapter

**Types that require intimate knowledge of topologies and/or transport**

❗️ ICreateAzureServiceBusSubscriptions ==|> AzureServiceBusSubscriptionCreator + AzureServiceBusSubscriptionCreatorV6 / AzureServiceBusForwardingSubscriptionCreator (creator per topology)
❗️  ITopologySectionManager ==|> EndpointOrientedTopologySectionManager / ForwardingTopologySectionManager
❗️ IOperateTopology ==|> TopologyOperator
❗️ IBatcher ==|> Batcher / Batch / BatchedOperation
❗️ IRouteOutgoingBatches ==|> DefaultOutgoingBatchRouter / ReceiveContext
❗️ IManageMessageSenderLifeCycle ==|> MessageSenderLifeCycleManager
❗️ ICreateMessageSenders ==|> MessageSenderCreator
❗️ IManageMessagingFactoryLifeCycle ==|> MessagingFactoryLifeCycleManager
❗️ ICreateMessagingFactories ==|> MessagingFactoryCreator
❗️ ICreateMessageReceivers ==|> MessageReceiverCreator
❗️ IManageMessageReceiverLifeCycle ==|> MessageReceiverLifeCycleManager
❗️ IConvertBrokeredMessagesToIncomingMessages ==|> DefaultBrokeredMessagesToIncomingMessagesConverter is the default. Custom implementation not possible since it would require ICanMapConnectionStringToNamespaceAlias which is an internal contract
❗️ IConvertOutgoingMessagesToBrokeredMessages ==|> DefaultBatchedOperationsToBrokeredMessagesConverter

**Types in question**

❓ ICreateTopology ==|> TopologyCreator
❓ IManageNamespaceManagerLifeCycle ==|> NamespaceManagerLifeCycleManager
❓ ICreateNamespaceManagers ==|> NamespaceManagerCreator
❓ ICreateAzureServiceBusQueues ==|> AzureServiceBusQueueCreator
❓ ICreateAzureServiceBusTopics ==|> AzureServiceBusTopicCreator
❓ IClientEntity ==|> IMessagingFactory / IMessageReceiver / IMessageSender 
❓ IMessagingFactory ==|> MessagingFactoryAdapter
❓ IMessageReceiver ==|> MessageReceiverAdapter
❓ IMessageSender ==|> MessageSenderAdapter
❓ IBrokerSideSubscriptionFilter ==|> only exposed because of the public SubscriptionInfo, which is exposed via TopologySection revealed by ITopologySectionManager
---
#### `ITransportPartsContainer`, `IRegisterTransportParts`, `IResolveTransportParts`
- Default container implementation (`TransportPartsContainer`) was not intended for replacement. 
- Access to the default container is revealed via dependency resolution, which can lead to undesired results.
#### `INotifyIncomingMessages`

`TopologyOperator` creates `INotifyIncomingMessages`, but it's [coupled to `MessageReceiverNotifier` implementation](https://github.com/Particular/NServiceBus.AzureServiceBus/blob/01b0b804c69d5d085e78d092d1b78f876fa84914/src/Transport/Topology/TopologyOperator.cs#L117) only. Having `INotifyIncomingMessages` exposed adds no value.
#### `IStoppableTopology`

To be merged with `ITopology` in 8.0.0
#### `INamespaceManager`

Default implementation provided by `NamespaceManagerAdapter` is an abstraction on top of native `NamespaceManager` and additional functionality required to determine if management is allowed for a given namespace.
#### `IClientSideSubscriptionFilter`

Exposed via `SubscriptionInfo.ClientSideFilter` that is never used

<!-- query used
from t in Application.Types
where t.IsPubliclyVisible && t.TypesThatImplementMe.Count() == 1
select new { t, impl = t.TypesThatImplementMe.Single() }
--> 

**Update**: agreed to internalize everything marked in red and review need to expose things based on case-by-case need.

<!-- query obsoleted types
from t in JustMyCode.Types 
where t.IsPubliclyVisible &&  t.HasAttribute("System.ObsoleteAttribute")
select new { t }
-->

</details>
