### PR TITLE
NamespaceManagerCreator is no longer on the container

### DIFF
--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -15,6 +15,8 @@ namespace NServiceBus
         ILog logger = LogManager.GetLogger("EndpointOrientedTopology");
         ITopologySectionManagerInternal topologySectionManager;
         ITransportPartsContainerInternal container;
+        NamespaceManagerCreator namespaceManagerCreator;
+        NamespaceManagerLifeCycleManagerInternal namespaceManagerLifeCycleManagerInternal;
 
         public EndpointOrientedTopologyInternal() : this(new TransportPartsContainer()){ }
 
@@ -48,8 +50,11 @@ namespace NServiceBus
             // runtime components
             container.Register<ReadOnlySettings>(() => settings);
             container.Register<ITopologySectionManagerInternal>(() => topologySectionManager);
-            container.RegisterSingleton<NamespaceManagerCreator>();
-            container.RegisterSingleton<NamespaceManagerLifeCycleManagerInternal>();
+
+            namespaceManagerCreator = new NamespaceManagerCreator(settings);
+            namespaceManagerLifeCycleManagerInternal = new NamespaceManagerLifeCycleManagerInternal(namespaceManagerCreator);
+            container.Register<IManageNamespaceManagerLifeCycleInternal>(() => namespaceManagerLifeCycleManagerInternal);
+
             container.RegisterSingleton<MessagingFactoryCreator>();
             container.RegisterSingleton<MessagingFactoryLifeCycleManager>();
             container.RegisterSingleton<MessageReceiverCreator>();

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -17,6 +17,8 @@ namespace NServiceBus
         ILog logger = LogManager.GetLogger("ForwardingTopology");
         ITopologySectionManagerInternal topologySectionManager;
         ITransportPartsContainerInternal container;
+        NamespaceManagerCreator namespaceManagerCreator;
+        NamespaceManagerLifeCycleManagerInternal namespaceManagerLifeCycleManagerInternal;
 
         public ForwardingTopologyInternal() : this(new TransportPartsContainer()) { }
 
@@ -52,8 +54,11 @@ namespace NServiceBus
             // runtime components
             container.Register<ReadOnlySettings>(() => settings);
             container.Register<ITopologySectionManagerInternal>(() => topologySectionManager);
-            container.RegisterSingleton<NamespaceManagerCreator>();
-            container.RegisterSingleton<NamespaceManagerLifeCycleManagerInternal>();
+
+            namespaceManagerCreator = new NamespaceManagerCreator(settings);
+            namespaceManagerLifeCycleManagerInternal = new NamespaceManagerLifeCycleManagerInternal(namespaceManagerCreator);
+            container.Register<IManageNamespaceManagerLifeCycleInternal>(() => namespaceManagerLifeCycleManagerInternal);
+
             container.RegisterSingleton<MessagingFactoryCreator>();
             container.RegisterSingleton<MessagingFactoryLifeCycleManager>();
             container.RegisterSingleton<MessageReceiverCreator>();


### PR DESCRIPTION
Small step towards https://github.com/Particular/NServiceBus.AzureServiceBus/issues/448

Removes `NamespaceManagerCreator ` from the container