### PR TITLE
Hotfix 7.0.8

### DIFF
--- a/src/Tests/Creation/When_creating_queues.cs
+++ b/src/Tests/Creation/When_creating_queues.cs
@@ -435,23 +435,39 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Creation
             await namespaceManager.CreateQueue(new QueueDescription("existingqueue")
             {
                 LockDuration = TimeSpan.FromSeconds(50),
+                MaxSizeInMegabytes = SizeInMegabytes.Size2048,
                 RequiresDuplicateDetection = true,
                 EnablePartitioning = true,
                 RequiresSession = true
             });
 
+            var queueDescription = await namespaceManager.GetQueue("existingqueue");
+
+            // partitioned topics will have a size that is 16x the requested max
+            Assert.AreEqual(2048 * 16, queueDescription.MaxSizeInMegabytes);
+            Assert.AreEqual(TimeSpan.FromSeconds(50), queueDescription.LockDuration);
+            Assert.IsTrue(queueDescription.EnablePartitioning);
+            Assert.IsTrue(queueDescription.RequiresDuplicateDetection);
+
             var settings = new DefaultConfigurationValues().Apply(new SettingsHolder());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
             extensions.Queues().DescriptionFactory((queuePath, readOnlySettings) => new QueueDescription(queuePath)
             {
-                LockDuration = TimeSpan.FromSeconds(50),
+                LockDuration = TimeSpan.FromSeconds(70),
+                MaxSizeInMegabytes = SizeInMegabytes.Size3072,
                 RequiresDuplicateDetection = false,
                 EnablePartitioning = false,
                 RequiresSession = false,
             });
 
             var creator = new AzureServiceBusQueueCreator(settings);
-            Assert.ThrowsAsync<ArgumentException>(async () =>  await creator.Create("existingqueue", namespaceManager));
+            await creator.Create("existingqueue", namespaceManager);
+
+            queueDescription = await namespaceManager.GetQueue("existingqueue");
+            Assert.AreEqual(3072 * 16, queueDescription.MaxSizeInMegabytes);
+            Assert.AreEqual(TimeSpan.FromSeconds(70), queueDescription.LockDuration);
+            Assert.IsTrue(queueDescription.EnablePartitioning);
+            Assert.IsTrue(queueDescription.RequiresDuplicateDetection);
 
             //cleanup
             await namespaceManager.DeleteQueue("existingqueue");

--- a/src/Tests/Creation/When_creating_subscription.cs
+++ b/src/Tests/Creation/When_creating_subscription.cs
@@ -435,7 +435,8 @@
             });
 
             var creator = new AzureServiceBusSubscriptionCreator(settings);
-            Assert.ThrowsAsync<ArgumentException>(async () => await creator.Create("sometopic2", "existingsubscription2", metadata, sqlFilter, namespaceManager));
+            var subscriptionDescription = await creator.Create("sometopic2", "existingsubscription2", metadata, sqlFilter, namespaceManager);
+            Assert.IsTrue(subscriptionDescription.RequiresSession);
 
             //cleanup
             await namespaceManager.DeleteTopic("sometopic2");

--- a/src/Transport/Creation/AzureServiceBusQueueCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusQueueCreator.cs
@@ -71,6 +71,7 @@
                         var existingDescription = await namespaceManager.GetQueue(description.Path).ConfigureAwait(false);
                         if (MembersAreNotEqual(existingDescription, description))
                         {
+                            OverrideImmutableMembers(existingDescription, description);
                             logger.InfoFormat("Updating queue '{0}' with new description", description.Path);
                             await namespaceManager.UpdateQueue(description).ConfigureAwait(false);
                         }
@@ -166,6 +167,13 @@
                    || existingDescription.SupportOrdering != newDescription.SupportOrdering
                    || existingDescription.EnableExpress != newDescription.EnableExpress
                    || existingDescription.ForwardDeadLetteredMessagesTo != newDescription.ForwardDeadLetteredMessagesTo;
+        }
+
+        void OverrideImmutableMembers(QueueDescription existingDescription, QueueDescription newDescription)
+        {
+            newDescription.RequiresDuplicateDetection = existingDescription.RequiresDuplicateDetection;
+            newDescription.EnablePartitioning = existingDescription.EnablePartitioning;
+            newDescription.RequiresSession = existingDescription.RequiresSession;
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreator.cs
@@ -65,6 +65,7 @@
                         var existingSubscriptionDescription = await namespaceManager.GetSubscription(subscriptionDescription.TopicPath, subscriptionDescription.Name).ConfigureAwait(false);
                         if (MembersAreNotEqual(existingSubscriptionDescription, subscriptionDescription))
                         {
+                            OverrideImmutableMembers(existingSubscriptionDescription, subscriptionDescription);
                             logger.InfoFormat("Updating subscription '{0}' in namespace '{1}' with new description.", subscriptionDescription.Name, namespaceManager.Address.Host);
                             await namespaceManager.UpdateSubscription(subscriptionDescription).ConfigureAwait(false);
                         }
@@ -188,6 +189,11 @@
         static string GenerateSubscriptionKey(Uri namespaceAddress, string topicPath, string subscriptionName)
         {
             return namespaceAddress + topicPath + subscriptionName;
+        }
+
+        void OverrideImmutableMembers(SubscriptionDescription existingDescription, SubscriptionDescription newDescription)
+        {
+            newDescription.RequiresSession = existingDescription.RequiresSession;
         }
     }
 }

--- a/src/Transport/Creation/AzureServiceBusTopicCreator.cs
+++ b/src/Transport/Creation/AzureServiceBusTopicCreator.cs
@@ -58,6 +58,7 @@
                         var existingTopicDescription = await namespaceManager.GetTopic(topicDescription.Path).ConfigureAwait(false);
                         if (MembersAreNotEqual(existingTopicDescription, topicDescription))
                         {
+                            OverrideImmutableMembers(existingTopicDescription, topicDescription);
                             logger.InfoFormat("Updating topic '{0}' with new description", topicDescription.Path);
                             await namespaceManager.UpdateTopic(topicDescription).ConfigureAwait(false);
                         }
@@ -144,5 +145,10 @@
                    || existingDescription.EnableFilteringMessagesBeforePublishing != newDescription.EnableFilteringMessagesBeforePublishing;
         }
 
+        void OverrideImmutableMembers(TopicDescription existingDescription, TopicDescription newDescription)
+        {
+            newDescription.RequiresDuplicateDetection = existingDescription.RequiresDuplicateDetection;
+            newDescription.EnablePartitioning = existingDescription.EnablePartitioning;
+        }
     }
 }


### PR DESCRIPTION
## Who's affected

- Anyone using Azure Service Bus 7.0 and up and performing entity updates that include immutable properties (`RequiresDuplicateDetection`, `EnablePartitioning`, `RequiresSession`).

## Symptoms

- The transport fails to update the entities.

## Original issue report

Issue #508 