### PR TITLE
Failing over on incoming message error

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -237,7 +237,7 @@
         Subscription = 2,
         Rule = 3,
     }
-    public class FailOverNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
+    public class FailOverNamespacePartitioning : NServiceBus.IPerformNamespacePartitioningFailOver, NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
         public FailOverNamespacePartitioning(NServiceBus.Settings.ReadOnlySettings settings) { }
         public NServiceBus.Transport.AzureServiceBus.FailOverMode Mode { get; set; }

--- a/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
+++ b/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
@@ -42,7 +42,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             extensions.SendViaReceiveQueue(true);
 
             // setup the receive side of things
-            var pump = new MessagePump(topology, container, settings);
+            var pump = new MessagePump(topology, container, null, settings);
 
             // setup the dispatching side of things
             var dispatcher = (IDispatchMessages)container.Resolve(typeof(IDispatchMessages));
@@ -119,7 +119,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var topology = await SetupEndpointOrientedTopology(container, "sales", settings);
 
             // setup the receive side of things
-            var pump = new MessagePump(topology, container, settings);
+            var pump = new MessagePump(topology, container, null, settings);
 
             // setup the dispatching side of things
             var dispatcher = (IDispatchMessages)container.Resolve(typeof(IDispatchMessages));
@@ -202,7 +202,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var topology = await SetupEndpointOrientedTopology(container, "sales", settings);
 
             // setup the receive side of things
-            var pump = new MessagePump(topology, container, settings);
+            var pump = new MessagePump(topology, container, null, settings);
 
             // setup the dispatching side of things
             var dispatcher = (IDispatchMessages)container.Resolve(typeof(IDispatchMessages));

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -41,7 +41,7 @@
             });
             criticalError.GetType().GetMethod("SetEndpoint", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Invoke(criticalError, new[] { new FakeEndpoint() });
 
-            var pump = new MessagePump(new FakeTopology(), container, settings);
+            var pump = new MessagePump(new FakeTopology(), container, null, settings);
             await pump.Init(context => TaskEx.Completed, null, criticalError, new PushSettings("sales", "error", false, TransportTransactionMode.ReceiveOnly));
             pump.OnError(exception =>
             {

--- a/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
+++ b/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             new DefaultConfigurationValues().Apply(settings);
             container.Register<ReadOnlySettings>(() => settings);
 
-            var pump = new MessagePump(null, container, settings);
+            var pump = new MessagePump(null, container, null, settings);
             var criticalError = new CriticalError(ctx => TaskEx.Completed);
 
             const bool purgeOnStartup = true;

--- a/src/Tests/Seam/When_receiving_messages.cs
+++ b/src/Tests/Seam/When_receiving_messages.cs
@@ -33,10 +33,9 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             var topology = await SetupEndpointOrientedTopology(container, "sales");
 
             // setup the operator
-            var pump = new MessagePump(topology, container, settings);
+            var pump = new MessagePump(topology, container, null, settings);
 
             var completed = new AsyncAutoResetEvent(false);
-            //var error = new AsyncAutoResetEvent(false);
 
             var received = false;
             Exception ex = null;

--- a/src/Transport/Addressing/Partitioning/IPerformNamespacePartitioningFailOver.cs
+++ b/src/Transport/Addressing/Partitioning/IPerformNamespacePartitioningFailOver.cs
@@ -1,0 +1,7 @@
+﻿namespace NServiceBus
+{
+    interface IPerformNamespacePartitioningFailOver
+    {
+        void FailOver();
+    }
+}

--- a/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
@@ -6,7 +6,7 @@
     using Transport.AzureServiceBus;
     using Settings;
 
-    public class FailOverNamespacePartitioning : INamespacePartitioningStrategy
+    public class FailOverNamespacePartitioning : INamespacePartitioningStrategy, IPerformNamespacePartitioningFailOver
     {
         NamespaceConfigurations namespaces;
 
@@ -38,6 +38,18 @@
 
             yield return new RuntimeNamespaceInfo(primary.Alias, primary.ConnectionString, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive);
             yield return new RuntimeNamespaceInfo(secondary.Alias, secondary.ConnectionString, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive);
+        }
+
+        void IPerformNamespacePartitioningFailOver.FailOver()
+        {
+            if (Mode == FailOverMode.Primary)
+            {
+                Mode = FailOverMode.Secondary;
+            }
+            else
+            {
+                Mode = FailOverMode.Primary;
+            }
         }
     }
 }

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Addressing\Partitioning\Strategies\FailOverMode.cs" />
     <Compile Include="Addressing\Individualization\Strategies\CoreIndividualization.cs" />
     <Compile Include="Addressing\Individualization\Strategies\DiscriminatorBasedIndividualization.cs" />
+    <Compile Include="Addressing\Partitioning\IPerformNamespacePartitioningFailOver.cs" />
     <Compile Include="Addressing\Sanitization\Strategies\ValidateAndHashIfNeeded.cs" />
     <Compile Include="Addressing\Sanitization\ValidationResult.cs" />
     <Compile Include="CircuitBreakers\RepeatedFailuresOverTimeCircuitBreaker.cs" />

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -14,6 +14,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         ITopologySectionManager topologySectionManager;
         readonly ITransportPartsContainer container;
+        readonly INamespacePartitioningStrategy namespacePartitioningStrategy;
         IOperateTopology topologyOperator;
         Func<MessageContext, Task> messagePump;
         RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
@@ -22,10 +23,11 @@ namespace NServiceBus.Transport.AzureServiceBus
         SatelliteTransportAddressCollection satelliteTransportAddresses;
         SemaphoreSlim throttler;
 
-        public MessagePump(ITopologySectionManager topologySectionManager, ITransportPartsContainer container, ReadOnlySettings settings)
+        public MessagePump(ITopologySectionManager topologySectionManager, ITransportPartsContainer container, INamespacePartitioningStrategy namespacePartitioningStrategy, ReadOnlySettings settings)
         {
             this.topologySectionManager = topologySectionManager;
             this.container = container;
+            this.namespacePartitioningStrategy = namespacePartitioningStrategy;
             satelliteTransportAddresses = settings.Get<SatelliteTransportAddressCollection>();
         }
 
@@ -93,6 +95,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             topologyOperator.OnError(async exception =>
             {
                 await circuitBreaker.Failure(exception).ConfigureAwait(false);
+
+                // in case of failover partitioning strategy, fail over
+                var namespacePartitioningStrategyWithFailover = namespacePartitioningStrategy as IPerformNamespacePartitioningFailOver;
+                namespacePartitioningStrategyWithFailover?.FailOver();
+
                 await func(exception).ConfigureAwait(false);
             });
         }


### PR DESCRIPTION
This PR was branched of PR #415 as it depends on the fixes from #415.
Both PRs together address bug #406.

## Description

When a `FailOverNamespacePartitioning` strategy is used, message pump will instruct the strategy to fail over to the passive namespace if error reported by OnMessage API (ASB client) while using the primary namespace.