### PR TITLE
Keep SubscriptionIfo comparison out of EntityInfo

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -842,6 +842,8 @@ namespace NServiceBus.Transport.AzureServiceBus
             "sion 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.Transport.AzureServiceBus.IClientSideSubscriptionFilter ClientSideFilter { get; set; }
         public NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata Metadata { get; set; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
     }
     [System.ObsoleteAttribute("Internal contract that shouldn\'t be exposed. Will be treated as an error from ver" +
         "sion 8.0.0. Will be removed in version 9.0.0.", false)]

--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -80,7 +80,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                         completed.Set();
                     }
                     return TaskEx.Completed;
-                }, null, null, 10);
+                }, null, null, 32);
 
 
             var sw = new Stopwatch();

--- a/src/Transport/Topology/MetaModel/EntityInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityInfo.cs
@@ -22,12 +22,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         protected bool Equals(EntityInfo other)
         {
-            return string.Equals(Path, other.Path) && Type == other.Type && Equals(Namespace, other.Namespace) && DerivedEqual(other);
-        }
-
-        internal virtual bool DerivedEqual(EntityInfo other)
-        {
-            return true;
+            return string.Equals(Path, other.Path) && Type == other.Type && Equals(Namespace, other.Namespace);
         }
 
         public override bool Equals(object obj)

--- a/src/Transport/Topology/MetaModel/EntityInfo.cs
+++ b/src/Transport/Topology/MetaModel/EntityInfo.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class EntityInfo
@@ -23,17 +22,12 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         protected bool Equals(EntityInfo other)
         {
-            if (Type == EntityType.Subscription)
-            {
-                var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
-                var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
-                var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
-                if (!targetPathEquals)
-                {
-                    return false;
-                }
-            }
-            return string.Equals(Path, other.Path) && Type == other.Type && Equals(Namespace, other.Namespace);
+            return string.Equals(Path, other.Path) && Type == other.Type && Equals(Namespace, other.Namespace) && DerivedEqual(other);
+        }
+
+        internal virtual bool DerivedEqual(EntityInfo other)
+        {
+            return true;
         }
 
         public override bool Equals(object obj)

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    using System.Linq;
+
     [ObsoleteEx(Message = ObsoleteMessages.WillBeInternalized, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
     public class SubscriptionInfo : EntityInfo
     {
@@ -9,5 +11,21 @@
         public IClientSideSubscriptionFilter ClientSideFilter { get; set; }
 
         public SubscriptionMetadata Metadata { get; set; }
+
+        internal override bool DerivedEqual(EntityInfo entityInfo)
+        {
+            var other = entityInfo as SubscriptionInfo;
+            if (other == null)
+                return false;
+
+            var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+            var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+            var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
+
+            return string.Equals(Path, other.Path)          // subscriptoin name is matches
+                   && Type == other.Type                    // both entities are subscriptions
+                   && targetPathEquals                      // both target the same topic
+                   && Equals(Namespace, other.Namespace);   // on the same namespace
+        }
     }
 }

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -12,20 +12,34 @@
 
         public SubscriptionMetadata Metadata { get; set; }
 
-        internal override bool DerivedEqual(EntityInfo entityInfo)
+        public override bool Equals(object obj)
         {
-            var other = entityInfo as SubscriptionInfo;
-            if (other == null)
+            if (!base.Equals(obj))
                 return false;
+
+            var other = obj as SubscriptionInfo;
+            if (other == null)
+            {
+                return false;
+            }
 
             var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
             var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
             var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
 
-            return string.Equals(Path, other.Path)          // subscriptoin name is matches
-                   && Type == other.Type                    // both entities are subscriptions
-                   && targetPathEquals                      // both target the same topic
-                   && Equals(Namespace, other.Namespace);   // on the same namespace
+            // both target the same topic
+            return targetPathEquals;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+                hashCode = (hashCode * 397) ^ entity.Target.Path.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }


### PR DESCRIPTION
This is just a small backwards compatible cleanup to perform subscription related comparison in `SubscriptionInfo` and not `EntityInfo`.

There's an issue with our entities abstraction and some features introduced in v7. I'll open a separate issue for that.