### PR TITLE
Subscription fails on multiple namespaces (#489)

### DIFF
--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -27,12 +27,21 @@
             {
                 namespaceManager.CreateTopic(new TopicDescription(topicPath)).GetAwaiter().GetResult();
             }
+
+            namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
+            if (!namespaceManager.TopicExists(topicPath).Result)
+            {
+                namespaceManager.CreateTopic(new TopicDescription(topicPath)).GetAwaiter().GetResult();
+            }
         }
 
         [OneTimeTearDown]
         public void TopicCleanUp()
         {
             var namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
+            namespaceManager.DeleteTopic(topicPath).GetAwaiter().GetResult();
+
+            namespaceManager = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
             namespaceManager.DeleteTopic(topicPath).GetAwaiter().GetResult();
         }
 
@@ -430,6 +439,24 @@
 
             //cleanup
             await namespaceManager.DeleteTopic("sometopic2");
+        }
+
+        [Test]
+        public async Task Should_create_subscription_on_multiple_namespaces()
+        {
+            const string subscriptionName = "MultipleNamespaceEvent";
+
+            var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
+            var creator = new AzureServiceBusSubscriptionCreator(settings);
+
+            var namespaceManager1 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value));
+            var namespaceManager2 = new NamespaceManagerAdapter(NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Fallback));
+
+            await creator.Create(topicPath, subscriptionName, metadata, sqlFilter, namespaceManager1);
+            await creator.Create(topicPath, subscriptionName, metadata, sqlFilter, namespaceManager2);
+
+            Assert.IsTrue(await namespaceManager1.SubscriptionExists(topicPath, subscriptionName), "Subscription on Value namespace was not created.");
+            Assert.IsTrue(await namespaceManager2.SubscriptionExists(topicPath, subscriptionName), "Subscription on Fallback namespace was not created.");
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusForwardingSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusForwardingSubscriptionCreator.cs
@@ -41,7 +41,7 @@
             var meta = metadata as ForwardingTopologySubscriptionMetadata;
             if (meta == null)
             {
-                throw new InvalidOperationException($"Cannot create subscription `{subscriptionName}` for topic `{topicPath}` without namespace inforation required.");
+                throw new InvalidOperationException($"Cannot create subscription `{subscriptionName}` for topic `{topicPath}` without namespace information required.");
             }
 
             var subscriptionDescription = subscriptionDescriptionFactory(topicPath, subscriptionName, settings);
@@ -62,20 +62,20 @@
                         };
 
                         await namespaceManager.CreateSubscription(subscriptionDescription, ruleDescription).ConfigureAwait(false);
-                        logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}' with rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'");
+                        logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}' with rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}' in namespace '{namespaceManager.Address.Host}'.");
 
-                        var key = subscriptionDescription.TopicPath + subscriptionDescription.Name;
+                        var key = GenerateSubscriptionKey(namespaceManager.Address, subscriptionDescription.TopicPath, subscriptionDescription.Name);
                         await rememberExistence.AddOrUpdate(key, keyNotFound => Task.FromResult(true), (updateTopicPath, previousValue) => Task.FromResult(true)).ConfigureAwait(false);
                     }
                     else
                     {
-                        logger.Info($"Subscription '{subscriptionDescription.Name}' aka '{subscriptionDescription.UserMetadata}' already exists, skipping creation");
-                        logger.InfoFormat("Checking if subscription '{0}' needs to be updated", subscriptionDescription.Name);
+                        logger.Info($"Subscription '{subscriptionDescription.Name}' aka '{subscriptionDescription.UserMetadata}' already exists, skipping creation.");
+                        logger.InfoFormat("Checking if subscription '{0}' in namespace '{1}' needs to be updated.", subscriptionDescription.Name, namespaceManager.Address.Host);
 
                         var existingSubscriptionDescription = await namespaceManager.GetSubscription(subscriptionDescription.TopicPath, subscriptionDescription.Name).ConfigureAwait(false);
                         if (MembersAreNotEqual(existingSubscriptionDescription, subscriptionDescription))
                         {
-                            logger.Info($"Updating subscription '{subscriptionDescription.Name}' with new description");
+                            logger.Info($"Updating subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' with new description.");
                             await namespaceManager.UpdateSubscription(subscriptionDescription).ConfigureAwait(false);
                         }
 
@@ -85,7 +85,7 @@
                             Filter = new SqlFilter(sqlFilter),
                             Name = metadata.SubscriptionNameBasedOnEventWithNamespace
                         };
-                        logger.Info($"Adding subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'");
+                        logger.Info($"Adding subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}' in namespace '{namespaceManager.Address.Host}'.");
                         try
                         {
                             var subscriptionClient = SubscriptionClient.CreateFromConnectionString(meta.NamespaceInfo.ConnectionString, topicPath, subscriptionName);
@@ -93,7 +93,7 @@
                         }
                         catch (MessagingEntityAlreadyExistsException exception)
                         {
-                            logger.Debug($"Rule '{ruleDescription.Name}' already exists. Response from the server: '{exception.Message}'");
+                            logger.Debug($"Rule '{ruleDescription.Name}' already exists. Response from the server: '{exception.Message}'.");
                         }
                     }
                 }
@@ -105,23 +105,23 @@
             catch (MessagingEntityAlreadyExistsException)
             {
                 // the subscription already exists or another node beat us to it, which is ok
-                logger.Info($"Subscription '{subscriptionDescription.Name}' already exists, another node probably beat us to it");
+                logger.Info($"Subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' already exists, another node probably beat us to it.");
             }
             catch (TimeoutException)
             {
-                logger.Info($"Timeout occurred on subscription creation for topic '{subscriptionDescription.TopicPath}' subscription name '{subscriptionDescription.Name}' going to validate if it doesn't exist");
+                logger.Info($"Timeout occurred on subscription creation for topic '{subscriptionDescription.TopicPath}' subscription name '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' going to validate if it doesn't exist.");
 
-                // there is a chance that the timeout occured, but the topic was still created, check again
+                // there is a chance that the timeout occurred, but the topic was still created, check again
                 if (!await ExistsAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name, metadata.Description, namespaceManager, removeCacheEntry: true).ConfigureAwait(false))
                 {
                     throw;
                 }
 
-                logger.Info($"Looks like subscription '{subscriptionDescription.Name}' exists anyway");
+                logger.Info($"Looks like subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' exists anyway.");
             }
             catch (MessagingException ex)
             {
-                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occured on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}'";
+                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occurred on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}' in namespace '{namespaceManager.Address.Host}'.";
 
                 if (!ex.IsTransient)
                 {
@@ -150,7 +150,7 @@
                         Filter = new SqlFilter(sqlFilter),
                         Name = metadata.SubscriptionNameBasedOnEventWithNamespace
                     };
-                    logger.Info($"Removing subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'");
+                    logger.Info($"Removing subscription rule '{ruleDescription.Name}' for event '{meta.SubscribedEventFullName}'.");
                     var subscriptionClient = SubscriptionClient.CreateFromConnectionString(meta.NamespaceInfo.ConnectionString, topicPath, subscriptionName);
                     await subscriptionClient.RemoveRuleAsync(ruleDescription.Name).ConfigureAwait(false);
 
@@ -165,7 +165,7 @@
             }
             catch (MessagingException ex)
             {
-                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occured on subscription '{subscriptionDescription.Name}' deletion for topic '{subscriptionDescription.TopicPath}'";
+                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occurred on subscription '{subscriptionDescription.Name}' deletion for topic '{subscriptionDescription.TopicPath}' in namespace '{namespaceManager.Address.Host}'.";
 
                 if (!ex.IsTransient)
                 {
@@ -179,9 +179,9 @@
 
         async Task<bool> ExistsAsync(string topicPath, string subscriptionName, string metadata, INamespaceManager namespaceClient, bool removeCacheEntry = false)
         {
-            logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}'");
+            logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}' in namespace '{namespaceClient.Address.Host}'.");
 
-            var key = topicPath + subscriptionName;
+            var key = GenerateSubscriptionKey(namespaceClient.Address, topicPath, subscriptionName);
 
             if (removeCacheEntry)
             {
@@ -191,11 +191,11 @@
 
             var exists = await rememberExistence.GetOrAdd(key, notFoundKey =>
             {
-                logger.Info($"Checking namespace for existence of subscription '{subscriptionName}' for the topic '{topicPath}'");
+                logger.Info($"Checking namespace '{namespaceClient.Address.Host}' for existence of subscription '{subscriptionName}' for the topic '{topicPath}'.");
                 return namespaceClient.SubscriptionExists(topicPath, subscriptionName);
             }).ConfigureAwait(false);
 
-            logger.Info($"Determined, from cache, that the subscription '{subscriptionName}' {(exists ? "exists" : "does not exist")}");
+            logger.Info($"Determined, from cache, that the subscription '{subscriptionName}' in namespace '{namespaceClient.Address.Host}' {(exists ? "exists" : "does not exist")}.");
 
             return exists;
         }
@@ -215,6 +215,11 @@
                    || existingDescription.MaxDeliveryCount != newDescription.MaxDeliveryCount
                    || existingDescription.EnableBatchedOperations != newDescription.EnableBatchedOperations
                    || existingDescription.ForwardDeadLetteredMessagesTo != newDescription.ForwardDeadLetteredMessagesTo;
+        }
+
+        static string GenerateSubscriptionKey(Uri namespaceAddress, string topicPath, string subscriptionName)
+        {
+            return  namespaceAddress + topicPath + subscriptionName;
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
@@ -53,19 +53,19 @@
                     if (!await ExistsAsync(topicPath, subscriptionName, metadata.Description, namespaceManager).ConfigureAwait(false))
                     {
                         await namespaceManager.CreateSubscription(subscriptionDescription, sqlFilter).ConfigureAwait(false);
-                        logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' created as '{subscriptionDescription.Name}'");
+                        logger.Info($"Subscription '{subscriptionDescription.UserMetadata}' in namespace '{namespaceManager.Address.Host}' created as '{subscriptionDescription.Name}'.");
 
-                        var key = subscriptionDescription.TopicPath + subscriptionDescription.Name;
+                        var key = GenerateSubscriptionKey(namespaceManager.Address, subscriptionDescription.TopicPath, subscriptionDescription.Name);
                         await rememberExistence.AddOrUpdate(key, keyNotFound => Task.FromResult(true), (updateTopicPath, previousValue) => Task.FromResult(true)).ConfigureAwait(false);
                     }
                     else
                     {
-                        logger.Info($"Subscription '{subscriptionDescription.Name}' aka '{subscriptionDescription.UserMetadata}' already exists, skipping creation");
-                        logger.InfoFormat("Checking if subscription '{0}' needs to be updated", subscriptionDescription.Name);
+                        logger.Info($"Subscription '{subscriptionDescription.Name}' in namespace '{namespaceManager.Address.Host}' aka '{subscriptionDescription.UserMetadata}' already exists, skipping creation.");
+                        logger.InfoFormat("Checking if subscription '{0}' in namespace '{1}' needs to be updated.", subscriptionDescription.Name, namespaceManager.Address.Host);
                         var existingSubscriptionDescription = await namespaceManager.GetSubscription(subscriptionDescription.TopicPath, subscriptionDescription.Name).ConfigureAwait(false);
                         if (MembersAreNotEqual(existingSubscriptionDescription, subscriptionDescription))
                         {
-                            logger.InfoFormat("Updating subscription '{0}' with new description", subscriptionDescription.Name);
+                            logger.InfoFormat("Updating subscription '{0}' in namespace '{1}' with new description.", subscriptionDescription.Name, namespaceManager.Address.Host);
                             await namespaceManager.UpdateSubscription(subscriptionDescription).ConfigureAwait(false);
                         }
                     }
@@ -78,23 +78,23 @@
             catch (MessagingEntityAlreadyExistsException)
             {
                 // the subscription already exists or another node beat us to it, which is ok
-                logger.InfoFormat("Subscription '{0}' already exists, another node probably beat us to it", subscriptionDescription.Name);
+                logger.InfoFormat("Subscription '{0}' in namespace '{1}' already exists, another node probably beat us to it.", subscriptionDescription.Name, namespaceManager.Address.Host);
             }
             catch (TimeoutException)
             {
-                logger.InfoFormat("Timeout occurred on subscription creation for topic '{0}' subscription name '{1}' going to validate if it doesn't exist", subscriptionDescription.TopicPath, subscriptionDescription.Name);
+                logger.InfoFormat("Timeout occurred on subscription creation for topic '{0}' subscription name '{1}' in namespace '{2}' going to validate if it doesn't exist.", subscriptionDescription.TopicPath, subscriptionDescription.Name, namespaceManager.Address.Host);
 
-                // there is a chance that the timeout occured, but the topic was still created, check again
+                // there is a chance that the timeout occurred, but the topic was still created, check again
                 if (!await ExistsAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name, metadata.Description, namespaceManager, removeCacheEntry: true).ConfigureAwait(false))
                 {
                     throw;
                 }
 
-                logger.InfoFormat("Looks like subscription '{0}' exists anyway", subscriptionDescription.Name);
+                logger.InfoFormat("Looks like subscription '{0}' in namespace '{1}' exists anyway.", subscriptionDescription.Name, namespaceManager.Address.Host);
             }
             catch (MessagingException ex)
             {
-                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occured on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}'";
+                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occurred on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}' in namespace '{namespaceManager.Address.Host}'.";
 
                 if (!ex.IsTransient)
                 {
@@ -133,7 +133,7 @@
             }
             catch (MessagingException ex)
             {
-                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occured on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}'";
+                var loggedMessage = $"{(ex.IsTransient ? "Transient" : "Non transient")} {ex.GetType().Name} occurred on subscription '{subscriptionDescription.Name}' creation for topic '{subscriptionDescription.TopicPath}' in namespace '{namespaceManager.Address.Host}'.";
 
                 if (!ex.IsTransient)
                 {
@@ -147,9 +147,9 @@
 
         async Task<bool> ExistsAsync(string topicPath, string subscriptionName, string metadata, INamespaceManager namespaceClient, bool removeCacheEntry = false)
         {
-            logger.Info($"Checking existence cache for subscription '{subscriptionName}' aka '{metadata}'");
+            logger.Info($"Checking existence cache for subscription '{subscriptionName}' in namespace '{namespaceClient.Address.Host}' aka '{metadata}'.");
 
-            var key = topicPath + subscriptionName;
+            var key = GenerateSubscriptionKey(namespaceClient.Address, topicPath, subscriptionName);
 
             if (removeCacheEntry)
             {
@@ -159,11 +159,11 @@
 
             var exists = await rememberExistence.GetOrAdd(key, notFoundKey =>
             {
-                logger.InfoFormat("Checking namespace for existence of subscription '{0}' for the topic '{1}'", subscriptionName, topicPath);
+                logger.InfoFormat("Checking namespace for existence of subscription '{0}' for the topic '{1}' in namespace '{2}'.", subscriptionName, topicPath, namespaceClient.Address.Host);
                 return namespaceClient.SubscriptionExists(topicPath, subscriptionName);
             }).ConfigureAwait(false);
 
-            logger.InfoFormat("Determined, from cache, that the subscription '{0}' {1}", subscriptionName, exists ? "exists" : "does not exist");
+            logger.InfoFormat("Determined, from cache, that the subscription '{0}' in namespace '{2}' {1}.", subscriptionName, exists ? "exists" : "does not exist", namespaceClient.Address.Host);
 
             return exists;
         }
@@ -183,6 +183,11 @@
                    || existingDescription.MaxDeliveryCount != newDescription.MaxDeliveryCount
                    || existingDescription.EnableBatchedOperations != newDescription.EnableBatchedOperations
                    || existingDescription.ForwardDeadLetteredMessagesTo != newDescription.ForwardDeadLetteredMessagesTo;
+        }
+
+        static string GenerateSubscriptionKey(Uri namespaceAddress, string topicPath, string subscriptionName)
+        {
+            return namespaceAddress + topicPath + subscriptionName;
         }
     }
 }


### PR DESCRIPTION
Backport of #489 to Support-7.0

## Who's affected

Anyone using Azure Service Bus transport and using a namespace partitioning strategy that creates the same subscription in multiple namespaces including the built-in strategies [Round Robin](https://docs.particular.net/nservicebus/azure-service-bus/multiple-namespaces-support#round-robin-namespace-partitioning) and [Fail over](https://docs.particular.net/nservicebus/azure-service-bus/multiple-namespaces-support#fail-over-namespace-partitioning).

## Symptoms

When using multiple namespaces NServiceBus throws a `MessagingEntityNotFoundException` exception during startup.