### PR TITLE
Events hierarchy from different publishers with EndpointOrientedTopology not handled

### DIFF
--- a/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -8,7 +8,7 @@
 
     public class When_multi_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
     {
-        [Test, Explicit("Polymorphic events will only work for ForwardingTopology, but since can't filter it out, disabling entirely.")]
+        [Test]
         public Task Both_events_should_be_delivered()
         {
             return Scenario.Define<Context>()

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -842,6 +842,8 @@ namespace NServiceBus.Transport.AzureServiceBus
             "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.Transport.AzureServiceBus.IClientSideSubscriptionFilter ClientSideFilter { get; set; }
         public NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata Metadata { get; set; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
     }
     [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
         "sion 8.0.0. Will be removed in version 9.0.0.", false)]

--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -80,7 +80,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                         completed.Set();
                     }
                     return TaskEx.Completed;
-                }, null, null, 10);
+                }, null, null, 32);
 
 
             var sw = new Stopwatch();

--- a/src/Transport/Topology/MetaModel/EntityInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityInfo.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityInfo
@@ -23,16 +22,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         protected bool Equals(EntityInfo other)
         {
-            if (Type == EntityType.Subscription)
-            {
-                var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
-                var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
-                var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
-                if (!targetPathEquals)
-                {
-                    return false;
-                }
-            }
             return string.Equals(Path, other.Path) && Type == other.Type && Equals(Namespace, other.Namespace);
         }
 

--- a/src/Transport/Topology/MetaModel/EntityInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityInfo.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityInfo
@@ -22,6 +23,16 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         protected bool Equals(EntityInfo other)
         {
+            if (Type == EntityType.Subscription)
+            {
+                var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+                var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+                var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
+                if (!targetPathEquals)
+                {
+                    return false;
+                }
+            }
             return string.Equals(Path, other.Path) && Type == other.Type && Equals(Namespace, other.Namespace);
         }
 

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    using System.Linq;
+
     [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class SubscriptionInfo : EntityInfo
     {
@@ -9,5 +11,35 @@
         public IClientSideSubscriptionFilter ClientSideFilter { get; set; }
 
         public SubscriptionMetadata Metadata { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!base.Equals(obj))
+                return false;
+
+            var other = obj as SubscriptionInfo;
+            if (other == null)
+            {
+                return false;
+            }
+
+            var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+            var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+            var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
+
+            // both target the same topic
+            return targetPathEquals;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+                hashCode = (hashCode * 397) ^ entity.Target.Path.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -205,7 +205,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     sub.RelationShips.Add(new EntityRelationShipInfo
                     {
                         Source = sub,
-                        Target = topics.First(t => t.Namespace == ns),
+                        Target = topics.First(t => t.Path == path && t.Namespace == ns),
                         Type = EntityRelationShipType.Subscription
                     });
                     return sub;


### PR DESCRIPTION
Fixes #460 (Polymorphic events from different publishers not handled properly with `EndpointOrientedTopology`).
Based on the changes made in [`entity-info` branch](https://github.com/Particular/NServiceBus.AzureServiceBus/tree/entity-info).
Details and description are in the original issue.

#### TODO
- [ ] backport to `support-7.0`
- [ ] port changes to `develop`

@Particular/azure-maintainers please review