### PR TITLE
[WIP] Message is completed instead of abandoned when incoming message processing is aborted

### DIFF
--- a/src/AcceptanceTests/Issues/When_publisher_and_subscriber_bundles_are_misconfigured.cs
+++ b/src/AcceptanceTests/Issues/When_publisher_and_subscriber_bundles_are_misconfigured.cs
@@ -63,6 +63,7 @@
             }
         }
 
+
         public class Context : ScenarioContext
         {
             public bool SubscribedToEvent { get; set; }

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -270,6 +270,7 @@
     <Compile Include="OldTests\When_sending_an_oversized_message_without_a_transaction_scope.cs" />
     <Compile Include="OldTests\When_sending_an_oversized_message_from_a_transaction_scope.cs" />
     <Compile Include="Publishing\When_using_a_signle_bundle.cs" />
+    <Compile Include="Receiving\When_receive_operation_is_aborted.cs" />
     <Compile Include="Receiving\When_incoming_message_lock_token_is_lost_in_send_atomic_with_receive_mode.cs" />
     <Compile Include="Routing\AzureServiceBusTransportConfigContext.cs" />
     <Compile Include="Routing\When_scaling_out_senders_that_uses_callbacks.cs" />

--- a/src/AcceptanceTests/Receiving/When_receive_operation_is_aborted.cs
+++ b/src/AcceptanceTests/Receiving/When_receive_operation_is_aborted.cs
@@ -1,0 +1,115 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using AcceptanceTesting.Customization;
+    using Pipeline;
+
+    public class When_receive_operation_is_aborted : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_dispatch_outgoing_message()
+        {
+            var delay = Task.Delay(TimeSpan.FromSeconds(30));
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<AbortReceivingEndpoint>(builder => builder.When((session, ctx) => session.SendLocal(new InitialMessage())))
+                .WithEndpoint<EndpointThatShouldNotReceive>()
+                .Done(ctx => delay.IsCompleted || ctx.TimesDispatchedMessageReceived > 0)
+                .Run();
+            
+            Assert.That(context.TimesDispatchedMessageReceived, Is.Zero);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int TimesDispatchedMessageReceived { get; set; }
+            public int TimesSenderHandlerInvoked { get; set; }
+        }
+
+        public class AbortReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public AbortReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var transport = config.UseTransport<AzureServiceBusTransport>();
+                    transport.Routing().RouteToEndpoint(typeof(DispatchedMessage), typeof(EndpointThatShouldNotReceive));
+                    config.LimitMessageProcessingConcurrencyTo(1);
+                    config.Recoverability().DisableLegacyRetriesSatellite();
+
+                    config.Pipeline.Register("AbortReceiveOperation", typeof(AbortReceiveOperationBehavior), "Abort receive operation");
+                });
+            }
+
+            public class InitialMessageHandler : IHandleMessages<InitialMessage>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(InitialMessage initialMessage, IMessageHandlerContext context)
+                {
+                    if (Context.TimesSenderHandlerInvoked == 0)
+                    {
+                        await context.Send(new DispatchedMessage { Id = Context.TestRunId });
+                    }
+                    Context.TimesSenderHandlerInvoked++;
+                }
+            }
+
+            class AbortReceiveOperationBehavior : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
+            {
+                string testRunId;
+
+                public AbortReceiveOperationBehavior(ScenarioContext scenarioContext)
+                {
+                    testRunId = scenarioContext.TestRunId.ToString();
+                }
+                public async Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
+                {
+                    await next(context);
+
+                    string runId;
+                    if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out runId) && runId == testRunId)
+                    {
+                        context.AbortReceiveOperation();
+                    }
+                }
+            }
+        }
+
+        public class EndpointThatShouldNotReceive : EndpointConfigurationBuilder
+        {
+            public EndpointThatShouldNotReceive()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Recoverability().DisableLegacyRetriesSatellite();
+                });
+            }
+
+            public class DispatchedMessageHandler : IHandleMessages<DispatchedMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(DispatchedMessage message, IMessageHandlerContext context)
+                {
+                    Context.TimesDispatchedMessageReceived++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class InitialMessage : IMessage
+        {
+        }
+
+        public class DispatchedMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/Transport/Receiving/MessageReceiverNotifier.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifier.cs
@@ -224,10 +224,17 @@ namespace NServiceBus.Transport.AzureServiceBus
                         {
                             await incomingCallback(incomingMessage, context).ConfigureAwait(false);
 
-                            var wasCompleted = await HandleCompletion(message, context, completionCanBeBatched, slotNumber).ConfigureAwait(false);
-                            if (wasCompleted)
+                            if (context.CancellationToken.IsCancellationRequested)
                             {
-                                scope?.Complete();
+                                await AbandonOnCancellation(message).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                var wasCompleted = await HandleCompletion(message, context, completionCanBeBatched, slotNumber).ConfigureAwait(false);
+                                if (wasCompleted)
+                                {
+                                    scope?.Complete();
+                                }
                             }
                         }
                     }
@@ -262,11 +269,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         Task<bool> HandleCompletion(BrokeredMessage message, BrokeredMessageReceiveContext context, bool canBeBatched, int slotNumber)
         {
-            if (context.CancellationToken.IsCancellationRequested)
-            {
-                return AbandonOnCancellation(message);
-            }
-
             if (receiveMode == ReceiveMode.PeekLock)
             {
                 if (canBeBatched)


### PR DESCRIPTION
Connects to #542
~~Depends on #533~~

This is an edge case when an incoming message is abandoned as a result of cancellation that was triggered via `CancellationToken` passed into Core. Currently, this is only possible using [custom behavior](https://github.com/Particular/NServiceBus.AzureServiceBus/compare/hotfix-7.2.2...issue-542-abandoning-on-shutdown?expand=1#diff-901eac66d7f6d8e53becc18c670d1f92R77) since Core doesn't use this cancellation token. Would still want to make sure we're covered and that messages are not abandoned and scope is completed.

Being an edge case, I'm not sure it's worth back-porting this.

@Particular/azure-maintainers thoughts?