### PR TITLE
Shutdown race

### DIFF
--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             batchedCompletionTasks = new Task[numberOfClients];
             internalReceivers = new IMessageReceiver[numberOfClients];
-            options = new OnMessageOptions[numberOfClients];
+            onMessageOptions = new OnMessageOptions[numberOfClients];
         }
 
         public void Start()
@@ -89,7 +89,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     PerformBatchedCompletionTask(internalReceiver, i);
 
                     internalReceivers[i] = internalReceiver;
-                    options[i] = onMessageOptions;
+                    this.onMessageOptions[i] = onMessageOptions;
 
                     isRunning = true;
                 }
@@ -107,7 +107,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             logger.Info($"Stopping notifier for '{fullPath}'");
 
-            foreach (var option in options)
+            foreach (var option in onMessageOptions)
             {
                 option.ExceptionReceived -= OptionsOnExceptionReceived;
             }
@@ -134,7 +134,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             pipelineInvocationTasks.Clear();
             Array.Clear(batchedCompletionTasks, 0, batchedCompletionTasks.Length);
             Array.Clear(internalReceivers, 0, internalReceivers.Length);
-            Array.Clear(options, 0, options.Length);
+            Array.Clear(onMessageOptions, 0, onMessageOptions.Length);
 
             logger.Info($"Notifier for '{fullPath}' stopped");
 
@@ -345,7 +345,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         ReadOnlySettings settings;
         IMessageReceiver[] internalReceivers;
         ReceiveMode receiveMode;
-        OnMessageOptions[] options;
+        OnMessageOptions[] onMessageOptions;
         Func<IncomingMessageDetails, ReceiveContext, Task> incomingCallback;
         Func<Exception, Task> errorCallback;
         ConcurrentDictionary<Task, Task> pipelineInvocationTasks;

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -294,7 +294,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     }
                     else
                     {
-                        await context.IncomingBrokeredMessage.CompleteAsync().ConfigureAwait(false);
+                        await context.IncomingBrokeredMessage.SafeCompleteAsync().ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -319,15 +319,15 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             using (var suppressScope = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             {
-                logger.InfoFormat("Abandoning brokered message {0}", message.MessageId);
+                logger.DebugFormat("Abandoning brokered message {0}", message.MessageId);
 
                 if (await message.SafeAbandonAsync(propertiesToModify).ConfigureAwait(false))
                 {
-                    logger.InfoFormat("Brokered message {0} abandoned successfully.", message.MessageId);
+                    logger.DebugFormat("Brokered message {0} abandoned successfully.", message.MessageId);
                 }
                 else
                 {
-                    logger.InfoFormat("Abandoning brokered message {0} failed. Message will reappear after peek lock duration is over.", message.MessageId);
+                    logger.DebugFormat("Abandoning brokered message {0} failed. Message will reappear after peek lock duration is over.", message.MessageId);
                 }
 
                 suppressScope.Complete();

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -20,6 +20,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             this.settings = settings;
             locksTokensToComplete = new ConcurrentStack<Guid>();
             batchedCompletionCts = new CancellationTokenSource();
+            RefCount = 1;
         }
 
         bool ShouldReceiveMessages => !stopping || isRunning;

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -23,7 +23,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             RefCount = 1;
         }
 
-        bool ShouldReceiveMessages => !stopping || isRunning;
+        bool ShouldReceiveMessages => !stopping;
 
         public bool IsRunning => isRunning;
 
@@ -130,6 +130,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             await Task.WhenAll(closeTasks).ConfigureAwait(false);
 
             pipelineInvocationTasks.Clear();
+            Array.Clear(batchedCompletionTasks, 0, batchedCompletionTasks.Length);
             Array.Clear(internalReceivers, 0, internalReceivers.Length);
             Array.Clear(options, 0, options.Length);
 
@@ -145,24 +146,26 @@ namespace NServiceBus.Transport.AzureServiceBus
             //- Exceptions raised during the time that your code is processing the BrokeredMessage
             //- It is raised when the receive process successfully completes. (Does not seem to be the case)
 
-            if (!stopping) //- It is raised when the underlying connection closes because of our close operation
+            if (!ShouldReceiveMessages)
             {
-                var messagingException = exceptionReceivedEventArgs.Exception as MessagingException;
-                if (messagingException != null && messagingException.IsTransient)
-                {
-                    logger.DebugFormat("OptionsOnExceptionReceived invoked, action: '{0}', transient exception with message: {1}", exceptionReceivedEventArgs.Action, messagingException.Detail.Message);
+                logger.Info($"OptionsOnExceptionReceived invoked, action: '{exceptionReceivedEventArgs.Action}' while shutting down.");
+                return;
+            }
 
-                    // TODO ideally we'd failover to another space if in a certain period of time there are too many transient errors
-                }
-                else
-                {
-                    logger.Info($"OptionsOnExceptionReceived invoked, action: '{exceptionReceivedEventArgs.Action}', with non-transient exception.", exceptionReceivedEventArgs.Exception);
+            //- It is raised when the underlying connection closes because of our close operation
+            var messagingException = exceptionReceivedEventArgs.Exception as MessagingException;
+            if (messagingException != null && messagingException.IsTransient)
+            {
+                logger.DebugFormat("OptionsOnExceptionReceived invoked, action: '{0}', transient exception with message: {1}", exceptionReceivedEventArgs.Action, messagingException.Detail.Message);
+            }
+            else
+            {
+                logger.Info($"OptionsOnExceptionReceived invoked, action: '{exceptionReceivedEventArgs.Action}', with non-transient exception.", exceptionReceivedEventArgs.Exception);
 
-                    errorCallback?.Invoke(exceptionReceivedEventArgs.Exception).GetAwaiter().GetResult();
-                }
+                errorCallback?.Invoke(exceptionReceivedEventArgs.Exception).GetAwaiter().GetResult();
             }
         }
-        
+
         Task ReceiveMessage(IMessageReceiver internalReceiver, BrokeredMessage message, ConcurrentDictionary<Task, Task> pipelineInvocations)
         {
             var processTask = ProcessMessage(internalReceiver, message);

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -119,11 +119,8 @@ namespace NServiceBus.Transport.AzureServiceBus
                     continue;
                 }
 
-                if (notifier.RefCount > 0)
-                {
-                    notifier.RefCount--;
-                }
-                else
+                notifier.RefCount--;
+                if (notifier.RefCount <= 0)
                 {
                     await notifier.Stop().ConfigureAwait(false);
                 }


### PR DESCRIPTION
Let's first review and squash #430 branch before we merge this in.

Closes #433 

## Changes introduced

* Shutdown notifier when all references are gone #409 
* Using dedicated OnMessageOptions per receiver #408 
* Guard the `OptionsOnExceptionReceived `with a try / catch to not throw to the SDK
* `OptionsOnExceptionReceived ` made async void because we don't want to hold up the SDK calls when we invoke the error callback
* Even when core instructed the transport to do an immediate retry we triggered before the errorCallback. This was not an issue since the error callback was not properly wired. With the changes introduced in #430 this would become a problem. We now only trigger the error callback when we are receiving a callback from the SDK in `OptionsOnExceptionReceived ` or when we could execute the operations to abandon or complete a messages after recoverability.
* While shutting down the settings bag will get cleared. Moved the wrapInScope and the completion in batch check into the Initialize method and rely on the cached value since this will never change during runtime
* Using `SafeCompleteAsync `to complete messages, closes https://github.com/Particular/NServiceBus.AzureServiceBus/issues/402
* It also changes the way ASB handles message exceptions. The processing messages should be now mostly safe as it's designed to do not throw exceptions (there's a `try-catch` that abandons message and calls the `errorCallback`). If by any changes an exception is thrown, the control is passed to the registered to ASB exception handler, which is `async void` running the `errorCallback` as the last step. It's highly unlikely that an exception is thrown in there (as marking the endpoint as `isStopping`) which is covered by the last `try-catch` block. With these changes, the endpoint won't any longer `FailFast` as there are no exceptions that are thrown by the handler.


@tmasternak @Scooletz here we go.