### PR TITLE
should not log that we would use send via if we don't

### DIFF
--- a/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
+++ b/src/Transport/Sending/DefaultOutgoingBatchRouter.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             {
                 var routingOptions = GetRoutingOptions(context, consistency);
 
-                if (!string.IsNullOrEmpty(routingOptions.ViaEntityPath))
+                if (routingOptions.SendVia && !string.IsNullOrEmpty(routingOptions.ViaEntityPath))
                 {
                     Logger.DebugFormat("Routing {0} messages to {1} via {2}", outgoingBatches.Count, entity.Path, routingOptions.ViaEntityPath);
                 }


### PR DESCRIPTION
Small fix in the logs, we are logging that we would use send via even if the tx mode is set to receive only. We don't effectively do, so the log is misleading