### PR TITLE
[WIP] Bumping test projects dependencies

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net452</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugSymbols>True</DebugSymbols>
-    <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>PCR0001</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -10,11 +10,11 @@
     <AssemblyOriginatorKeyFile>WorkaroundKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.4" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.3.4" />
-    <PackageReference Include="NServiceBus" Version="6.3.4" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.6" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.3.6" />
+    <PackageReference Include="NServiceBus" Version="6.3.6" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <ProjectReference Include="..\Transport\NServiceBus.AzureServiceBus.csproj" />
   </ItemGroup>

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -13,10 +13,10 @@
   <ItemGroup>
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.0.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.3.1" />
-    <PackageReference Include="NServiceBus" Version="6.3.1" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.4" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.3.4" />
+    <PackageReference Include="NServiceBus" Version="6.3.4" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
     <ProjectReference Include="..\Transport\NServiceBus.AzureServiceBus.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -16,14 +16,14 @@
     <Compile Remove="NServiceBus.Azure.Transports.WindowsAzureServiceBus.received.cs" />
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
-    <PackageReference Include="FakeItEasy" Version="2.3.3" />
+    <PackageReference Include="FakeItEasy" Version="3.4.1" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.0.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="ApiApprover" Version="6.1.0-beta2" />
     <PackageReference Include="PublicApiGenerator" Version="6.1.0-beta2" />
-    <PackageReference Include="NServiceBus" Version="6.3.1" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus" Version="6.3.4" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
     <Reference Include="System.Configuration" />
     <ProjectReference Include="..\Transport\NServiceBus.AzureServiceBus.csproj" />
   </ItemGroup>

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
     <PackageReference Include="FakeItEasy" Version="3.4.1" />
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="ApiApprover" Version="6.1.0-beta2" />
     <PackageReference Include="PublicApiGenerator" Version="6.1.0-beta2" />
-    <PackageReference Include="NServiceBus" Version="6.3.4" />
+    <PackageReference Include="NServiceBus" Version="6.3.6" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <Reference Include="System.Configuration" />
     <ProjectReference Include="..\Transport\NServiceBus.AzureServiceBus.csproj" />

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -12,9 +12,9 @@
     <NoWarn>PCR0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.0.0" />
-    <PackageReference Include="NServiceBus" Version="6.3.4" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.4" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="NServiceBus" Version="6.3.6" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.6" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <ProjectReference Include="..\Transport\NServiceBus.AzureServiceBus.csproj" />
   </ItemGroup>

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.0.0" />
-    <PackageReference Include="NServiceBus" Version="6.3.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.1" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NServiceBus" Version="6.3.4" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.4" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
     <ProjectReference Include="..\Transport\NServiceBus.AzureServiceBus.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This combination fails:
- NUnit `3.7.1`
- NSB Core `6.3.4`

Requires newer version of either NSB Core or NUnit.

Investigating why tests are failing with Core 6.3.3 and later.