### PR TITLE
Shutdown notifier when all references are gone

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -812,8 +812,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         public string ViaEntityPath { get; set; }
         public string ViaPartitionKey { get; set; }
     }
-    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
-        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class RuntimeNamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo>
     {
         public RuntimeNamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1, NServiceBus.Transport.AzureServiceBus.NamespaceMode mode = 0) { }

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -19,6 +19,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             this.clientEntities = clientEntities;
             this.brokeredMessageConverter = brokeredMessageConverter;
             this.settings = settings;
+            RefCount = 1;
         }
 
         bool ShouldReceiveMessages => !stopping || isRunning;

--- a/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/RuntimeNamespaceInfo.cs
@@ -2,7 +2,6 @@
 {
     using System;
 
-    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class RuntimeNamespaceInfo : IEquatable<RuntimeNamespaceInfo>
     {
         readonly NamespaceInfo info;

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -132,11 +132,8 @@ namespace NServiceBus.Transport.AzureServiceBus
                     continue;
                 }
 
-                if (notifier.RefCount > 0)
-                {
-                    notifier.RefCount--;
-                }
-                else
+                notifier.RefCount--;
+                if (notifier.RefCount <= 0)
                 {
                     await notifier.Stop().ConfigureAwait(false);
                 }


### PR DESCRIPTION
When RefCount is one we would just decrease the RefCount but not shutdown.

This will make sure we shut down when all references are gone.