### PR TITLE
Backport issue 460 to 7.0.5

### DIFF
--- a/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -8,7 +8,7 @@
 
     public class When_multi_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
     {
-        [Test, Explicit("Polymorphic events will only work for ForwardingTopology, but since can't filter it out, disabling entirely.")]
+        [Test]
         public Task Both_events_should_be_delivered()
         {
             return Scenario.Define<Context>()

--- a/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -678,6 +678,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public NServiceBus.Transport.AzureServiceBus.IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }
         public NServiceBus.Transport.AzureServiceBus.IClientSideSubscriptionFilter ClientSideFilter { get; set; }
         public NServiceBus.Transport.AzureServiceBus.SubscriptionMetadata Metadata { get; set; }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
     }
     public class SubscriptionMetadata
     {

--- a/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
+++ b/src/Transport/Topology/MetaModel/SubscriptionInfo.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    using System.Linq;
+
     public class SubscriptionInfo : EntityInfo
     {
         public IBrokerSideSubscriptionFilter BrokerSideFilter { get; set; }
@@ -7,5 +9,35 @@
         public IClientSideSubscriptionFilter ClientSideFilter { get; set; }
 
         public SubscriptionMetadata Metadata { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!base.Equals(obj))
+                return false;
+
+            var other = obj as SubscriptionInfo;
+            if (other == null)
+            {
+                return false;
+            }
+
+            var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+            var otherEntity = other.RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+            var targetPathEquals = string.Equals(entity.Target.Path, otherEntity.Target.Path);
+
+            // both target the same topic
+            return targetPathEquals;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                var entity = RelationShips.First(r => r.Type == EntityRelationShipType.Subscription);
+                hashCode = (hashCode * 397) ^ entity.Target.Path.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -206,7 +206,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     sub.RelationShips.Add(new EntityRelationShipInfo
                     {
                         Source = sub,
-                        Target = topics.First(t => t.Namespace == ns),
+                        Target = topics.First(t => t.Path == path && t.Namespace == ns),
                         Type = EntityRelationShipType.Subscription
                     });
                     return sub;


### PR DESCRIPTION
## Who's affected

- Anyone using `EndpointOrientedTopology` and has endpoints that subscribe to polymorphic events published by different endpoints, applying workaround demonstrated in [Polymorphic events with Azure Service Bus Transport](https://docs.particular.net/samples/azure/polymorphic-events-asb/) sample.

## Symptoms

Each publisher should have a subscription for the subscriber, but only one such subscription is created under a single publisher. This could lead to published events disappear and never be handled. While `EndpointOrientedTopology` doesn't support polymorphic events out-of-the-box, with disabled `AutoSubscribe` feature and manual subscription to the base event it should work as expected.

## Details

Verification `When_multi_subscribing_to_a_polymorphic_event` should work for this scenario when `AutoSubscribe` feature is disabled for the `Subscriber` endpoint and registered publishers are using the base event type (`IMyEvent`) for `EndpointOrientedTopology`.