### PR TITLE
TestIndependenceSkipBehavior improvement

### DIFF
--- a/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
+++ b/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
@@ -22,7 +22,7 @@
         }
     }
 
-    class TestIndependenceSkipBehavior : Behavior<IIncomingPhysicalMessageContext>
+    class TestIndependenceSkipBehavior : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
     {
         string testRunId;
 
@@ -31,16 +31,16 @@
             testRunId = scenarioContext.TestRunId.ToString();
         }
 
-        public override Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+        public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
             string runId;
-            if (!context.MessageHeaders.TryGetValue("$AcceptanceTesting.TestRunId", out runId) || runId != testRunId)
+            if (!context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out runId) || runId != testRunId)
             {
-                Console.WriteLine($"Skipping message {context.MessageId} from previous test run");
+                Console.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
                 return Task.FromResult(0);
             }
 
-            return next();
+            return next(context);
         }
     }
 }


### PR DESCRIPTION
Skip message earlier if message is not part of the current acceptance test run.

`ITransportReceiveContext` behavior is executed prior to `IIncomingPhysicalMessageContext`.

@danielmarbach also using `IBehavior` instead of `Behavior<T>` as per discussion with @bording 