### PR TITLE
Hotfix 7.1.6

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -328,6 +328,7 @@
     <Compile Include="OldTests\When_sending_an_oversized_message_without_a_transaction_scope.cs" />
     <Compile Include="OldTests\When_sending_an_oversized_message_from_a_transaction_scope.cs" />
     <Compile Include="Publishing\When_using_a_signle_bundle.cs" />
+    <Compile Include="Receiving\When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs" />
     <Compile Include="Routing\AzureServiceBusTransportConfigContext.cs" />
     <Compile Include="Routing\When_scaling_out_senders_that_uses_callbacks.cs" />
     <Compile Include="Routing\When_sending_to_specific_namespace.cs" />

--- a/src/AcceptanceTests/Receiving/When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs
+++ b/src/AcceptanceTests/Receiving/When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs
@@ -6,7 +6,6 @@
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
-    using AcceptanceTesting.Customization;
 
     public class When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode : NServiceBusAcceptanceTest
     {

--- a/src/AcceptanceTests/Receiving/When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs
+++ b/src/AcceptanceTests/Receiving/When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using AcceptanceTesting.Customization;
+
+    public class When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode : NServiceBusAcceptanceTest
+    {
+        const int LockDurationOnIncomingMessageInSeconds = 5;
+
+        [Test]
+        public async Task Should_not_dispatch_outgoing_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(builder => builder.When((session, ctx) => session.SendLocal(new InitialMessage())))
+                .WithEndpoint<Receiver>()
+                .Done(ctx => ctx.TimesDispatchedMessageSent > 0)
+                .Run();
+
+            Assert.That(context.TimesDispatchedMessageReceived, Is.Zero);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int TimesDispatchedMessageReceived { get; set; }
+            public int TimesDispatchedMessageSent { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var transport = config.UseTransport<AzureServiceBusTransport>();
+                    transport.Queues().LockDuration(TimeSpan.FromSeconds(LockDurationOnIncomingMessageInSeconds));
+                    transport.Queues().MaxDeliveryCount(100);
+                    transport.MessageReceivers().AutoRenewTimeout(TimeSpan.Zero);
+                    transport.Routing().RouteToEndpoint(typeof(DispatchedMessage), "Receiver");
+                    config.LimitMessageProcessingConcurrencyTo(1);
+#pragma warning disable 618
+                    config.Recoverability().DisableLegacyRetriesSatellite();
+#pragma warning restore 618
+                });
+            }
+
+            public class InitialMessageHandler : IHandleMessages<InitialMessage>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(InitialMessage initialMessage, IMessageHandlerContext context)
+                {
+                    await context.Send(new DispatchedMessage { Id = Context.TestRunId });
+                    await Task.Delay(TimeSpan.FromSeconds(LockDurationOnIncomingMessageInSeconds * 2));
+                    Context.TimesDispatchedMessageSent++;
+                }
+            }
+        }
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+#pragma warning disable 618
+                    config.Recoverability().DisableLegacyRetriesSatellite();
+#pragma warning restore 618
+                });
+            }
+
+            public class DispatchedMessageHandler : IHandleMessages<DispatchedMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(DispatchedMessage message, IMessageHandlerContext context)
+                {
+                    Context.TimesDispatchedMessageReceived++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class InitialMessage : IMessage
+        {
+        }
+
+        public class DispatchedMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/AcceptanceTests/Receiving/When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs
+++ b/src/AcceptanceTests/Receiving/When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs
@@ -39,7 +39,7 @@
                     transport.Queues().LockDuration(TimeSpan.FromSeconds(LockDurationOnIncomingMessageInSeconds));
                     transport.Queues().MaxDeliveryCount(100);
                     transport.MessageReceivers().AutoRenewTimeout(TimeSpan.Zero);
-                    transport.Routing().RouteToEndpoint(typeof(DispatchedMessage), "Receiver");
+                    transport.Routing().RouteToEndpoint(typeof(DispatchedMessage), ConfigureEndpointAzureServiceBusTransport.NameForEndpoint<Receiver>());
                     config.LimitMessageProcessingConcurrencyTo(1);
 #pragma warning disable 618
                     config.Recoverability().DisableLegacyRetriesSatellite();

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -224,8 +224,11 @@ namespace NServiceBus.Transport.AzureServiceBus
                         {
                             await incomingCallback(incomingMessage, context).ConfigureAwait(false);
 
-                            await HandleCompletion(message, context, completionCanBeBatched, slotNumber).ConfigureAwait(false);
-                            scope?.Complete();
+                            var wasCompleted = await HandleCompletion(message, context, completionCanBeBatched, slotNumber).ConfigureAwait(false);
+                            if (wasCompleted)
+                            {
+                                scope?.Complete();
+                            }
                         }
                     }
                 }
@@ -257,7 +260,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
         }
 
-        Task HandleCompletion(BrokeredMessage message, BrokeredMessageReceiveContext context, bool canBeBatched, int slotNumber)
+        Task<bool> HandleCompletion(BrokeredMessage message, BrokeredMessageReceiveContext context, bool canBeBatched, int slotNumber)
         {
             if (context.CancellationToken.IsCancellationRequested)
             {
@@ -275,32 +278,34 @@ namespace NServiceBus.Transport.AzureServiceBus
                     return context.IncomingBrokeredMessage.SafeCompleteAsync();
                 }
             }
-            return TaskEx.Completed;
+            return TaskEx.CompletedTrue;
         }
 
-        Task AbandonOnCancellation(BrokeredMessage message)
+        Task<bool> AbandonOnCancellation(BrokeredMessage message)
         {
             logger.Debug("Received message is cancelled by the pipeline, abandoning it so we can process it later.");
 
             return AbandonInternal(message);
         }
 
-        Task Abandon(BrokeredMessage message, Exception exception)
+        Task<bool> Abandon(BrokeredMessage message, Exception exception)
         {
             logger.Debug("Exceptions occurred OnComplete", exception);
 
             return AbandonInternal(message);
         }
 
-        async Task AbandonInternal(BrokeredMessage message, IDictionary<string, object> propertiesToModify = null)
+        async Task<bool> AbandonInternal(BrokeredMessage message, IDictionary<string, object> propertiesToModify = null)
         {
-            if (receiveMode == ReceiveMode.ReceiveAndDelete) return;
+            if (receiveMode == ReceiveMode.ReceiveAndDelete) return true;
 
+            bool wasAbandoned;
             using (var suppressScope = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             {
                 logger.DebugFormat("Abandoning brokered message {0}", message.MessageId);
 
-                if (await message.SafeAbandonAsync(propertiesToModify).ConfigureAwait(false))
+                wasAbandoned = await message.SafeAbandonAsync(propertiesToModify).ConfigureAwait(false);
+                if (wasAbandoned)
                 {
                     logger.DebugFormat("Brokered message {0} abandoned successfully.", message.MessageId);
                 }
@@ -311,6 +316,8 @@ namespace NServiceBus.Transport.AzureServiceBus
 
                 suppressScope.Complete();
             }
+
+            return wasAbandoned;
         }
 
         static Task EmptyErrorCallback(Exception exception)

--- a/src/Transport/Utils/TaskEx.cs
+++ b/src/Transport/Utils/TaskEx.cs
@@ -8,6 +8,8 @@
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
         public static readonly Task Completed = Task.FromResult(0);
 
+        public static readonly Task<bool> CompletedTrue = Task.FromResult(true);
+
         public static void Ignore(this Task task)
         {
         }


### PR DESCRIPTION
Connected to #532 
Backport of `hotfix-7.2.1`
Related to #530 

## Who's affected

Anyone using Azure Service Bus transport with `SendsAtomicWithReceive` transaction guarantee

## Symptoms 

Incoming message is processed, **not** completed (a warning about message lost lock is logged), but the outgoing messages are dispatched.
As a result of that, incoming message is re-processed, causing outgoing messages to be sent again, generating duplicates.