### PR TITLE
Types used for namespace partitioning are no longer obsoleted

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -725,8 +725,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         public MessageTooLargeException(string message, System.Exception inner) { }
         protected MessageTooLargeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
-        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class NamespaceConfigurations : System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.NamespaceInfo>, System.Collections.IEnumerable
     {
         public NamespaceConfigurations() { }
@@ -735,8 +733,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         public string GetConnectionString(string name) { }
         public System.Collections.Generic.IEnumerator<NServiceBus.Transport.AzureServiceBus.NamespaceInfo> GetEnumerator() { }
     }
-    [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
-        "sion 8.0.0. Will be removed in version 9.0.0.", false)]
     public class NamespaceInfo : System.IEquatable<NServiceBus.Transport.AzureServiceBus.NamespaceInfo>
     {
         public NamespaceInfo(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose = 1) { }

--- a/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
@@ -6,7 +6,6 @@
     using System.Linq;
     using Logging;
 
-    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceConfigurations : IEnumerable<NamespaceInfo>
     {
         static ILog Log = LogManager.GetLogger(typeof(NamespaceConfigurations));

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -2,7 +2,6 @@
 {
     using System;
 
-    [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class NamespaceInfo : IEquatable<NamespaceInfo>
     {
         public string Alias { get; }


### PR DESCRIPTION
Closes #404 

For more details see the issue for details