### PR TITLE
Safe entity update (#508)

### DIFF
--- a/src/Transport/Creation/AzureServiceBusQueueCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusQueueCreator.cs
@@ -31,20 +31,20 @@
         {
             var description = new QueueDescription(queuePath)
             {
-               LockDuration = queueSettings.LockDuration,
-               MaxSizeInMegabytes = queueSettings.MaxSizeInMegabytes,
-               RequiresDuplicateDetection = queueSettings.RequiresDuplicateDetection,
-               DefaultMessageTimeToLive = queueSettings.DefaultMessageTimeToLive,
-               EnableDeadLetteringOnMessageExpiration = queueSettings.EnableDeadLetteringOnMessageExpiration,
-               DuplicateDetectionHistoryTimeWindow = queueSettings.DuplicateDetectionHistoryTimeWindow,
-               MaxDeliveryCount = IsSystemQueue(queuePath) ? 10 : numberOfImmediateRetries,
-               EnableBatchedOperations = queueSettings.EnableBatchedOperations,
-               EnablePartitioning = queueSettings.EnablePartitioning,
-               SupportOrdering = queueSettings.SupportOrdering,
-               AutoDeleteOnIdle = queueSettings.AutoDeleteOnIdle,
+                LockDuration = queueSettings.LockDuration,
+                MaxSizeInMegabytes = queueSettings.MaxSizeInMegabytes,
+                RequiresDuplicateDetection = queueSettings.RequiresDuplicateDetection,
+                DefaultMessageTimeToLive = queueSettings.DefaultMessageTimeToLive,
+                EnableDeadLetteringOnMessageExpiration = queueSettings.EnableDeadLetteringOnMessageExpiration,
+                DuplicateDetectionHistoryTimeWindow = queueSettings.DuplicateDetectionHistoryTimeWindow,
+                MaxDeliveryCount = IsSystemQueue(queuePath) ? 10 : numberOfImmediateRetries,
+                EnableBatchedOperations = queueSettings.EnableBatchedOperations,
+                EnablePartitioning = queueSettings.EnablePartitioning,
+                SupportOrdering = queueSettings.SupportOrdering,
+                AutoDeleteOnIdle = queueSettings.AutoDeleteOnIdle,
 
-               EnableExpress = queueSettings.EnableExpress,
-               ForwardDeadLetteredMessagesTo = queueSettings.ForwardDeadLetteredMessagesTo
+                EnableExpress = queueSettings.EnableExpress,
+                ForwardDeadLetteredMessagesTo = queueSettings.ForwardDeadLetteredMessagesTo
             };
 
             queueSettings.DescriptionCustomizer(description);
@@ -70,6 +70,7 @@
                     var existingDescription = await namespaceManager.GetQueue(description.Path).ConfigureAwait(false);
                     if (MembersAreNotEqual(existingDescription, description))
                     {
+                        OverrideImmutableMembers(existingDescription, description);
                         logger.InfoFormat("Updating queue '{0}' with new description", description.Path);
                         await namespaceManager.UpdateQueue(description).ConfigureAwait(false);
                     }
@@ -159,6 +160,13 @@
                    || existingDescription.SupportOrdering != newDescription.SupportOrdering
                    || existingDescription.EnableExpress != newDescription.EnableExpress
                    || existingDescription.ForwardDeadLetteredMessagesTo != newDescription.ForwardDeadLetteredMessagesTo;
+        }
+
+        void OverrideImmutableMembers(QueueDescription existingDescription, QueueDescription newDescription)
+        {
+            newDescription.RequiresDuplicateDetection = existingDescription.RequiresDuplicateDetection;
+            newDescription.EnablePartitioning = existingDescription.EnablePartitioning;
+            newDescription.RequiresSession = existingDescription.RequiresSession;
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusQueueCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusQueueCreator.cs
@@ -31,20 +31,20 @@
         {
             var description = new QueueDescription(queuePath)
             {
-                LockDuration = queueSettings.LockDuration,
-                MaxSizeInMegabytes = queueSettings.MaxSizeInMegabytes,
-                RequiresDuplicateDetection = queueSettings.RequiresDuplicateDetection,
-                DefaultMessageTimeToLive = queueSettings.DefaultMessageTimeToLive,
-                EnableDeadLetteringOnMessageExpiration = queueSettings.EnableDeadLetteringOnMessageExpiration,
-                DuplicateDetectionHistoryTimeWindow = queueSettings.DuplicateDetectionHistoryTimeWindow,
-                MaxDeliveryCount = IsSystemQueue(queuePath) ? 10 : numberOfImmediateRetries,
-                EnableBatchedOperations = queueSettings.EnableBatchedOperations,
-                EnablePartitioning = queueSettings.EnablePartitioning,
-                SupportOrdering = queueSettings.SupportOrdering,
-                AutoDeleteOnIdle = queueSettings.AutoDeleteOnIdle,
+               LockDuration = queueSettings.LockDuration,
+               MaxSizeInMegabytes = queueSettings.MaxSizeInMegabytes,
+               RequiresDuplicateDetection = queueSettings.RequiresDuplicateDetection,
+               DefaultMessageTimeToLive = queueSettings.DefaultMessageTimeToLive,
+               EnableDeadLetteringOnMessageExpiration = queueSettings.EnableDeadLetteringOnMessageExpiration,
+               DuplicateDetectionHistoryTimeWindow = queueSettings.DuplicateDetectionHistoryTimeWindow,
+               MaxDeliveryCount = IsSystemQueue(queuePath) ? 10 : numberOfImmediateRetries,
+               EnableBatchedOperations = queueSettings.EnableBatchedOperations,
+               EnablePartitioning = queueSettings.EnablePartitioning,
+               SupportOrdering = queueSettings.SupportOrdering,
+               AutoDeleteOnIdle = queueSettings.AutoDeleteOnIdle,
 
-                EnableExpress = queueSettings.EnableExpress,
-                ForwardDeadLetteredMessagesTo = queueSettings.ForwardDeadLetteredMessagesTo
+               EnableExpress = queueSettings.EnableExpress,
+               ForwardDeadLetteredMessagesTo = queueSettings.ForwardDeadLetteredMessagesTo
             };
 
             queueSettings.DescriptionCustomizer(description);

--- a/src/Transport/Creation/AzureServiceBusTopicCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusTopicCreator.cs
@@ -52,6 +52,7 @@
                     if (MembersAreNotEqual(existingTopicDescription, topicDescription))
                     {
                         logger.InfoFormat("Updating topic '{0}' with new description", topicDescription.Path);
+	                    OverrideImmutableMembers(existingTopicDescription, topicDescription);
                         await namespaceManager.UpdateTopic(topicDescription).ConfigureAwait(false);
                     }
                 }
@@ -132,5 +133,10 @@
                    || existingDescription.EnableFilteringMessagesBeforePublishing != newDescription.EnableFilteringMessagesBeforePublishing;
         }
 
+	    void OverrideImmutableMembers(TopicDescription existingDescription, TopicDescription newDescription)
+	    {
+		    newDescription.RequiresDuplicateDetection = existingDescription.RequiresDuplicateDetection;
+		    newDescription.EnablePartitioning = existingDescription.EnablePartitioning;
+	    }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusTopicCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusTopicCreator.cs
@@ -133,10 +133,10 @@
                    || existingDescription.EnableFilteringMessagesBeforePublishing != newDescription.EnableFilteringMessagesBeforePublishing;
         }
 
-	    void OverrideImmutableMembers(TopicDescription existingDescription, TopicDescription newDescription)
-	    {
-		    newDescription.RequiresDuplicateDetection = existingDescription.RequiresDuplicateDetection;
-		    newDescription.EnablePartitioning = existingDescription.EnablePartitioning;
-	    }
+        void OverrideImmutableMembers(TopicDescription existingDescription, TopicDescription newDescription)
+        {
+            newDescription.RequiresDuplicateDetection = existingDescription.RequiresDuplicateDetection;
+            newDescription.EnablePartitioning = existingDescription.EnablePartitioning;
+        }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusTopicCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusTopicCreator.cs
@@ -52,7 +52,7 @@
                     if (MembersAreNotEqual(existingTopicDescription, topicDescription))
                     {
                         logger.InfoFormat("Updating topic '{0}' with new description", topicDescription.Path);
-	                    OverrideImmutableMembers(existingTopicDescription, topicDescription);
+                        OverrideImmutableMembers(existingTopicDescription, topicDescription);
                         await namespaceManager.UpdateTopic(topicDescription).ConfigureAwait(false);
                     }
                 }

--- a/src/Transport/Creation/AzureServiceBusTopicCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusTopicCreator.cs
@@ -51,8 +51,8 @@
                     var existingTopicDescription = await namespaceManager.GetTopic(topicDescription.Path).ConfigureAwait(false);
                     if (MembersAreNotEqual(existingTopicDescription, topicDescription))
                     {
-                        logger.InfoFormat("Updating topic '{0}' with new description", topicDescription.Path);
                         OverrideImmutableMembers(existingTopicDescription, topicDescription);
+                        logger.InfoFormat("Updating topic '{0}' with new description", topicDescription.Path);
                         await namespaceManager.UpdateTopic(topicDescription).ConfigureAwait(false);
                     }
                 }


### PR DESCRIPTION
Connect to https://github.com/Particular/NServiceBus.AzureServiceBus/issues/508

On startup the transport will attempt to create the entity (queue or topic) if it does not exist.
Some entity properties may only be set at creation time and may not be modified later (immutable).
This PR corrects an issue where the endpoint configuration might describe an entity in such a way that it is different from the existing entity, and includes changes to both mutable and immutable properties.  The previous behavior would attempt to modify all properties to match the endpoint configuration, which would be rejected by ASB with a 400 error.  The new behavior is to copy the value of existing, immutable properties from the existing entity into the requested entity for update.  This will eliminate the exception.