### PR TITLE
Applying batch flush interval for AMQP

### DIFF
--- a/src/Transport/Connectivity/MessagingFactoryCreator.cs
+++ b/src/Transport/Connectivity/MessagingFactoryCreator.cs
@@ -8,12 +8,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class MessagingFactoryCreator : ICreateMessagingFactories
     {
-        IManageNamespaceManagerLifeCycle namespaceManagers;
-        Func<string, MessagingFactorySettings> settingsFactory;
-        RetryPolicy retryPolicy;
-        TransportType transportType;
-        TimeSpan batchFlushInterval;
-
         public MessagingFactoryCreator(IManageNamespaceManagerLifeCycle namespaceManagers, ReadOnlySettings settings)
         {
             this.namespaceManagers = namespaceManagers;
@@ -79,5 +73,11 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             return new MessagingFactoryAdapter(inner);
         }
+
+        IManageNamespaceManagerLifeCycle namespaceManagers;
+        Func<string, MessagingFactorySettings> settingsFactory;
+        RetryPolicy retryPolicy;
+        TransportType transportType;
+        TimeSpan batchFlushInterval;
     }
 }

--- a/src/Transport/Connectivity/MessagingFactoryCreator.cs
+++ b/src/Transport/Connectivity/MessagingFactoryCreator.cs
@@ -26,17 +26,33 @@ namespace NServiceBus.Transport.AzureServiceBus
                 {
                     var namespaceManager = this.namespaceManagers.Get(namespaceName);
 
-                    var s = new MessagingFactorySettings
+                    var transportType = this.settings.Get<TransportType>(WellKnownConfigurationKeys.Connectivity.TransportType);
+
+                    var factorySettings = new MessagingFactorySettings
                     {
                         TokenProvider = namespaceManager.Settings.TokenProvider,
-                        NetMessagingTransportSettings =
-                        {
-                            BatchFlushInterval = settings.Get<TimeSpan>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.BatchFlushInterval)
-                        },
-                        TransportType = settings.Get<TransportType>(WellKnownConfigurationKeys.Connectivity.TransportType)
+                        TransportType = transportType
                     };
 
-                    return s;
+                    var batchFlushInterval = this.settings.Get<TimeSpan>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.BatchFlushInterval);
+
+                    switch (transportType)
+                    {
+                        case TransportType.NetMessaging:
+                            factorySettings.NetMessagingTransportSettings = new NetMessagingTransportSettings
+                            {
+                                BatchFlushInterval = batchFlushInterval,
+                            };
+                            break;
+                        case TransportType.Amqp:
+                            factorySettings.AmqpTransportSettings = new AmqpTransportSettings
+                            {
+                                BatchFlushInterval = batchFlushInterval,
+                            };
+                            break;
+                    }
+
+                    return factorySettings;
                 };
             }
         }

--- a/src/Transport/Connectivity/MessagingFactoryCreator.cs
+++ b/src/Transport/Connectivity/MessagingFactoryCreator.cs
@@ -12,11 +12,15 @@ namespace NServiceBus.Transport.AzureServiceBus
         Func<string, MessagingFactorySettings> settingsFactory;
         ReadOnlySettings settings;
         RetryPolicy retryPolicy;
+        TransportType transportType;
+        TimeSpan batchFlushInterval;
 
         public MessagingFactoryCreator(IManageNamespaceManagerLifeCycle namespaceManagers, ReadOnlySettings settings)
         {
             this.namespaceManagers = namespaceManagers;
             this.settings = settings;
+            transportType = this.settings.Get<TransportType>(WellKnownConfigurationKeys.Connectivity.TransportType);
+            batchFlushInterval = this.settings.Get<TimeSpan>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.BatchFlushInterval);
 
             if (settings.HasExplicitValue(WellKnownConfigurationKeys.Connectivity.MessagingFactories.RetryPolicy))
             {
@@ -33,28 +37,24 @@ namespace NServiceBus.Transport.AzureServiceBus
                 {
                     var namespaceManager = this.namespaceManagers.Get(namespaceName);
 
-                    var transportType = this.settings.Get<TransportType>(WellKnownConfigurationKeys.Connectivity.TransportType);
-
                     var factorySettings = new MessagingFactorySettings
                     {
                         TokenProvider = namespaceManager.Settings.TokenProvider,
                         TransportType = transportType
                     };
 
-                    var batchFlushInterval = this.settings.Get<TimeSpan>(WellKnownConfigurationKeys.Connectivity.MessagingFactories.BatchFlushInterval);
-
                     switch (transportType)
                     {
                         case TransportType.NetMessaging:
                             factorySettings.NetMessagingTransportSettings = new NetMessagingTransportSettings
                             {
-                                BatchFlushInterval = batchFlushInterval,
+                                BatchFlushInterval = batchFlushInterval
                             };
                             break;
                         case TransportType.Amqp:
                             factorySettings.AmqpTransportSettings = new AmqpTransportSettings
                             {
-                                BatchFlushInterval = batchFlushInterval,
+                                BatchFlushInterval = batchFlushInterval
                             };
                             break;
                     }


### PR DESCRIPTION
Closes #389 

* Assigns the batch flush interval for SMB and or AMQP depending on the transport type
* Reduces the runtime access to settings
* Applies reformat as discussed as a dedicated commit for simplified reviewing