### PR TITLE
ASB 4.0.0 dependency update

### DIFF
--- a/packaging/nuget/nservicebus.azureservicebus.nuspec
+++ b/packaging/nuget/nservicebus.azureservicebus.nuspec
@@ -14,7 +14,7 @@
     <copyright>$copyright$</copyright>
     <tags>$tags$</tags>
     <dependencies>
-      <dependency id="WindowsAzure.ServiceBus" version="[3.0.0.0, 4.0.0.0)" />
+      <dependency id="WindowsAzure.ServiceBus" version="[4.0.0.0, 5.0.0.0)" />
       <dependency id="NServiceBus" version="[6.0.0.0, 7.0.0.0)" />
     </dependencies>
   </metadata>

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -38,8 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.4.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.4.0.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/src/AcceptanceTests/packages.config
+++ b/src/AcceptanceTests/packages.config
@@ -5,5 +5,5 @@
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="6.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
-  <package id="WindowsAzure.ServiceBus" version="3.4.0" targetFramework="net452" />
+  <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -52,8 +52,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.4.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.4.0.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -8,5 +8,5 @@
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
-  <package id="WindowsAzure.ServiceBus" version="3.4.0" targetFramework="net452" />
+  <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -54,8 +54,7 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.4.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.4.0.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/src/Transport/packages.config
+++ b/src/Transport/packages.config
@@ -8,5 +8,5 @@
   <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Particular.CodeRules" version="0.1.1" targetFramework="net452" developmentDependency="true" />
-  <package id="WindowsAzure.ServiceBus" version="3.4.0" targetFramework="net452" />
+  <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -31,8 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.4.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.4.0.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.0.0\lib\net452\NServiceBus.Core.dll</HintPath>

--- a/src/TransportTests/packages.config
+++ b/src/TransportTests/packages.config
@@ -3,5 +3,5 @@
   <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
   <package id="NServiceBus.TransportTests.Sources" version="6.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
-  <package id="WindowsAzure.ServiceBus" version="3.4.0" targetFramework="net452" />
+  <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Connects to #514

## Who's affected

- Anyone using Azure Service Bus and required to use `WindowsAzure.ServiceBus` version 4.0.0

## Symptoms

No symptoms. This release is is to support the latest version of the `WindowsAzure.ServiceBus` library version 4.0.0