### PR TITLE
Subscription not removed when unsubscribing with EndpointOrientedTopology

### DIFF
--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -73,7 +73,9 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
                 .RegisterPublisher(typeof(When_publishing_to_scaled_out_subscribers.MyEvent), NameForEndpoint<When_publishing_to_scaled_out_subscribers.Publisher>())
                 .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher1>())
                 .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher2>())
-                .RegisterPublisher(typeof(When_unsubscribing.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>());
+                .RegisterPublisher(typeof(When_unsubscribing.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>())
+                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>())
+                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), NameForEndpoint<When_unsubscribing.Endpoint>());
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -13,7 +13,6 @@ using NServiceBus.AcceptanceTests.Versioning;
 using NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing;
 using NServiceBus.AzureServiceBus.AcceptanceTests.Infrastructure;
 
-
 public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestExecution
 {
     public Task Configure(string endpointName, EndpointConfiguration config, RunSettings settings)
@@ -74,8 +73,8 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
                 .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher1>())
                 .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher2>())
                 .RegisterPublisher(typeof(When_unsubscribing.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>())
-                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>())
-                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), NameForEndpoint<When_unsubscribing.Endpoint>());
+                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), NameForEndpoint<When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint>())
+                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), NameForEndpoint<When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint>());
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -72,7 +72,8 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
                 .RegisterPublisher(typeof(When_publishing_an_interface_with_unobtrusive.MyEvent), NameForEndpoint<When_publishing_an_interface_with_unobtrusive.Publisher>())
                 .RegisterPublisher(typeof(When_publishing_to_scaled_out_subscribers.MyEvent), NameForEndpoint<When_publishing_to_scaled_out_subscribers.Publisher>())
                 .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher1>())
-                .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher2>());
+                .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher2>())
+                .RegisterPublisher(typeof(When_unsubscribing.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>());
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -332,6 +332,7 @@
     <Compile Include="Routing\When_scaling_out_senders_that_uses_callbacks.cs" />
     <Compile Include="Routing\When_sending_to_specific_namespace.cs" />
     <Compile Include="Routing\When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs" />
+    <Compile Include="Routing\When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs" />
     <Compile Include="Routing\When_unsubscribing.cs" />
     <Compile Include="Routing\When_using_single_namespace.cs" />
     <Compile Include="Sending\When_sending_more_than_100_messages_in_a_transaction.cs" />

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -332,6 +332,7 @@
     <Compile Include="Routing\When_scaling_out_senders_that_uses_callbacks.cs" />
     <Compile Include="Routing\When_sending_to_specific_namespace.cs" />
     <Compile Include="Routing\When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs" />
+    <Compile Include="Routing\When_unsubscribing.cs" />
     <Compile Include="Routing\When_using_single_namespace.cs" />
     <Compile Include="Sending\When_sending_more_than_100_messages_in_a_transaction.cs" />
     <Compile Include="Serialization\When_using_default_serialization.cs" />

--- a/src/AcceptanceTests/Routing/When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs
+++ b/src/AcceptanceTests/Routing/When_subscribing_to_a_derived_polymorphic_event_with_forwarding_topology.cs
@@ -67,19 +67,6 @@
 
             class DetermineWhatTopologyIsUsed : Feature
             {
-                //                public Context Context { get; set; }
-                //
-                //                public ReadOnlySettings Settings { get; set; }
-                //
-                //                public Task Start(IMessageSession session)
-                //                {
-                //                    Context.IsForwardingTopology = Settings.Get<ITopology>() is ForwardingTopology;
-                //                    return Task.FromResult(0);
-                //                }
-                //
-                //                public Task Stop(IMessageSession session)
-                //                {
-                //                    return Task.FromResult(0);
                 protected override void Setup(FeatureConfigurationContext context)
                 {
                     context.RegisterStartupTask(builder => new TaskToDetermineCurrentTopology(builder.Build<Context>(), builder.Build<ReadOnlySettings>()));

--- a/src/AcceptanceTests/Routing/When_unsubscribing.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing.cs
@@ -28,10 +28,10 @@
 
             if (context.IsForwardingTopology)
             {
-                var isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-1", $"{endpointName}");
+                var isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-1", endpointName);
                 Assert.IsFalse(isSubscriptionFound, "Subscription under 'bundle-1' should have been deleted, but it wasn't.");
 
-                isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-2", $"{endpointName}");
+                isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-2", endpointName);
                 Assert.IsFalse(isSubscriptionFound, "Subscription under 'bundle-2' should have been deleted, but it wasn't.");
             }
             else // EndpointOrientedTopology

--- a/src/AcceptanceTests/Routing/When_unsubscribing.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing.cs
@@ -42,7 +42,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>()
+                EndpointSetup<DefaultServer>(endpointConfiguration => endpointConfiguration.EnableFeature<DetermineWhatTopologyIsUsed>())
                     .AddMapping<MyEvent>(typeof(Endpoint));
             }
 

--- a/src/AcceptanceTests/Routing/When_unsubscribing.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing.cs
@@ -24,10 +24,18 @@
 
             var connectionString = Environment.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
             var namespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
+            var endpointName = ConfigureEndpointAzureServiceBusTransport.NameForEndpoint<Endpoint>();
 
-            if (!context.IsForwardingTopology)
+            if (context.IsForwardingTopology)
             {
-                var endpointName = ConfigureEndpointAzureServiceBusTransport.NameForEndpoint<Endpoint>();
+                var isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-1", $"{endpointName}");
+                Assert.IsFalse(isSubscriptionFound, "Subscription under 'bundle-1' should have been deleted, but it wasn't.");
+
+                isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-2", $"{endpointName}");
+                Assert.IsFalse(isSubscriptionFound, "Subscription under 'bundle-2' should have been deleted, but it wasn't.");
+            }
+            else // EndpointOrientedTopology
+            {
                 var isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync(endpointName + ".events", $"{endpointName}.{nameof(MyEvent)}");
                 Assert.IsFalse(isSubscriptionFound, "Subscription should have been deleted, but it wasn't.");
             }

--- a/src/AcceptanceTests/Routing/When_unsubscribing.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Features;
+    using Microsoft.ServiceBus;
+    using NUnit.Framework;
+    using Settings;
+    using Transport.AzureServiceBus;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+
+    public class When_unsubscribing : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_remove_subscription_from_topology()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Unsubscribe<MyEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            var connectionString = Environment.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+            var namespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
+
+            if (!context.IsForwardingTopology)
+            {
+                var endpointName = ConfigureEndpointAzureServiceBusTransport.NameForEndpoint<Endpoint>();
+                var isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync(endpointName + ".events", $"{endpointName}.{nameof(MyEvent)}");
+                Assert.IsFalse(isSubscriptionFound, "Subscription should have been deleted, but it wasn't.");
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsForwardingTopology { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyEvent>(typeof(Endpoint));
+            }
+
+            public class Handler : IHandleMessages<MyEvent>
+            {
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+
+            class DetermineWhatTopologyIsUsed : Feature
+            {
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.RegisterStartupTask(builder => new TaskToDetermineCurrentTopology(builder.Build<Context>(), builder.Build<ReadOnlySettings>()));
+                }
+            }
+
+            class TaskToDetermineCurrentTopology : FeatureStartupTask
+            {
+                Context context;
+                ReadOnlySettings settings;
+
+                public TaskToDetermineCurrentTopology(Context context, ReadOnlySettings settings)
+                {
+                    this.context = context;
+                    this.settings = settings;
+                }
+
+                protected override Task OnStart(IMessageSession session)
+                {
+#pragma warning disable 618
+                    context.IsForwardingTopology = settings.Get<ITopology>() is ForwardingTopology;
+#pragma warning restore 618
+                    return TaskEx.Completed;
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
@@ -45,6 +45,10 @@
                 rules = await namespaceManager.GetRulesAsync("bundle-2", endpointName);
                 Assert.That(rules.Any(rule => rule.Name == ruleName), Is.False);
             }
+            else
+            {
+                Assert.Ignore("Not applicable to EndpointOrientedTopology");
+            }
         }
 
         public class Context : ScenarioContext

--- a/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
@@ -29,7 +29,8 @@
             var namespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
             var rawEndpointName = ConfigureEndpointAzureServiceBusTransport.NameForEndpoint<Endpoint>();
             var endpointName = MD5HashBuilder.Build(rawEndpointName);
-            var ruleName = MD5HashBuilder.Build(typeof(MyEvent).FullName);
+            var sanitizedEventFullName = typeof(MyOtherEvent).FullName.Replace("+", string.Empty);
+            var otherRuleName = MD5HashBuilder.Build(sanitizedEventFullName);
 
             if (context.IsForwardingTopology)
             {
@@ -40,10 +41,10 @@
                 Assert.IsTrue(isSubscriptionFound, "Subscription under 'bundle-2' should have been found, but it wasn't.");
 
                 var rules = await namespaceManager.GetRulesAsync("bundle-1", endpointName);
-                Assert.That(rules.Any(rule => rule.Name == ruleName), Is.False);
+                CollectionAssert.AreEquivalent(new[] { otherRuleName }, rules.Select(r => r.Name));
 
                 rules = await namespaceManager.GetRulesAsync("bundle-2", endpointName);
-                Assert.That(rules.Any(rule => rule.Name == ruleName), Is.False);
+                CollectionAssert.AreEquivalent(new [] { otherRuleName }, rules.Select(r => r.Name));
             }
             else
             {

--- a/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
@@ -1,0 +1,134 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Features;
+    using Microsoft.ServiceBus;
+    using NUnit.Framework;
+    using Settings;
+    using Transport.AzureServiceBus;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+
+    public class When_unsubscribing_from_one_of_the_events_for_ForwardingTopology : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_remove_subscription_rule_from_topology()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Unsubscribe<MyEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            var connectionString = Environment.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+            var namespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
+            var rawEndpointName = ConfigureEndpointAzureServiceBusTransport.NameForEndpoint<Endpoint>();
+            var endpointName = MD5HashBuilder.Build(rawEndpointName);
+            var ruleName = MD5HashBuilder.Build(typeof(MyEvent).FullName);
+
+            if (context.IsForwardingTopology)
+            {
+                var isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-1", endpointName);
+                Assert.IsTrue(isSubscriptionFound, "Subscription under 'bundle-1' should have been found, but it wasn't.");
+
+                isSubscriptionFound = await namespaceManager.SubscriptionExistsAsync("bundle-2", endpointName);
+                Assert.IsTrue(isSubscriptionFound, "Subscription under 'bundle-2' should have been found, but it wasn't.");
+
+                var rules = await namespaceManager.GetRulesAsync("bundle-1", endpointName);
+                Assert.That(rules.Any(rule => rule.Name == ruleName), Is.False);
+
+                rules = await namespaceManager.GetRulesAsync("bundle-2", endpointName);
+                Assert.That(rules.Any(rule => rule.Name == ruleName), Is.False);
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsForwardingTopology { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(endpointConfiguration => endpointConfiguration.EnableFeature<DetermineWhatTopologyIsUsed>())
+                    .AddMapping<MyEvent>(typeof(Endpoint))
+                    .AddMapping<MyOtherEvent>(typeof(Endpoint));
+            }
+
+            public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyOtherEvent>
+            {
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(MyOtherEvent message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+
+            class DetermineWhatTopologyIsUsed : Feature
+            {
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.RegisterStartupTask(builder => new TaskToDetermineCurrentTopology(builder.Build<Context>(), builder.Build<ReadOnlySettings>()));
+                }
+            }
+
+            class TaskToDetermineCurrentTopology : FeatureStartupTask
+            {
+                Context context;
+                ReadOnlySettings settings;
+
+                public TaskToDetermineCurrentTopology(Context context, ReadOnlySettings settings)
+                {
+                    this.context = context;
+                    this.settings = settings;
+                }
+
+                protected override Task OnStart(IMessageSession session)
+                {
+#pragma warning disable 618
+                    context.IsForwardingTopology = settings.Get<ITopology>() is ForwardingTopology;
+#pragma warning restore 618
+                    return TaskEx.Completed;
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+        public class MyOtherEvent : IEvent
+        {
+        }
+    }
+
+    static class MD5HashBuilder
+    {
+        public static string Build(string input)
+        {
+            //use MD5 hash to get a 16-byte hash of the string
+            using (var provider = new MD5CryptoServiceProvider())
+            {
+                var inputBytes = Encoding.Default.GetBytes(input);
+                var hashBytes = provider.ComputeHash(inputBytes);
+
+                return new Guid(hashBytes).ToString();
+            }
+        }
+    }
+
+}

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
@@ -39,15 +39,15 @@
 
             var subscriptionDescription = new SubscriptionDescription(topicPath, subscriptionName);
             
-            // check the if the subscription with event name only is the one we should delete, i.e. event with another namespace owns it
-            if (!await SubscriptionIsReusedAcrossDifferentNamespaces(subscriptionDescription, sqlFilter, namespaceManager).ConfigureAwait(false))
+            // Check subscription with event name only is the one we should delete. If it's reused, then we need to use event full name.
+            if (await SubscriptionIsReusedAcrossDifferentNamespaces(subscriptionDescription, sqlFilter, namespaceManager).ConfigureAwait(false))
             {
                 logger.Debug("Deleting subscription using event type full name");
                 subscriptionDescription = new SubscriptionDescription(topicPath, metadata.SubscriptionNameBasedOnEventWithNamespace);
             }
 
             // delete subscription based on event name only
-            await namespaceManagerAbleToDeleteSubscriptions.DeleteSubscription(subscriptionDescription).ConfigureAwait(false);
+            await creator.DeleteSubscription(subscriptionDescription.TopicPath, subscriptionDescription.Name, metadata, sqlFilter, namespaceManager, forwardTo).ConfigureAwait(false);
         }
 
         async Task<bool> SubscriptionIsReusedAcrossDifferentNamespaces(SubscriptionDescription subscriptionDescription, string sqlFilter, INamespaceManager namespaceManager)


### PR DESCRIPTION
## Who's affected

- Anyone that requires to be able to unsubscribe endpoints from events and using `EndpointOrientedTopology`

## Symptoms

Unsubscribe requests are not persisted, causing unsubscribed endpoints continue receiving events after those endpoints were restarts.

## Details

Similar to the issue that was found in `ForwardingTopology` (#392).

The request to unsubscribe should be modifying topologies. [Currently](https://github.com/Particular/NServiceBus.AzureServiceBus/blob/e5f64e929ecf7ff2227541870ae9a2c243ed9222/src/Transport/Seam/SubscriptionManager.cs#L28) it doesn't.

For the `EndpointOrientedTopology`, subscriber should remove the subscription from the publisher.events topic.

This could cause events to accumulate under subscription that is no longer monitored. If there's a high volume of these events, subscription could eventually overflood and cause production degradation.

#### TODO
- [ ] backport to `support-7.0`
- [ ] port changes to `develop`

@Particular/azure-maintainers please review