### PR TITLE
[SPIKE] Bringing in tests

### DIFF
--- a/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
+++ b/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
@@ -1,0 +1,137 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public Task ShouldNoLongerReceiveEvent()
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(c => c
+                    .When(
+                        ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
+                        s => s.Publish(new Event()))
+                    .When(
+                        ctx => ctx.Subscriber2Unsubscribed,
+                        async s =>
+                        {
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+                        }))
+                .WithEndpoint<Subscriber1>(c => c
+                    .When(s => s.Subscribe<Event>()))
+                .WithEndpoint<Subscriber2>(c => c
+                    .When(s => s.Subscribe<Event>())
+                    .When(
+                        ctx => ctx.Subscriber2ReceivedMessages >= 1,
+                        s => s.Unsubscribe<Event>()))
+                .Done(c => c.Subscriber1ReceivedMessages >= 4)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    Assert.AreEqual(4, c.Subscriber1ReceivedMessages);
+                    Assert.AreEqual(1, c.Subscriber2ReceivedMessages);
+                    Assert.IsTrue(c.Subscriber2Unsubscribed);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber2Unsubscribed { get; set; }
+            public int Subscriber1ReceivedMessages { get; set; }
+            public int Subscriber2ReceivedMessages { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.OnEndpointSubscribed<Context>((args, ctx) =>
+                    {
+                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
+                        {
+                            ctx.Subscriber1Subscribed = true;
+                        }
+
+                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
+                        {
+                            ctx.Subscriber2Subscribed = true;
+                        }
+                    });
+                    c.OnEndpointUnsubscribed<Context>((args, ctx) =>
+                    {
+                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
+                        {
+                            ctx.Subscriber2Unsubscribed = true;
+                        }
+                    });
+                });
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>());
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber1ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>());
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber2ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class Event : IEvent
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -1,0 +1,134 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing.NativePublishSubscribe
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task ShouldNoLongerReceiveEvent()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(c => c
+                    .When(
+                        ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
+                        s => s.Publish(new Event()))
+                    .When(
+                        ctx => ctx.Subscriber2Unsubscribed,
+                        async s =>
+                        {
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+
+                        }))
+                .WithEndpoint<Subscriber1>(c => c
+                    .When(async (s, ctx) =>
+                    {
+                        await s.Subscribe<Event>();
+                        ctx.Subscriber1Subscribed = true;
+                    }))
+                .WithEndpoint<Subscriber2>(c => c
+                    .When(async (s, ctx) =>
+                    {
+                        await s.Subscribe<Event>();
+                        ctx.Subscriber2Subscribed = true;
+                    })
+                    .When(
+                        ctx => ctx.Subscriber2ReceivedMessages >= 1,
+                        async (s, ctx) =>
+                        {
+                            await s.Unsubscribe<Event>();
+                            ctx.Subscriber2Unsubscribed = true;
+                        }))
+                .Done(c => c.Subscriber1ReceivedMessages >= 4)
+                .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                .Should(c =>
+                {
+                    Assert.AreEqual(4, c.Subscriber1ReceivedMessages);
+                    Assert.AreEqual(1, c.Subscriber2ReceivedMessages);
+                    Assert.IsTrue(c.Subscriber2Unsubscribed);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber2Unsubscribed { get; set; }
+            public int Subscriber1ReceivedMessages { get; set; }
+            public int Subscriber2ReceivedMessages { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber1ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber2ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Event : IEvent
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -80,6 +80,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.DisableFeature<AutoSubscribe>();
+                    c.LimitMessageProcessingConcurrencyTo(1);
                 });
             }
 
@@ -107,6 +108,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.DisableFeature<AutoSubscribe>();
+                    c.LimitMessageProcessingConcurrencyTo(1);
                 });
             }
 

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -12,7 +12,6 @@ using NServiceBus.AcceptanceTests.Sagas;
 using NServiceBus.AcceptanceTests.Versioning;
 using NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing;
 using NServiceBus.AzureServiceBus.AcceptanceTests.Infrastructure;
-using When_unsubscribing_from_event = NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions.When_unsubscribing_from_event;
 
 public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestExecution
 {

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -12,6 +12,7 @@ using NServiceBus.AcceptanceTests.Sagas;
 using NServiceBus.AcceptanceTests.Versioning;
 using NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing;
 using NServiceBus.AzureServiceBus.AcceptanceTests.Infrastructure;
+using When_unsubscribing_from_event = NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions.When_unsubscribing_from_event;
 
 public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestExecution
 {
@@ -74,7 +75,8 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
                 .RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), NameForEndpoint<When_multi_subscribing_to_a_polymorphic_event.Publisher2>())
                 .RegisterPublisher(typeof(When_unsubscribing.MyEvent), NameForEndpoint<When_unsubscribing.Endpoint>())
                 .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), NameForEndpoint<When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint>())
-                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), NameForEndpoint<When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint>());
+                .RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), NameForEndpoint<When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint>())
+                .RegisterPublisher(typeof(When_unsubscribing_from_event.Event), NameForEndpoint<When_unsubscribing_from_event.Publisher>());
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -220,12 +220,14 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_subscribing_to_a_derived_event.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_subscribing_to_multiple_publishers.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_subscribing_to_scaled_out_publisher.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_unsubscribing_from_event.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_using_assembly_level_message_mapping_for_pub_sub.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_using_autosubscribe_with_missing_routing_information.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\MessageDrivenSubscriptions\When_using_legacy_routing_configuration.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\NativePublishSubscribe\When_multi_subscribing_to_a_polymorphic_event.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\NativePublishSubscribe\When_publishing_to_scaled_out_subscribers.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\NativePublishSubscribe\When_unsubscribing_from_event.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\SubscriptionBehavior.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\SubscriptionBehaviorExtensions.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.0.0\Routing\SubscriptionEventArgs.cs" />


### PR DESCRIPTION
Connects to #449 

**Base line** for this spike is `master` that is green on build server.

**Change introduced**: single ATT test `When_unsubscribing_from_event` which is causing failures.