### PR TITLE
Subscription fails on multiple namespaces

### DIFF
--- a/src/Tests/Creation/When_creating_forwarding_subscription.cs
+++ b/src/Tests/Creation/When_creating_forwarding_subscription.cs
@@ -39,12 +39,26 @@
             {
                 namespaceManager.CreateQueue(new QueueDescription(forwardToQueue)).GetAwaiter().GetResult();
             }
+
+            namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
+            if (!namespaceManager.TopicExists(topicPath).GetAwaiter().GetResult())
+            {
+                namespaceManager.CreateTopic(new TopicDescription(topicPath)).GetAwaiter().GetResult();
+            }
+            if (!namespaceManager.QueueExists(forwardToQueue).GetAwaiter().GetResult())
+            {
+                namespaceManager.CreateQueue(new QueueDescription(forwardToQueue)).GetAwaiter().GetResult();
+            }
         }
 
         [OneTimeTearDown]
         public void TopicCleanUp()
         {
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
+            namespaceManager.DeleteTopic(topicPath).GetAwaiter().GetResult();
+            namespaceManager.DeleteQueue(forwardToQueue).GetAwaiter().GetResult();
+
+            namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
             namespaceManager.DeleteTopic(topicPath).GetAwaiter().GetResult();
             namespaceManager.DeleteQueue(forwardToQueue).GetAwaiter().GetResult();
         }
@@ -460,5 +474,29 @@
             await namespaceManager.DeleteSubscription(new SubscriptionDescription(topicPath, subscriber));
         }
 
+        [Test]
+        public async Task Should_create_subscription_on_multiple_namespaces()
+        {
+            const string subscriber = "someendpoint";
+
+            var namespaceManager1 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
+            var namespaceManager2 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
+
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+            extensions.UseForwardingTopology().Subscriptions().DescriptionFactory((topic, subName, readOnlySettings) => new SubscriptionDescription(topic, subName)
+            {
+                MaxDeliveryCount = 100,
+                EnableDeadLetteringOnMessageExpiration = true,
+            });
+
+            var creator = new AzureServiceBusForwardingSubscriptionCreator(settings);
+            await creator.Create(topicPath, subscriber, metadata, sqlFilter, namespaceManager1, forwardToQueue);
+            await creator.Create(topicPath, subscriber, metadata, sqlFilter, namespaceManager2, forwardToQueue);
+
+
+            Assert.IsTrue(await namespaceManager1.SubscriptionExists(topicPath, subscriber), "Subscription on Value namespace was not created.");
+            Assert.IsTrue(await namespaceManager2.SubscriptionExists(topicPath, subscriber), "Subscription on Fallback namespace was not created.");
+        }
     }
 }

--- a/src/Tests/Creation/When_creating_forwarding_subscription.cs
+++ b/src/Tests/Creation/When_creating_forwarding_subscription.cs
@@ -477,7 +477,7 @@
         [Test]
         public async Task Should_create_subscription_on_multiple_namespaces()
         {
-            const string subscriber = "someendpoint";
+            const string subscriber = "MultipleNamespaceSubscriber";
 
             var namespaceManager1 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
             var namespaceManager2 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));

--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -28,12 +28,21 @@
             {
                 namespaceManager.CreateTopic(new TopicDescription(topicPath)).GetAwaiter().GetResult();
             }
+
+            namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
+            if (!namespaceManager.TopicExists(topicPath).Result)
+            {
+                namespaceManager.CreateTopic(new TopicDescription(topicPath)).GetAwaiter().GetResult();
+            }
         }
 
         [OneTimeTearDown]
         public void TopicCleanUp()
         {
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
+            namespaceManager.DeleteTopic(topicPath).GetAwaiter().GetResult();
+
+            namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
             namespaceManager.DeleteTopic(topicPath).GetAwaiter().GetResult();
         }
 
@@ -413,6 +422,24 @@
 
             //cleanup
             await namespaceManager.DeleteTopic("sometopic2");
+        }
+
+        [Test]
+        public async Task Should_create_subscription_on_multiple_namespaces()
+        {
+            const string subscriptionName = "SomeEvent";
+
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+            var creator = new AzureServiceBusSubscriptionCreator(settings);
+
+            var namespaceManager1 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
+            var namespaceManager2 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
+
+            await creator.Create(topicPath, subscriptionName, metadata, sqlFilter, namespaceManager1);
+            await creator.Create(topicPath, subscriptionName, metadata, sqlFilter, namespaceManager2);
+
+            Assert.IsTrue(await namespaceManager1.SubscriptionExists(topicPath, subscriptionName), "Subscription on Value namespace was not created.");
+            Assert.IsTrue(await namespaceManager2.SubscriptionExists(topicPath, subscriptionName), "Subscription on Fallback namespace was not created.");
         }
     }
 }

--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -427,7 +427,7 @@
         [Test]
         public async Task Should_create_subscription_on_multiple_namespaces()
         {
-            const string subscriptionName = "SomeEvent";
+            const string subscriptionName = "MultipleNamespaceEvent";
 
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var creator = new AzureServiceBusSubscriptionCreator(settings);

--- a/src/Transport/Creation/AzureServiceBusForwardingSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusForwardingSubscriptionCreator.cs
@@ -60,20 +60,20 @@
                     };
 
                     await namespaceManager.CreateSubscription(subscriptionDescription, ruleDescription).ConfigureAwait(false);
-                    logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}' with rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}' in namespace {namespaceManager.Address.Host}");
+                    logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}' with rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}' in namespace '{namespaceManager.Address.Host}'.");
 
                     var key = GenerateSubscriptionKey(namespaceManager.Address, subscriptionDescription.TopicPath, subscriptionDescription.Name);
                     await rememberExistence.AddOrUpdate(key, keyNotFound => Task.FromResult(true), (updateTopicPath, previousValue) => Task.FromResult(true)).ConfigureAwait(false);
                 }
                 else
                 {
-                    logger.Info($"Subscription '{subscriptionDescription.Name}' aka '{subscriptionDescription.UserMetadata}' already exists, skipping creation");
-                    logger.InfoFormat("Checking if subscription '{0}' in namespace {1} needs to be updated", subscriptionDescription.Name, namespaceManager.Address.Host);
+                    logger.Info($"Subscription '{subscriptionDescription.Name}' aka '{subscriptionDescription.UserMetadata}' already exists, skipping creation.");
+                    logger.InfoFormat("Checking if subscription '{0}' in namespace '{1}' needs to be updated.", subscriptionDescription.Name, namespaceManager.Address.Host);
 
                     var existingSubscriptionDescription = await namespaceManager.GetSubscription(subscriptionDescription.TopicPath, subscriptionDescription.Name).ConfigureAwait(false);
                     if (MembersAreNotEqual(existingSubscriptionDescription, subscriptionDescription))
                     {
-                        logger.Info($"Updating subscription '{subscriptionDescription.Name}' in namespace {namespaceManager.Address.Host} with new description");
+                        logger.Info($"Updating subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' with new description.");
                         await namespaceManager.UpdateSubscription(subscriptionDescription).ConfigureAwait(false);
                     }
 
@@ -83,7 +83,7 @@
                         Filter = new SqlFilter(sqlFilter),
                         Name = metadata.SubscriptionNameBasedOnEventWithNamespace
                     };
-                    logger.Info($"Adding subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}' in namespace {namespaceManager.Address.Host}");
+                    logger.Info($"Adding subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}' in namespace '{namespaceManager.Address.Host}'.");
                     try
                     {
                         var subscriptionClient = SubscriptionClient.CreateFromConnectionString(meta.NamespaceInfo.ConnectionString, topicPath, subscriptionName);
@@ -91,30 +91,30 @@
                     }
                     catch (MessagingEntityAlreadyExistsException exception)
                     {
-                        logger.Debug($"Rule '{ruleDescription.Name}' already exists. Response from the server: '{exception.Message}'");
+                        logger.Debug($"Rule '{ruleDescription.Name}' already exists. Response from the server: '{exception.Message}'.");
                     }
                 }
             }
             catch (MessagingEntityAlreadyExistsException)
             {
                 // the subscription already exists or another node beat us to it, which is ok
-                logger.Info($"Subscription '{subscriptionDescription.Name}' in namespace {namespaceManager.Address.Host} already exists, another node probably beat us to it");
+                logger.Info($"Subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' already exists, another node probably beat us to it.");
             }
             catch (TimeoutException)
             {
-                logger.Info($"Timeout occurred on subscription creation for topic '{subscriptionDescription.TopicPath}' subscription name '{subscriptionDescription.Name}' going to validate if it doesn't exist");
+                logger.Info($"Timeout occurred on subscription creation for topic '{subscriptionDescription.TopicPath}' subscription name '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' going to validate if it doesn't exist.");
 
-                // there is a chance that the timeout occured, but the topic was still created, check again
+                // there is a chance that the timeout occurred, but the topic was still created, check again
                 if (!await ExistsAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name, metadata.Description, namespaceManager, removeCacheEntry: true).ConfigureAwait(false))
                 {
                     throw;
                 }
 
-                logger.Info($"Looks like subscription '{subscriptionDescription.Name}' exists anyway");
+                logger.Info($"Looks like subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' exists anyway.");
             }
             catch (MessagingException ex)
             {
-                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occured on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}'";
+                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occurred on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}' in namespace '{namespaceManager.Address.Host}'.";
 
                 if (!ex.IsTransient)
                 {
@@ -143,7 +143,7 @@
                         Filter = new SqlFilter(sqlFilter),
                         Name = metadata.SubscriptionNameBasedOnEventWithNamespace
                     };
-                    logger.Info($"Removing subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'");
+                    logger.Info($"Removing subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'.");
                     var subscriptionClient = SubscriptionClient.CreateFromConnectionString(meta.NamespaceInfo.ConnectionString, topicPath, subscriptionName);
                     await subscriptionClient.RemoveRuleAsync(ruleDescription.Name).ConfigureAwait(false);
 
@@ -158,7 +158,7 @@
             }
             catch (MessagingException ex)
             {
-                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occured on subscription '{subscriptionDescription.Name}' deletion for topic '{subscriptionDescription.TopicPath}'";
+                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occurred on subscription '{subscriptionDescription.Name}' deletion for topic '{subscriptionDescription.TopicPath}' in namespace '{namespaceManager.Address.Host}'.";
 
                 if (!ex.IsTransient)
                 {
@@ -172,7 +172,7 @@
 
         async Task<bool> ExistsAsync(string topicPath, string subscriptionName, string metadata, INamespaceManager namespaceClient, bool removeCacheEntry = false)
         {
-            logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}' in namespace {namespaceClient.Address.Host}");
+            logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}' in namespace '{namespaceClient.Address.Host}'.");
 
             var key = GenerateSubscriptionKey(namespaceClient.Address, topicPath, subscriptionName);
 
@@ -184,11 +184,11 @@
 
             var exists = await rememberExistence.GetOrAdd(key, notFoundKey =>
             {
-                logger.Info($"Checking namespace {namespaceClient.Address.Host} for existence of subscription '{subscriptionName}' for the topic '{topicPath}'");
+                logger.Info($"Checking namespace '{namespaceClient.Address.Host}' for existence of subscription '{subscriptionName}' for the topic '{topicPath}'.");
                 return namespaceClient.SubscriptionExists(topicPath, subscriptionName);
             }).ConfigureAwait(false);
 
-            logger.Info($"Determined, from cache, that the subscription '{subscriptionName}' in namespace {namespaceClient.Address.Host} {(exists ? "exists" : "does not exist")}");
+            logger.Info($"Determined, from cache, that the subscription '{subscriptionName}' in namespace '{namespaceClient.Address.Host}' {(exists ? "exists" : "does not exist")}.");
 
             return exists;
         }

--- a/src/Transport/Creation/AzureServiceBusForwardingSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusForwardingSubscriptionCreator.cs
@@ -62,7 +62,7 @@
                     await namespaceManager.CreateSubscription(subscriptionDescription, ruleDescription).ConfigureAwait(false);
                     logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}' with rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'");
 
-                    var key = subscriptionDescription.TopicPath + subscriptionDescription.Name;
+                    var key = GenerateSubscriptionKey(namespaceManager.Address, subscriptionDescription.TopicPath, subscriptionDescription.Name);
                     await rememberExistence.AddOrUpdate(key, keyNotFound => Task.FromResult(true), (updateTopicPath, previousValue) => Task.FromResult(true)).ConfigureAwait(false);
                 }
                 else
@@ -174,7 +174,7 @@
         {
             logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}'");
 
-            var key = topicPath + subscriptionName;
+            var key = GenerateSubscriptionKey(namespaceClient.Address, topicPath, subscriptionName);
 
             if (removeCacheEntry)
             {
@@ -208,6 +208,11 @@
                    || existingDescription.MaxDeliveryCount != newDescription.MaxDeliveryCount
                    || existingDescription.EnableBatchedOperations != newDescription.EnableBatchedOperations
                    || existingDescription.ForwardDeadLetteredMessagesTo != newDescription.ForwardDeadLetteredMessagesTo;
+        }
+
+        static string GenerateSubscriptionKey(Uri namespaceAddress, string topicPath, string subscriptionName)
+        {
+            return  namespaceAddress + topicPath + subscriptionName;
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
@@ -53,7 +53,7 @@
                     await namespaceManager.CreateSubscription(subscriptionDescription, sqlFilter).ConfigureAwait(false);
                     logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}'");
 
-                    var key = subscriptionDescription.TopicPath + subscriptionDescription.Name;
+                    var key = GenerateSubscriptionKey(namespaceManager.Address, subscriptionDescription.TopicPath, subscriptionDescription.Name);
                     await rememberExistence.AddOrUpdate(key, keyNotFound => Task.FromResult(true), (updateTopicPath, previousValue) => Task.FromResult(true)).ConfigureAwait(false);
                 }
                 else
@@ -135,7 +135,7 @@
         {
             logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}'");
 
-            var key = topicPath + subscriptionName;
+            var key = GenerateSubscriptionKey(namespaceClient.Address, topicPath, subscriptionName);
 
             if (removeCacheEntry)
             {
@@ -169,6 +169,11 @@
                    || existingDescription.MaxDeliveryCount != newDescription.MaxDeliveryCount
                    || existingDescription.EnableBatchedOperations != newDescription.EnableBatchedOperations
                    || existingDescription.ForwardDeadLetteredMessagesTo != newDescription.ForwardDeadLetteredMessagesTo;
+        }
+
+        static string GenerateSubscriptionKey(Uri namespaceAddress, string topicPath, string subscriptionName)
+        {
+            return namespaceAddress + topicPath + subscriptionName;
         }
     }
 }


### PR DESCRIPTION
Fixes #487 

## Who's affected

Anyone using Azure Service Bus transport and using a namespace partitioning strategy that creates the same subscription in multiple namespaces including the built-in strategies [Round Robin](https://docs.particular.net/nservicebus/azure-service-bus/multiple-namespaces-support#round-robin-namespace-partitioning) and [Fail over](https://docs.particular.net/nservicebus/azure-service-bus/multiple-namespaces-support#fail-over-namespace-partitioning).

## Symptoms

When using multiple namespaces NServiceBus throws a `MessagingEntityNotFoundException` exception during startup.