### PR TITLE
Fix unsubscribe

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -413,6 +413,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ICreateAzureServiceBusSubscriptions
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> Create(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
+        System.Threading.Tasks.Task DeleteSubscription(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
     }
     public interface ICreateAzureServiceBusTopics
     {
@@ -437,6 +438,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ICreateTopology
     {
         System.Threading.Tasks.Task Create(NServiceBus.Transport.AzureServiceBus.TopologySection topology);
+        System.Threading.Tasks.Task TearDownSubscription(NServiceBus.Transport.AzureServiceBus.TopologySection topologySection);
     }
     public interface IHandleOversizedBrokeredMessages
     {
@@ -493,6 +495,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> CreateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription, Microsoft.ServiceBus.Messaging.RuleDescription ruleDescription);
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> CreateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription);
         System.Threading.Tasks.Task DeleteQueue(string path);
+        System.Threading.Tasks.Task DeleteSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
         System.Threading.Tasks.Task DeleteTopic(string path);
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> GetQueue(string path);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.RuleDescription>> GetRules(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
@@ -621,6 +624,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> CreateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription, Microsoft.ServiceBus.Messaging.RuleDescription ruleDescription) { }
         public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> CreateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription) { }
         public System.Threading.Tasks.Task DeleteQueue(string path) { }
+        public System.Threading.Tasks.Task DeleteSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription) { }
         public System.Threading.Tasks.Task DeleteSubscriptionAsync(string topicPath, string subscriptionName) { }
         public System.Threading.Tasks.Task DeleteTopic(string path) { }
         public System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> GetQueue(string path) { }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -494,7 +494,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> CreateSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription, Microsoft.ServiceBus.Messaging.RuleDescription ruleDescription);
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.TopicDescription> CreateTopic(Microsoft.ServiceBus.Messaging.TopicDescription topicDescription);
         System.Threading.Tasks.Task DeleteQueue(string path);
-        System.Threading.Tasks.Task DeleteSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
         System.Threading.Tasks.Task DeleteTopic(string path);
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.QueueDescription> GetQueue(string path);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.ServiceBus.Messaging.RuleDescription>> GetRules(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
@@ -612,7 +611,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
-    public class NamespaceManagerAdapter : NServiceBus.Transport.AzureServiceBus.INamespaceManager
+    public class NamespaceManagerAdapter : NServiceBus.Transport.AzureServiceBus.INamespaceManager, NServiceBus.Transport.AzureServiceBus.INamespaceManagerAbleToDeleteSubscriptions
     {
         public NamespaceManagerAdapter(Microsoft.ServiceBus.NamespaceManager manager) { }
         public System.Uri Address { get; }

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -413,6 +413,9 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ICreateAzureServiceBusSubscriptions
     {
         System.Threading.Tasks.Task<Microsoft.ServiceBus.Messaging.SubscriptionDescription> Create(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
+    }
+    public interface ICreateAzureServiceBusSubscriptionsAbleToDeleteSubscriptions
+    {
         System.Threading.Tasks.Task DeleteSubscription(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
     }
     public interface ICreateAzureServiceBusTopics

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -438,7 +438,6 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ICreateTopology
     {
         System.Threading.Tasks.Task Create(NServiceBus.Transport.AzureServiceBus.TopologySection topology);
-        System.Threading.Tasks.Task TearDownSubscription(NServiceBus.Transport.AzureServiceBus.TopologySection topologySection);
     }
     public interface IHandleOversizedBrokeredMessages
     {

--- a/src/Tests/Connectivity/When_managing_namespace_manager_lifecycle.cs
+++ b/src/Tests/Connectivity/When_managing_namespace_manager_lifecycle.cs
@@ -149,6 +149,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Connectivity
             {
                 throw new NotImplementedException();
             }
+
+            public Task DeleteSubscription(SubscriptionDescription subscriptionDescription)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Tests/Creation/When_creating_forwarding_subscription.cs
+++ b/src/Tests/Creation/When_creating_forwarding_subscription.cs
@@ -57,7 +57,7 @@
             const string subscriptionName = "endpoint0";
             //make sure there is no leftover from previous test
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
 
             var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
 
@@ -88,7 +88,7 @@
             Assert.IsNull(subscriptionDescription.ForwardDeadLetteredMessagesTo);
             Assert.That(subscriptionDescription.ForwardTo, Does.EndWith(forwardToQueue));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
 
@@ -114,7 +114,7 @@
             Assert.IsTrue(await namespaceManager.SubscriptionExists(topicPath, subscriptionName));
             Assert.AreEqual(subscriptionDescription, foundDescription);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -141,7 +141,7 @@
             }
             Assert.AreEqual(autoDeleteTime, foundDescription.AutoDeleteOnIdle);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -164,7 +164,7 @@
 
             Assert.AreEqual(timeToLive, foundDescription.DefaultMessageTimeToLive);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -186,7 +186,7 @@
 
             Assert.IsFalse(foundDescription.EnableBatchedOperations);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -208,7 +208,7 @@
 
             Assert.IsTrue(foundDescription.EnableDeadLetteringOnFilterEvaluationExceptions);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -230,7 +230,7 @@
 
             Assert.IsTrue(foundDescription.EnableDeadLetteringOnMessageExpiration);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -253,7 +253,7 @@
 
             Assert.AreEqual(lockDuration, foundDescription.LockDuration);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -276,7 +276,7 @@
 
             Assert.AreEqual(deliveryCount, foundDescription.MaxDeliveryCount);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -297,7 +297,7 @@
 
             Assert.That(foundDescription.ForwardTo.EndsWith(queueToForwardTo.Path));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
             await namespaceManager.DeleteQueue(queueToForwardTo.Path);
         }
 
@@ -324,7 +324,7 @@
 
             Assert.That(foundDescription.ForwardDeadLetteredMessagesTo.EndsWith(topicToForwardTo.Path));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
             await namespaceManager.DeleteTopic(topicToForwardTo.Path);
         }
 
@@ -351,7 +351,7 @@
 
             Assert.That(foundDescription.ForwardDeadLetteredMessagesTo.EndsWith(notUsedEntity.Path));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
             await namespaceManager.DeleteTopic(notUsedEntity.Path);
         }
 
@@ -377,7 +377,7 @@
             Assert.IsTrue(rules.Count() == 1, "Subscription should only have 1 rule");
             Assert.AreEqual(filter, foundFilter.SqlExpression, "Rule was expected to have a specific SQL filter, but it didn't");
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriber);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriber));
         }
 
 
@@ -474,7 +474,7 @@
 
             Assert.That(rules.Count(), Is.EqualTo(2), "Subscription didn't have correct number of rules");
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriber);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriber));
         }
 
     }

--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -45,7 +45,7 @@
             const string subscriptionName = "mysubscription1";
             //make sure there is no leftover from previous test
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
 
             var creator = new AzureServiceBusSubscriptionCreator(settings);
 
@@ -76,7 +76,7 @@
             Assert.IsNull(subscriptionDescription.ForwardDeadLetteredMessagesTo);
             Assert.IsNull(subscriptionDescription.ForwardTo);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
 
@@ -102,7 +102,7 @@
             Assert.IsTrue(await namespaceManager.SubscriptionExists(topicPath, subscriptionName));
             Assert.AreEqual(subscriptionDescription, foundDescription);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -124,7 +124,7 @@
 
             Assert.AreEqual(autoDeleteTime, foundDescription.AutoDeleteOnIdle);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -147,7 +147,7 @@
 
             Assert.AreEqual(timeToLive, foundDescription.DefaultMessageTimeToLive);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -169,7 +169,7 @@
 
             Assert.IsFalse(foundDescription.EnableBatchedOperations);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -191,7 +191,7 @@
 
             Assert.IsTrue(foundDescription.EnableDeadLetteringOnFilterEvaluationExceptions);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -213,7 +213,7 @@
 
             Assert.IsTrue(foundDescription.EnableDeadLetteringOnMessageExpiration);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -236,7 +236,7 @@
 
             Assert.AreEqual(lockDuration, foundDescription.LockDuration);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -259,7 +259,7 @@
 
             Assert.AreEqual(deliveryCount, foundDescription.MaxDeliveryCount);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -280,7 +280,7 @@
 
             Assert.That(foundDescription.ForwardTo.EndsWith(queueToForwardTo.Path));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
             await namespaceManager.DeleteQueue(queueToForwardTo.Path);
         }
 
@@ -307,7 +307,7 @@
 
             Assert.That(foundDescription.ForwardDeadLetteredMessagesTo.EndsWith(topicToForwardTo.Path));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
             await namespaceManager.DeleteTopic(topicToForwardTo.Path);
         }
 
@@ -334,7 +334,7 @@
 
             Assert.That(foundDescription.ForwardDeadLetteredMessagesTo.EndsWith(topicToForwardTo.Path));
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
             await namespaceManager.DeleteTopic(topicToForwardTo.Path);
         }
 
@@ -360,7 +360,7 @@
             Assert.IsTrue(rules.Count() == 1, "Subscription should only have 1 rule");
             Assert.AreEqual(filter, foundFilter.SqlExpression, "Rule was expected to have a specific SQL filter, but it didn't");
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
         [Test]
@@ -377,7 +377,7 @@
             Assert.IsTrue(await namespaceManager.SubscriptionExists(topicPath, subscriptionName));
             Assert.AreEqual("very.logn.name.of.an.event.that.would.exceed.subscription.length", subscriptionDescription.UserMetadata);
 
-            await namespaceManager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
         }
 
 

--- a/src/Transport/Connectivity/INamespaceManager.cs
+++ b/src/Transport/Connectivity/INamespaceManager.cs
@@ -31,5 +31,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         Task<IEnumerable<RuleDescription>> GetRules(SubscriptionDescription subscriptionDescription);
         Task<SubscriptionDescription> CreateSubscription(SubscriptionDescription subscriptionDescription, RuleDescription ruleDescription);
+        Task DeleteSubscription(SubscriptionDescription subscriptionDescription);
     }
 }

--- a/src/Transport/Connectivity/INamespaceManager.cs
+++ b/src/Transport/Connectivity/INamespaceManager.cs
@@ -31,6 +31,11 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         Task<IEnumerable<RuleDescription>> GetRules(SubscriptionDescription subscriptionDescription);
         Task<SubscriptionDescription> CreateSubscription(SubscriptionDescription subscriptionDescription, RuleDescription ruleDescription);
+    }
+
+    // TODO: Move into internalized INamespaceManager in v8
+    interface INamespaceManagerAbleToDeleteSubscriptions
+    {
         Task DeleteSubscription(SubscriptionDescription subscriptionDescription);
     }
 }

--- a/src/Transport/Connectivity/NamespaceManagerAdapter.cs
+++ b/src/Transport/Connectivity/NamespaceManagerAdapter.cs
@@ -98,6 +98,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             return manager.CreateSubscriptionAsync(subscriptionDescription, ruleDescription);
         }
 
+        public Task DeleteSubscription(SubscriptionDescription subscriptionDescription)
+        {
+            return manager.DeleteSubscriptionAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name);
+        }
+
         public Task<TopicDescription> UpdateTopic(TopicDescription topicDescription)
         {
             return manager.UpdateTopicAsync(topicDescription);

--- a/src/Transport/Connectivity/NamespaceManagerAdapter.cs
+++ b/src/Transport/Connectivity/NamespaceManagerAdapter.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
 
-    public class NamespaceManagerAdapter : INamespaceManager
+    public class NamespaceManagerAdapter : INamespaceManager, INamespaceManagerAbleToDeleteSubscriptions
     {
         NamespaceManager manager;
 
@@ -98,11 +98,6 @@ namespace NServiceBus.Transport.AzureServiceBus
             return manager.CreateSubscriptionAsync(subscriptionDescription, ruleDescription);
         }
 
-        public Task DeleteSubscription(SubscriptionDescription subscriptionDescription)
-        {
-            return manager.DeleteSubscriptionAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name);
-        }
-
         public Task<TopicDescription> UpdateTopic(TopicDescription topicDescription)
         {
             return manager.UpdateTopicAsync(topicDescription);
@@ -118,9 +113,15 @@ namespace NServiceBus.Transport.AzureServiceBus
             return manager.GetTopicAsync(path);
         }
 
+        // TODO: delete this once NamespaceManagerAdapter is internalized
         public Task DeleteSubscriptionAsync(string topicPath, string subscriptionName)
         {
-            return manager.DeleteSubscriptionAsync(topicPath, subscriptionName);
+            return DeleteSubscription(new SubscriptionDescription(topicPath, subscriptionName));
+        }
+
+        public Task DeleteSubscription(SubscriptionDescription subscriptionDescription)
+        {
+            return manager.DeleteSubscriptionAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name);
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
@@ -119,7 +119,11 @@
                 {
                     if (await ExistsAsync(topicPath, subscriptionName, metadata.Description, namespaceManager, true).ConfigureAwait(false))
                     {
-                        await namespaceManager.DeleteSubscription(subscriptionDescription).ConfigureAwait(false);
+                        var namespaceManagerAbleToDeleteSubscriptions = namespaceManager as INamespaceManagerAbleToDeleteSubscriptions;
+                        if (namespaceManagerAbleToDeleteSubscriptions != null)
+                        {
+                            await namespaceManagerAbleToDeleteSubscriptions.DeleteSubscription(subscriptionDescription).ConfigureAwait(false);
+                        }
                     }
                 }
                 else

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
@@ -31,19 +31,23 @@
 
         public async Task DeleteSubscription(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo)
         {
+            var namespaceManagerAbleToDeleteSubscriptions = namespaceManager as INamespaceManagerAbleToDeleteSubscriptions;
+            if (namespaceManagerAbleToDeleteSubscriptions == null)
+            {
+                return;
+            }
+
             var subscriptionDescription = new SubscriptionDescription(topicPath, subscriptionName);
             
             // check the if the subscription with event name only is the one we should delete, i.e. event with another namespace owns it
             if (!await SubscriptionIsReusedAcrossDifferentNamespaces(subscriptionDescription, sqlFilter, namespaceManager).ConfigureAwait(false))
             {
                 logger.Debug("Deleting subscription using event type full name");
-                var alternativeSubscription = new SubscriptionDescription(topicPath, metadata.SubscriptionNameBasedOnEventWithNamespace);
-                await namespaceManager.DeleteSubscription(alternativeSubscription).ConfigureAwait(false);
-                return;
+                subscriptionDescription = new SubscriptionDescription(topicPath, metadata.SubscriptionNameBasedOnEventWithNamespace);
             }
 
             // delete subscription based on event name only
-            await namespaceManager.DeleteSubscription(subscriptionDescription).ConfigureAwait(false);
+            await namespaceManagerAbleToDeleteSubscriptions.DeleteSubscription(subscriptionDescription).ConfigureAwait(false);
         }
 
         async Task<bool> SubscriptionIsReusedAcrossDifferentNamespaces(SubscriptionDescription subscriptionDescription, string sqlFilter, INamespaceManager namespaceManager)

--- a/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
@@ -6,6 +6,11 @@
     public interface ICreateAzureServiceBusSubscriptions
     {
         Task<SubscriptionDescription> Create(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo);
+    }
+
+    // TODO Move into internalized ICreateAzureServiceBusSubscriptions in v8
+    public interface ICreateAzureServiceBusSubscriptionsAbleToDeleteSubscriptions
+    {
         Task DeleteSubscription(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo);
     }
 }

--- a/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
+++ b/src/Transport/Creation/ICreateAzureServiceBusSubscriptions.cs
@@ -6,5 +6,6 @@
     public interface ICreateAzureServiceBusSubscriptions
     {
         Task<SubscriptionDescription> Create(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo);
+        Task DeleteSubscription(string topicPath, string subscriptionName, SubscriptionMetadata metadata, string sqlFilter, INamespaceManager namespaceManager, string forwardTo);
     }
 }

--- a/src/Transport/Seam/SubscriptionManager.cs
+++ b/src/Transport/Seam/SubscriptionManager.cs
@@ -30,10 +30,10 @@ namespace NServiceBus.Transport.AzureServiceBus
             var section = topologySectionManager.DetermineResourcesToUnsubscribeFrom(eventType);
             await topologyOperator.Stop(section.Entities).ConfigureAwait(false);
 
-            var topologyCreatorThatCanDeleteSubscriptions = (topologyCreator as ICreateTopologyAbleToDeleteSubscriptions);
+            var topologyCreatorThatCanDeleteSubscriptions = (topologyCreator as ITearDownTopology);
             if (topologyCreatorThatCanDeleteSubscriptions != null)
             {
-                await topologyCreatorThatCanDeleteSubscriptions.TearDownSubscription(section).ConfigureAwait(false);
+                await topologyCreatorThatCanDeleteSubscriptions.TearDown(section).ConfigureAwait(false);
             }
         }
     }

--- a/src/Transport/Seam/SubscriptionManager.cs
+++ b/src/Transport/Seam/SubscriptionManager.cs
@@ -25,10 +25,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             topologyOperator.Start(section.Entities);
         }
 
-        public Task Unsubscribe(Type eventType, ContextBag context)
+        public async Task Unsubscribe(Type eventType, ContextBag context)
         {
             var section = topologySectionManager.DetermineResourcesToUnsubscribeFrom(eventType);
-            return topologyOperator.Stop(section.Entities);
+            await topologyCreator.TearDownSubscription(section).ConfigureAwait(false);
+            await topologyOperator.Stop(section.Entities).ConfigureAwait(false);
         }
     }
 }

--- a/src/Transport/Seam/SubscriptionManager.cs
+++ b/src/Transport/Seam/SubscriptionManager.cs
@@ -28,8 +28,13 @@ namespace NServiceBus.Transport.AzureServiceBus
         public async Task Unsubscribe(Type eventType, ContextBag context)
         {
             var section = topologySectionManager.DetermineResourcesToUnsubscribeFrom(eventType);
-            await topologyCreator.TearDownSubscription(section).ConfigureAwait(false);
             await topologyOperator.Stop(section.Entities).ConfigureAwait(false);
+
+            var topologyCreatorThatCanDeleteSubscriptions = (topologyCreator as ICreateTopologyAbleToDeleteSubscriptions);
+            if (topologyCreatorThatCanDeleteSubscriptions != null)
+            {
+                await topologyCreatorThatCanDeleteSubscriptions.TearDownSubscription(section).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Transport/Topology/ICreateTopology.cs
+++ b/src/Transport/Topology/ICreateTopology.cs
@@ -13,8 +13,8 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
 
     // TODO: Move into internalized ICreateTopology in v8
-    interface ICreateTopologyAbleToDeleteSubscriptions
+    interface ITearDownTopology
     {
-        Task TearDownSubscription(TopologySection topologySection);
+        Task TearDown(TopologySection topologySection);
     }
 }

--- a/src/Transport/Topology/ICreateTopology.cs
+++ b/src/Transport/Topology/ICreateTopology.cs
@@ -10,5 +10,6 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ICreateTopology
     {
         Task Create(TopologySection topology);
+        Task TearDownSubscription(TopologySection topologySection);
     }
 }

--- a/src/Transport/Topology/ICreateTopology.cs
+++ b/src/Transport/Topology/ICreateTopology.cs
@@ -10,6 +10,11 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface ICreateTopology
     {
         Task Create(TopologySection topology);
+    }
+
+    // Move into internalized ICreateTopology in v8
+    interface ICreateTopologyAbleToDeleteSubscriptions
+    {
         Task TearDownSubscription(TopologySection topologySection);
     }
 }

--- a/src/Transport/Topology/ICreateTopology.cs
+++ b/src/Transport/Topology/ICreateTopology.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         Task Create(TopologySection topology);
     }
 
-    // Move into internalized ICreateTopology in v8
+    // TODO: Move into internalized ICreateTopology in v8
     interface ICreateTopologyAbleToDeleteSubscriptions
     {
         Task TearDownSubscription(TopologySection topologySection);

--- a/src/Transport/Topology/TopologyCreator.cs
+++ b/src/Transport/Topology/TopologyCreator.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Linq;
     using System.Threading.Tasks;
 
-    class TopologyCreator : ICreateTopology
+    class TopologyCreator : ICreateTopology, ICreateTopologyAbleToDeleteSubscriptions
     {
         ITransportPartsContainer container;
         IManageNamespaceManagerLifeCycle namespaces;

--- a/src/Transport/Topology/TopologyCreator.cs
+++ b/src/Transport/Topology/TopologyCreator.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Linq;
     using System.Threading.Tasks;
 
-    class TopologyCreator : ICreateTopology, ICreateTopologyAbleToDeleteSubscriptions
+    class TopologyCreator : ICreateTopology, ITearDownTopology
     {
         ITransportPartsContainer container;
         IManageNamespaceManagerLifeCycle namespaces;
@@ -52,7 +52,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
         }
 
-        public async Task TearDownSubscription(TopologySection topologySection)
+        public async Task TearDown(TopologySection topologySection)
         {
             var subscriptions = topologySection.Entities.Where(e => e.Type == EntityType.Subscription).ToList();
             if (subscriptions.Any())

--- a/src/Transport/Topology/TopologyCreator.cs
+++ b/src/Transport/Topology/TopologyCreator.cs
@@ -58,18 +58,27 @@ namespace NServiceBus.Transport.AzureServiceBus
             if (subscriptions.Any())
             {
                 var subscriptionCreator = (ICreateAzureServiceBusSubscriptions)container.Resolve(typeof(ICreateAzureServiceBusSubscriptions));
+
+                var subscriptionCreatorAbleToDeleteSubscriptions = subscriptionCreator as ICreateAzureServiceBusSubscriptionsAbleToDeleteSubscriptions;
+                if (subscriptionCreatorAbleToDeleteSubscriptions == null)
+                {
+                    return;
+                }
+
                 foreach (var subscription in subscriptions)
                 {
                     var topic = subscription.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
                     var forwardTo = subscription.RelationShips.FirstOrDefault(r => r.Type == EntityRelationShipType.Forward);
                     var sqlFilter = (subscription as SubscriptionInfo)?.BrokerSideFilter.Serialize();
                     var metadata = (subscription as SubscriptionInfo)?.Metadata ?? new SubscriptionMetadata();
-                    await subscriptionCreator.DeleteSubscription(topicPath: topic.Target.Path, 
-                                                     subscriptionName: subscription.Path, 
-                                                     metadata: metadata, 
-                                                     sqlFilter: sqlFilter, 
-                                                     namespaceManager: namespaces.Get(subscription.Namespace.Alias), 
-                                                     forwardTo: forwardTo?.Target.Path).ConfigureAwait(false);
+
+
+                    await subscriptionCreatorAbleToDeleteSubscriptions.DeleteSubscription(topicPath: topic.Target.Path, 
+                        subscriptionName: subscription.Path, 
+                        metadata: metadata, 
+                        sqlFilter: sqlFilter, 
+                        namespaceManager: namespaces.Get(subscription.Namespace.Alias), 
+                        forwardTo: forwardTo?.Target.Path).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
Fixes #392

To implement unsubscribe functionality, 3 internal contracts were added to avoid public API changes (additions) which will be internalized in 7.1.0:

```diff
public interface ICreateTopologyAbleToDeleteSubscriptions
{
+  System.Threading.Tasks.Task TearDownSubscription(NServiceBus.Transport.AzureServiceBus.TopologySection topologySection);
}

public interface INamespaceManagerAbleToDeleteSubscriptions
{
+  DeleteSubscription(Microsoft.ServiceBus.Messaging.SubscriptionDescription subscriptionDescription);
}      

public interface ICreateAzureServiceBusSubscriptionsAbleToDeleteSubscriptions
{
+  System.Threading.Tasks.Task DeleteSubscription(string topicPath, string subscriptionName, NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata metadata, string sqlFilter, NServiceBus.Transport.AzureServiceBus.INamespaceManager namespaceManager, string forwardTo);
}
```

~~According to SemVer, this should not be a hotfix, but a minor version. There's already a [PR targeting next minor](https://github.com/Particular/NServiceBus.AzureServiceBus/pull/388) which discusses making these contracts internal. In addition, there's a [bug fix PR](https://github.com/Particular/NServiceBus.AzureServiceBus/pull/393) that was originally targeting  `hotfix-7.0.3`.~~

I suggest we first agree on #388 and based on that decide on the next steps.

### Related items are

- Bug fix for #391 (PR #393)
- Bug fix for #392 (this PR)
- Internalizing contracts #390 (PR #388)

**Update**: agreement was reached on #388. 