### PR TITLE
Safe subscriptions update

### DIFF
--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -429,7 +429,8 @@
             });
 
             var creator = new AzureServiceBusSubscriptionCreator(topology.Settings.SubscriptionSettings, settings);
-            Assert.ThrowsAsync<ArgumentException>(async () => await creator.Create("sometopic2", "existingsubscription2", metadata, sqlFilter, namespaceManager));
+            var subscriptionDescription = await creator.Create("sometopic2", "existingsubscription2", metadata, sqlFilter, namespaceManager);
+            Assert.IsTrue(subscriptionDescription.RequiresSession);
 
             //cleanup
             await namespaceManager.DeleteTopic("sometopic2");

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
@@ -63,6 +63,7 @@
                     var existingSubscriptionDescription = await namespaceManager.GetSubscription(subscriptionDescription.TopicPath, subscriptionDescription.Name).ConfigureAwait(false);
                     if (MembersAreNotEqual(existingSubscriptionDescription, subscriptionDescription))
                     {
+                        OverrideImmutableMembers(existingSubscriptionDescription, subscriptionDescription);
                         logger.InfoFormat("Updating subscription '{0}' in namespace '{1}' with new description.", subscriptionDescription.Name, namespaceManager.Address.Host);
                         await namespaceManager.UpdateSubscription(subscriptionDescription).ConfigureAwait(false);
                     }
@@ -170,6 +171,11 @@
         static string GenerateSubscriptionKey(Uri namespaceAddress, string topicPath, string subscriptionName)
         {
             return namespaceAddress + topicPath + subscriptionName;
+        }
+
+        void OverrideImmutableMembers(SubscriptionDescription existingDescription, SubscriptionDescription newDescription)
+        {
+            newDescription.RequiresSession = existingDescription.RequiresSession;
         }
     }
 }


### PR DESCRIPTION
Connect to https://github.com/Particular/NServiceBus.AzureServiceBus/issues/508

`RequiresSession` is a read-only/immutable property for subscriptions that should not be changed. 
