### PR TITLE
Namespace managers and FailOverNamespacePartitioning fixes

### DIFF
--- a/src/Tests/Addressing/NamespacePartitioning/When_using_failover_namespace_strategy.cs
+++ b/src/Tests/Addressing/NamespacePartitioning/When_using_failover_namespace_strategy.cs
@@ -32,11 +32,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         }
 
         [Test]
-        public void Failover_partitioning_strategy_will_return_a_single_active_namespace_for_the_purpose_of_sending()
+        public void Failover_partitioning_strategy_will_return_a_all_namespace_for_the_purpose_of_sending()
         {
             var namespaces = strategy.GetNamespaces(PartitioningIntent.Sending);
 
-            Assert.AreEqual(1, namespaces.Count());
+            Assert.AreEqual(2, namespaces.Count());
         }
 
         [Test]
@@ -64,13 +64,13 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.NamespacePar
         }
 
         [Test]
-        public void Failover_partitioning_strategy_will_return_secondary_namespace_when_in_secondary_state()
+        public void Failover_partitioning_strategy_will_return_primary_and_secondary_namespace_when_in_secondary_state()
         {
             strategy.Mode = FailOverMode.Secondary;
 
             var namespaces = strategy.GetNamespaces(PartitioningIntent.Sending);
 
-            Assert.AreEqual(new RuntimeNamespaceInfo(SecondaryName, SecondaryConnectionString), namespaces.First());
+            Assert.AreEqual(new RuntimeNamespaceInfo(SecondaryName, SecondaryConnectionString), namespaces.Last());
         }
 
         [Test]

--- a/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
@@ -56,5 +56,37 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
         class SomeMessageType
         {
         }
+
+        [Test]
+        public void Returns_active_and_passive_namespaces_for_partitioned_sends()
+        {
+            var container = new TransportPartsContainer();
+
+            // setup using FailOverNamespacePartitioning to ensure we have active and passive namespaces for a failover
+            var topology = SetupEndpointOrientedTopologyWithFailoverNamespace(container, "sales");
+
+            var destination = topology.DetermineSendDestination("operations");
+
+            Assert.AreEqual(2, destination.Entities.Count(), "active and passive namespace should be returned");
+        }
+
+        ITopologySectionManager SetupEndpointOrientedTopologyWithFailoverNamespace(TransportPartsContainer container, string enpointname)
+        {
+            var settings = new SettingsHolder();
+            settings.Set<Conventions>(new Conventions());
+            container.Register(typeof(SettingsHolder), () => settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+            settings.SetDefault("NServiceBus.Routing.EndpointName", enpointname);
+            extensions.NamespacePartitioning().AddNamespace("namespace1", AzureServiceBusConnectionString.Value);
+            extensions.NamespacePartitioning().AddNamespace("namespace2", AzureServiceBusConnectionString.Fallback);
+            extensions.NamespacePartitioning().UseStrategy<FailOverNamespacePartitioning>();
+
+            var topology = new EndpointOrientedTopology(container);
+
+            topology.Initialize(settings);
+
+            return container.Resolve<ITopologySectionManager>();
+        }
+
     }
 }

--- a/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
@@ -55,5 +55,36 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
         class SomeMessageType
         {
         }
+
+        [Test]
+        public void Returns_active_and_passive_namespaces_for_partitioned_sends()
+        {
+            var container = new TransportPartsContainer();
+
+            // setup using FailOverNamespacePartitioning to ensure we have active and passive namespaces for a failover
+            var topology = SetupForwardingTopologyWithFailoverNamespace(container, "sales");
+
+            var destination = topology.DetermineSendDestination("operations");
+
+            Assert.AreEqual(2, destination.Entities.Count(), "active and passive namespace should be returned");
+        }
+
+        ITopologySectionManager SetupForwardingTopologyWithFailoverNamespace(TransportPartsContainer container, string enpointname)
+        {
+            var settings = new SettingsHolder();
+            container.Register(typeof(SettingsHolder), () => settings);
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+            settings.SetDefault("NServiceBus.Routing.EndpointName", enpointname);
+            extensions.NamespacePartitioning().AddNamespace("namespace1", AzureServiceBusConnectionString.Value);
+            extensions.NamespacePartitioning().AddNamespace("namespace2", AzureServiceBusConnectionString.Fallback);
+            extensions.NamespacePartitioning().UseStrategy<FailOverNamespacePartitioning>();
+
+            var topology = new ForwardingTopology(container);
+
+            topology.Initialize(settings);
+
+            return container.Resolve<ITopologySectionManager>();
+        }
+
     }
 }

--- a/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
@@ -36,18 +36,8 @@
             var primary = namespaces.First();
             var secondary = namespaces.Last();
 
-            if (partitioningIntent == PartitioningIntent.Sending)
-            {
-                yield return Mode == FailOverMode.Primary
-                ? new RuntimeNamespaceInfo(primary.Alias, primary.ConnectionString, primary.Purpose, NamespaceMode.Active)
-                : new RuntimeNamespaceInfo(secondary.Alias, secondary.ConnectionString, secondary.Purpose, NamespaceMode.Active);
-            }
-
-            if (partitioningIntent == PartitioningIntent.Creating || partitioningIntent == PartitioningIntent.Receiving)
-            {
-                yield return new RuntimeNamespaceInfo(primary.Alias, primary.ConnectionString, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive);
-                yield return new RuntimeNamespaceInfo(secondary.Alias, secondary.ConnectionString, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive);
-            }
+            yield return new RuntimeNamespaceInfo(primary.Alias, primary.ConnectionString, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive);
+            yield return new RuntimeNamespaceInfo(secondary.Alias, secondary.ConnectionString, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive);
         }
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -135,7 +135,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
             else // sending to the partition
             {
-                namespaces = partitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
+                namespaces = partitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
             }
 
             if (namespaces == null)

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -157,7 +157,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 }
                 else // sending to the partition
                 {
-                    namespaces = partitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
+                    namespaces = partitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
                 }
 
                 if (namespaces == null)


### PR DESCRIPTION
Partially addresses issue #406.

Discussed by @Particular/azure-service-bus-maintainers on a call ([summary](https://github.com/Particular/NServiceBus.AzureServiceBus/issues/406#issuecomment-258554790))

- Section managers incorrectly filtering out passive namespaces for partitioned sends. Section managers were filtering out namespaces when should not have. 
- FailOverNamespacePartitioning returns incorrect values. Regardless of the partitioning intent, all namespaces should have been returned.

This PR does **not** address the issue with not failing over on incoming message error. That should be a separate PR.