### PR TITLE
RuntimeNamespaceInfo should not be internal

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -812,8 +812,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         public string ViaEntityPath { get; set; }
         public string ViaPartitionKey { get; set; }
     }
-    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
-        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class RuntimeNamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo>
     {
         public RuntimeNamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1, NServiceBus.Transport.AzureServiceBus.NamespaceMode mode = 0) { }

--- a/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
@@ -2,7 +2,6 @@
 {
     using System;
 
-    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class RuntimeNamespaceInfo : IEquatable<RuntimeNamespaceInfo>
     {
         readonly NamespaceInfo info;


### PR DESCRIPTION
If `RuntimeNamespaceInfo` is internalized, no custom partitioning strategy can be created.
Creating custom partitioning strategies should still be allowed in version 7.1.0