### PR TITLE
Move the ObsoleteMessages where it belongs

### DIFF
--- a/src/Transport/Topology/ITopology.cs
+++ b/src/Transport/Topology/ITopology.cs
@@ -6,11 +6,6 @@ namespace NServiceBus.Transport.AzureServiceBus
     using Settings;
     using Transport;
 
-    static class ObsoleteMessages
-    {
-        public const string InternalizedContract = "Internal contract.";
-    }
-
     interface ITopologyInternal
     {
         void Initialize(SettingsHolder settings);

--- a/src/Transport/obsoletes.cs
+++ b/src/Transport/obsoletes.cs
@@ -5,6 +5,11 @@
     using Settings;
     using Transport.AzureServiceBus;
 
+    static class ObsoleteMessages
+    {
+        public const string InternalizedContract = "Internal contract.";
+    }
+
     [ObsoleteEx(Message = ObsoleteMessages.InternalizedContract, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class ForwardingTopology : ITopology { }
 


### PR DESCRIPTION
Moving into `obsolete.cs` rather than keeping with `ITopologyInternal`

@Particular/azure-maintainers please review