### PR TITLE
Message routing - use active namespaces first

### DIFF
--- a/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
+++ b/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
@@ -51,7 +51,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             var passiveNamespaces = batch.Destinations.Namespaces.Where(n => n.Mode == NamespaceMode.Passive).ToList();
             var pendingSends = new List<Task>();
 
-            foreach (var entity in batch.Destinations.Entities)
+            foreach (var entity in batch.Destinations.Entities.Where(entity => entity.Namespace.Mode == NamespaceMode.Active))
             {
                 var routingOptions = GetRoutingOptions(context, consistency);
 


### PR DESCRIPTION
As part of the fix for issue #406 in PR #415 (Namespace managers and FailOverNamespacePartitioning fixes), section managers ([`EndpointOrientedTopologySectionManager`](https://github.com/Particular/NServiceBus.AzureServiceBus/pull/415/commits/6364a832b5b12f4f23c12963fe2573229320bd39#diff-7ccd1556a44585057aa61f115e9cb3a4R138) and [`ForwardingTopologySectionManager`](https://github.com/Particular/NServiceBus.AzureServiceBus/pull/415/commits/6364a832b5b12f4f23c12963fe2573229320bd39#diff-a135cb6bf20a8a4e627120877fbb9833R160)) were fixed to return _all_ namespaces w/o filtering out passive ones. This has introduces a problem for `DefaultOutgoingBatchRouter` as it was supposed to attempt sending messages over active namespaces first, and only if that fails, to try fallback namespaces (passive ones).

This PR filters out passive namespaces to allow first attempt to send out messages to be performed solely on active namespaces, and later, if unsuccessful, attempt fallback namespaces.