### PR TITLE
Strategies use readonly settings in ctor only and are optimized for fewer allocs

### DIFF
--- a/src/Tests/Addressing/Individualization/When_using_discriminator_individualization_strategy.cs
+++ b/src/Tests/Addressing/Individualization/When_using_discriminator_individualization_strategy.cs
@@ -28,14 +28,11 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Individualiz
         [Test]
         public void Discriminator_individualization_will_blow_up_if_no_discriminator_generator_is_registered()
         {
-            const string endpointname = "myendpoint";
-
             var settingsHolder = new SettingsHolder();
             var config = new AzureServiceBusIndividualizationSettings(settingsHolder);
             config.UseStrategy<DiscriminatorBasedIndividualization>();
-            var strategy = new DiscriminatorBasedIndividualization(settingsHolder);
 
-            Assert.Throws<Exception>(() => strategy.Individualize(endpointname));
+            Assert.Throws<Exception>(() => new DiscriminatorBasedIndividualization(settingsHolder));
         }
     }
 }

--- a/src/Tests/NServiceBus.Azure.Transports.WindowsAzureServiceBus.approved.cs
+++ b/src/Tests/NServiceBus.Azure.Transports.WindowsAzureServiceBus.approved.cs
@@ -261,7 +261,6 @@ namespace NServiceBus
     public class FailOverNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
         public NServiceBus.Transport.AzureServiceBus.FailOverMode Mode { get; set; }
-        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.FailOverNamespacePartitioning.<GetNamespaces>d__5))]
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class FlatComposition : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
@@ -276,7 +275,7 @@ namespace NServiceBus
     }
     public class HierarchyComposition : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
     {
-        public string GetEntityPath(string entityname, NServiceBus.EntityType entityType) { }
+        public string GetEntityPath(string entityName, NServiceBus.EntityType entityType) { }
     }
     public class RoundRobinNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
@@ -285,7 +284,6 @@ namespace NServiceBus
     }
     public class SingleNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
-        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.SingleNamespacePartitioning.<GetNamespaces>d__1))]
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class SizeInMegabytes
@@ -543,6 +541,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     }
     public class ValidationResult
     {
+        public static NServiceBus.Transport.AzureServiceBus.ValidationResult Empty;
         public ValidationResult() { }
         public bool CharactersAreValid { get; }
         public string CharactersError { get; set; }

--- a/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
+++ b/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
@@ -8,28 +8,24 @@ namespace NServiceBus
     {
         internal HierarchyComposition(ReadOnlySettings settings)
         {
-            this.settings = settings;
+            pathGenerator = settings.Get<Func<string, string>>(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator);
         }
 
-        public string GetEntityPath(string entityname, EntityType entityType)
+        public string GetEntityPath(string entityName, EntityType entityType)
         {
-            var pathGenerator = settings.Get<Func<string, string>>(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator);
-
             switch (entityType)
             {
                 case EntityType.Queue:
                 case EntityType.Topic:
-                    return pathGenerator(entityname) + entityname;
-
+                    return pathGenerator(entityName) + entityName;
                 case EntityType.Subscription:
                 case EntityType.Rule:
-                    return entityname;
-
+                    return entityName;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null);
             }
         }
 
-        ReadOnlySettings settings;
+        Func<string, string> pathGenerator;
     }
 }

--- a/src/Transport/Addressing/Individualization/Strategies/DiscriminatorBasedIndividualization.cs
+++ b/src/Transport/Addressing/Individualization/Strategies/DiscriminatorBasedIndividualization.cs
@@ -8,19 +8,16 @@ namespace NServiceBus
     {
         internal DiscriminatorBasedIndividualization(ReadOnlySettings settings)
         {
-            this.settings = settings;
-        }
-
-        public string Individualize(string endpointName)
-        {
-            Func<string, string> discriminatorGenerator;
             var found = settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Individualization.DiscriminatorBasedIndividualizationDiscriminatorGenerator, out discriminatorGenerator);
             if (found == false)
             {
                 var strategyName = typeof(DiscriminatorBasedIndividualization).Name;
                 throw new Exception($"{strategyName} required discrimination generator to be registered. Use `.UseStrategy<{strategyName}>().DiscriminatorGenerator()` configuration API to register discrimination generator.");
             }
+        }
 
+        public string Individualize(string endpointName)
+        {
             var discriminator = discriminatorGenerator(endpointName);
 
             if (endpointName.EndsWith(discriminator))
@@ -31,6 +28,6 @@ namespace NServiceBus
             return endpointName + discriminator;
         }
 
-        ReadOnlySettings settings;
+        Func<string, string> discriminatorGenerator;
     }
 }

--- a/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
@@ -10,7 +10,7 @@
     {
         internal FailOverNamespacePartitioning(ReadOnlySettings settings)
         {
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out NamespaceConfigurations namespaces))
             {
                 throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces to be configured, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register the namespaces.");
             }
@@ -25,19 +25,24 @@
             {
                 throw new ConfigurationErrorsException($"The '{nameof(FailOverNamespacePartitioning)}' strategy requires exactly two namespaces for the purpose of partitioning, found {namespaces.Count}, please register less namespaces.");
             }
+
+            var primary = namespaces.First();
+            var secondary = namespaces.Last();
+
+            runtimeNamespaces = new[]
+            {
+                new RuntimeNamespaceInfo(primary.Alias, primary.Connection, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive),
+                new RuntimeNamespaceInfo(secondary.Alias, secondary.Connection, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive)
+            };
         }
 
         public FailOverMode Mode { get; set; }
 
         public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
         {
-            var primary = namespaces.First();
-            var secondary = namespaces.Last();
-
-            yield return new RuntimeNamespaceInfo(primary.Alias, primary.Connection, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive);
-            yield return new RuntimeNamespaceInfo(secondary.Alias, secondary.Connection, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive);
+            return runtimeNamespaces;
         }
 
-        NamespaceConfigurations namespaces;
+        RuntimeNamespaceInfo[] runtimeNamespaces;
     }
 }

--- a/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
     {
         internal SingleNamespacePartitioning(ReadOnlySettings settings)
         {
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out NamespaceConfigurations namespaces))
             {
                 throw new ConfigurationErrorsException($"The '{nameof(SingleNamespacePartitioning)}' strategy requires exactly one namespace, please configure the connection string to your azure servicebus namespace.");
             }
@@ -21,14 +21,19 @@ namespace NServiceBus
             {
                 throw new ConfigurationErrorsException($"The '{nameof(SingleNamespacePartitioning)}' strategy requires exactly one namespace for the purpose of partitioning, found {namespaces.Count}. Please remove additional namespace registrations.");
             }
+
+            var @namespace = namespaces.First();
+            runtimeNamespaces = new[]
+            {
+                new RuntimeNamespaceInfo(@namespace.Alias, @namespace.Connection, @namespace.Purpose, NamespaceMode.Active)
+            };
         }
 
         public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
         {
-            var @namespace = namespaces.First();
-            yield return new RuntimeNamespaceInfo(@namespace.Alias, @namespace.Connection, @namespace.Purpose, NamespaceMode.Active);
+            return runtimeNamespaces;
         }
 
-        NamespaceConfigurations namespaces;
+        RuntimeNamespaceInfo[] runtimeNamespaces;
     }
 }

--- a/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailedValidation.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/ThrowOnFailedValidation.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
                     if (!ValidateAndHashIfNeeded.queueAndTopicPathValidationRegex.IsMatch(queuePath))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Queue path {queuePath} contains illegal characters. Legal characters should match the following regex: `{queuePath}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Queue path {queuePath} contains illegal characters. Legal characters should match the following regex: `{ValidateAndHashIfNeeded.queueAndTopicPathValidationRegex}`.");
                     }
 
                     if (queuePath.Length > maximumQueuePathLength)
@@ -41,7 +41,7 @@ namespace NServiceBus
                     if (!ValidateAndHashIfNeeded.queueAndTopicPathValidationRegex.IsMatch(topicPath))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Topic path {topicPath} contains illegal characters. Legal characters should match the following regex: `{topicPath}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Topic path {topicPath} contains illegal characters. Legal characters should match the following regex: `{ValidateAndHashIfNeeded.queueAndTopicPathValidationRegex}`.");
                     }
 
 
@@ -65,7 +65,7 @@ namespace NServiceBus
                     if (!ValidateAndHashIfNeeded.subscriptionAndRuleNameValidationRegex.IsMatch(subscriptionName))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Subscription name {subscriptionName} contains illegal characters. Legal characters should match the following regex: `{subscriptionName}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Subscription name {subscriptionName} contains illegal characters. Legal characters should match the following regex: `{ValidateAndHashIfNeeded.subscriptionAndRuleNameValidationRegex}`.");
                     }
 
 
@@ -89,7 +89,7 @@ namespace NServiceBus
                     if (!ValidateAndHashIfNeeded.subscriptionAndRuleNameValidationRegex.IsMatch(ruleName))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Rule name {ruleName} contains illegal characters. Legal characters should match the following regex: `{ruleName}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Rule name {ruleName} contains illegal characters. Legal characters should match the following regex: `{ValidateAndHashIfNeeded.subscriptionAndRuleNameValidationRegex}`.");
                     }
 
                     if (ruleName.Length > ruleNameMaximumLength)

--- a/src/Transport/Addressing/Sanitization/Strategies/ValidateAndHashIfNeeded.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/ValidateAndHashIfNeeded.cs
@@ -9,91 +9,120 @@
     {
         internal ValidateAndHashIfNeeded(ReadOnlySettings settings)
         {
-            this.settings = settings;
-
-            // validators
-
-            defaultQueuePathValidation = queuePath =>
+            var maximumQueuePathLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathMaximumLength);
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathValidator, out queuePathValidation))
             {
-                var validationResult = new ValidationResult();
-
-                if (!queueAndTopicPathValidationRegex.IsMatch(queuePath))
+                queuePathValidation = queuePath =>
                 {
-                    validationResult.AddErrorForInvalidCharacters($"Queue path {queuePath} contains illegal characters. Legal characters should match the following regex: `{queuePath}`.");
-                }
+                    ValidationResult validationResult = null;
 
-                var maximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathMaximumLength);
-                if (queuePath.Length > maximumLength)
-                {
-                    validationResult.AddErrorForInvalidLenth($"Queue path `{queuePath}` exceeds maximum length of {maximumLength} characters.");
-                }
+                    if (!queueAndTopicPathValidationRegex.IsMatch(queuePath))
+                    {
+                        validationResult = new ValidationResult();
+                        validationResult.AddErrorForInvalidCharacters($"Queue path {queuePath} contains illegal characters. Legal characters should match the following regex: `{queuePath}`.");
+                    }
 
-                return validationResult;
-            };
+                    if (queuePath.Length > maximumQueuePathLength)
+                    {
+                        validationResult = validationResult ?? new ValidationResult();
+                        validationResult.AddErrorForInvalidLenth($"Queue path `{queuePath}` exceeds maximum length of {maximumQueuePathLength} characters.");
+                    }
 
-            defaultTopicPathValidation = topicPath =>
+                    return validationResult ?? ValidationResult.Empty;
+                };
+            }
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathSanitizer, out queuePathSanitization))
             {
-                var validationResult = new ValidationResult();
+                queuePathSanitization = queuePath => queueAndTopicPathSanitizationRegex.Replace(queuePath, string.Empty);
+            }
 
-                if (!queueAndTopicPathValidationRegex.IsMatch(topicPath))
-                {
-                    validationResult.AddErrorForInvalidCharacters($"Topic path {topicPath} contains illegal characters. Legal characters should match the following regex: `{topicPath}`.");
-                }
-
-                var maximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathMaximumLength);
-                if (topicPath.Length > maximumLength)
-                {
-                    validationResult.AddErrorForInvalidLenth($"Topic path `{topicPath}` exceeds maximum length of {maximumLength} characters.");
-                }
-
-                return validationResult;
-            };
-
-            defaultSubscriptionNameValidation = subscriptionName =>
+            var topicPathMaximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathMaximumLength);
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathValidator, out topicPathValidation))
             {
-                var validationResult = new ValidationResult();
-
-                if (!subscriptionAndRuleNameValidationRegex.IsMatch(subscriptionName))
+                topicPathValidation = topicPath =>
                 {
-                    validationResult.AddErrorForInvalidCharacters($"Subscription name {subscriptionName} contains illegal characters. Legal characters should match the following regex: `{subscriptionName}`.");
-                }
+                    ValidationResult validationResult = null;
 
-                var maximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameMaximumLength);
-                if (subscriptionName.Length > maximumLength)
-                {
-                    validationResult.AddErrorForInvalidLenth($"Subscription name `{subscriptionName}` exceeds maximum length of {maximumLength} characters.");
-                }
+                    if (!queueAndTopicPathValidationRegex.IsMatch(topicPath))
+                    {
+                        validationResult = new ValidationResult();
+                        validationResult.AddErrorForInvalidCharacters($"Topic path {topicPath} contains illegal characters. Legal characters should match the following regex: `{topicPath}`.");
+                    }
 
-                return validationResult;
-            };
 
-            defaultRuleNameValidation = ruleName =>
+                    if (topicPath.Length > topicPathMaximumLength)
+                    {
+                        validationResult = validationResult ?? new ValidationResult();
+                        validationResult.AddErrorForInvalidLenth($"Topic path `{topicPath}` exceeds maximum length of {topicPathMaximumLength} characters.");
+                    }
+
+                    return validationResult ?? ValidationResult.Empty;
+                };
+            }
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathSanitizer, out topicPathSanitization))
             {
-                var validationResult = new ValidationResult();
+                topicPathSanitization = topicPath => queueAndTopicPathSanitizationRegex.Replace(topicPath, string.Empty);
+            }
 
-                if (!subscriptionAndRuleNameValidationRegex.IsMatch(ruleName))
+            var subscriptionNameMaximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameMaximumLength);
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameValidator, out subscriptionNameValidation))
+            {
+                subscriptionNameValidation = subscriptionName =>
                 {
-                    validationResult.AddErrorForInvalidCharacters($"Rule name {ruleName} contains illegal characters. Legal characters should match the following regex: `{ruleName}`.");
-                }
+                    ValidationResult validationResult = null;
 
-                var maximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameMaximumLength);
-                if (ruleName.Length > maximumLength)
+                    if (!subscriptionAndRuleNameValidationRegex.IsMatch(subscriptionName))
+                    {
+                        validationResult = new ValidationResult();
+                        validationResult.AddErrorForInvalidCharacters($"Subscription name {subscriptionName} contains illegal characters. Legal characters should match the following regex: `{subscriptionName}`.");
+                    }
+
+
+                    if (subscriptionName.Length > subscriptionNameMaximumLength)
+                    {
+                        validationResult = validationResult ?? new ValidationResult();
+                        validationResult.AddErrorForInvalidLenth($"Subscription name `{subscriptionName}` exceeds maximum length of {subscriptionNameMaximumLength} characters.");
+                    }
+
+                    return validationResult ?? ValidationResult.Empty;
+                };
+            }
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameSanitizer, out subscriptionNameSanitization))
+            {
+                subscriptionNameSanitization = subscriptionPath => subscriptionAndRuleNameSanitizationRegex.Replace(subscriptionPath, string.Empty);
+            }
+
+            var ruleNameMaximumLength = settings.GetOrDefault<int>(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameMaximumLength);
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameValidator, out ruleNameValidation))
+            {
+                ruleNameValidation = ruleName =>
                 {
-                    validationResult.AddErrorForInvalidLenth($"Rule name `{ruleName}` exceeds maximum length of {maximumLength} characters.");
-                }
+                    ValidationResult validationResult = null;
 
-                return validationResult;
-            };
+                    if (!subscriptionAndRuleNameValidationRegex.IsMatch(ruleName))
+                    {
+                        validationResult = new ValidationResult();
+                        validationResult.AddErrorForInvalidCharacters($"Rule name {ruleName} contains illegal characters. Legal characters should match the following regex: `{ruleName}`.");
+                    }
 
-            // sanitizers
+                    if (ruleName.Length > ruleNameMaximumLength)
+                    {
+                        validationResult = validationResult ?? new ValidationResult();
+                        validationResult.AddErrorForInvalidLenth($"Rule name `{ruleName}` exceeds maximum length of {ruleNameMaximumLength} characters.");
+                    }
 
-            defaultQueuePathSanitization = queuePath => queueAndTopicPathSanitizationRegex.Replace(queuePath, string.Empty);
-            defaultTopicPathSanitization = topicPath => queueAndTopicPathSanitizationRegex.Replace(topicPath, string.Empty);
-            defaultSubscriptionNameSanitization = subscriptionPath => subscriptionAndRuleNameSanitizationRegex.Replace(subscriptionPath, string.Empty);
-            defaultRuleNameSanitization = rulePath => subscriptionAndRuleNameSanitizationRegex.Replace(rulePath, string.Empty);
+                    return validationResult ?? ValidationResult.Empty;
+                };
+            }
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameSanitizer, out ruleNameSanitization))
+            {
+                ruleNameSanitization = rulePath => subscriptionAndRuleNameSanitizationRegex.Replace(rulePath, string.Empty);
+            }
 
-            // hash
-            defaultHashing = entityPathOrName => MD5DeterministicNameBuilder.Build(entityPathOrName);
+            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.Hash, out hashing))
+            {
+                hashing = entityPathOrName => MD5DeterministicNameBuilder.Build(entityPathOrName);
+            }
         }
 
         public string Sanitize(string entityPathOrName, EntityType entityType)
@@ -105,48 +134,21 @@
             switch (entityType)
             {
                 case EntityType.Queue:
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathValidator, out validator))
-                    {
-                        validator = defaultQueuePathValidation;
-                    }
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathSanitizer, out sanitizer))
-                    {
-                        sanitizer = defaultQueuePathSanitization;
-                    }
+                    validator = queuePathValidation;
+                    sanitizer = queuePathSanitization;
                     break;
                 case EntityType.Topic:
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathValidator, out validator))
-                    {
-                        validator = defaultTopicPathValidation;
-                    }
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathSanitizer, out sanitizer))
-                    {
-                        sanitizer = defaultTopicPathSanitization;
-                    }
+                    validator = topicPathValidation;
+                    sanitizer = topicPathSanitization;
                     break;
-
                 case EntityType.Subscription:
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameValidator, out validator))
-                    {
-                        validator = defaultSubscriptionNameValidation;
-                    }
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameSanitizer, out sanitizer))
-                    {
-                        sanitizer = defaultSubscriptionNameSanitization;
-                    }
+                    validator = subscriptionNameValidation;
+                    sanitizer = subscriptionNameSanitization;
                     break;
-
                 case EntityType.Rule:
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameValidator, out validator))
-                    {
-                        validator = defaultRuleNameValidation;
-                    }
-                    if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameSanitizer, out sanitizer))
-                    {
-                        sanitizer = defaultRuleNameSanitization;
-                    }
+                    validator = ruleNameValidation;
+                    sanitizer = ruleNameSanitization;
                     break;
-
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null);
             }
@@ -170,38 +172,30 @@
                 return sanitizedValue;
             }
 
-            Func<string, string> hash;
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.Hash, out hash))
-            {
-                hash = defaultHashing;
-            }
-
-            return hash(sanitizedValue);
+            return hashing(sanitizedValue);
         }
 
-        readonly ReadOnlySettings settings;
+        Func<string, ValidationResult> queuePathValidation;
+        Func<string, ValidationResult> topicPathValidation;
+        Func<string, ValidationResult> subscriptionNameValidation;
+        Func<string, ValidationResult> ruleNameValidation;
+
+        Func<string, string> queuePathSanitization;
+        Func<string, string> topicPathSanitization;
+        Func<string, string> subscriptionNameSanitization;
+        Func<string, string> ruleNameSanitization;
+
+        Func<string, string> hashing;
 
         // Entity segments can contain only letters, numbers, periods (.), hyphens (-), and underscores (-), paths can contain slashes (/)
-        Regex queueAndTopicPathValidationRegex = new Regex(@"^[^\/][0-9A-Za-z_\.\-\/]+[^\/]$");
+        internal static Regex queueAndTopicPathValidationRegex = new Regex(@"^[^\/][0-9A-Za-z_\.\-\/]+[^\/]$", RegexOptions.Compiled);
 
         // Except for subscriptions and rules, these cannot contain slashes (/)
-        Regex subscriptionAndRuleNameValidationRegex = new Regex(@"^[0-9A-Za-z_\.\-]+$");
+        internal static Regex subscriptionAndRuleNameValidationRegex = new Regex(@"^[0-9A-Za-z_\.\-]+$", RegexOptions.Compiled);
 
         // Sanitize anything that is [NOT letters, numbers, periods (.), hyphens (-), underscores (-)], and leading or trailing slashes (/)
-        Regex queueAndTopicPathSanitizationRegex = new Regex(@"[^a-zA-Z0-9\-\._/]|^/*|/*$");
+        static Regex queueAndTopicPathSanitizationRegex = new Regex(@"[^a-zA-Z0-9\-\._/]|^/*|/*$", RegexOptions.Compiled);
 
-        Regex subscriptionAndRuleNameSanitizationRegex = new Regex(@"[^a-zA-Z0-9\-\._]");
-
-        Func<string, ValidationResult> defaultQueuePathValidation;
-        Func<string, ValidationResult> defaultTopicPathValidation;
-        Func<string, ValidationResult> defaultSubscriptionNameValidation;
-        Func<string, ValidationResult> defaultRuleNameValidation;
-
-        Func<string, string> defaultQueuePathSanitization;
-        Func<string, string> defaultTopicPathSanitization;
-        Func<string, string> defaultSubscriptionNameSanitization;
-        Func<string, string> defaultRuleNameSanitization;
-
-        Func<string, string> defaultHashing;
+        static Regex subscriptionAndRuleNameSanitizationRegex = new Regex(@"[^a-zA-Z0-9\-\._]", RegexOptions.Compiled);
     }
 }

--- a/src/Transport/Addressing/Sanitization/Strategies/ValidateAndHashIfNeeded.cs
+++ b/src/Transport/Addressing/Sanitization/Strategies/ValidateAndHashIfNeeded.cs
@@ -19,7 +19,7 @@
                     if (!queueAndTopicPathValidationRegex.IsMatch(queuePath))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Queue path {queuePath} contains illegal characters. Legal characters should match the following regex: `{queuePath}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Queue path {queuePath} contains illegal characters. Legal characters should match the following regex: `{queueAndTopicPathValidationRegex}`.");
                     }
 
                     if (queuePath.Length > maximumQueuePathLength)
@@ -46,7 +46,7 @@
                     if (!queueAndTopicPathValidationRegex.IsMatch(topicPath))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Topic path {topicPath} contains illegal characters. Legal characters should match the following regex: `{topicPath}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Topic path {topicPath} contains illegal characters. Legal characters should match the following regex: `{queueAndTopicPathValidationRegex}`.");
                     }
 
 
@@ -74,7 +74,7 @@
                     if (!subscriptionAndRuleNameValidationRegex.IsMatch(subscriptionName))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Subscription name {subscriptionName} contains illegal characters. Legal characters should match the following regex: `{subscriptionName}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Subscription name {subscriptionName} contains illegal characters. Legal characters should match the following regex: `{subscriptionAndRuleNameValidationRegex}`.");
                     }
 
 
@@ -102,7 +102,7 @@
                     if (!subscriptionAndRuleNameValidationRegex.IsMatch(ruleName))
                     {
                         validationResult = new ValidationResult();
-                        validationResult.AddErrorForInvalidCharacters($"Rule name {ruleName} contains illegal characters. Legal characters should match the following regex: `{ruleName}`.");
+                        validationResult.AddErrorForInvalidCharacters($"Rule name {ruleName} contains illegal characters. Legal characters should match the following regex: `{subscriptionAndRuleNameValidationRegex}`.");
                     }
 
                     if (ruleName.Length > ruleNameMaximumLength)

--- a/src/Transport/Addressing/Sanitization/ValidationResult.cs
+++ b/src/Transport/Addressing/Sanitization/ValidationResult.cs
@@ -23,5 +23,7 @@
             LengthError = error;
             LengthIsValid = false;
         }
+
+        public static ValidationResult Empty = new ValidationResult();
     }
 }


### PR DESCRIPTION
Replaces #601 

Ports all the optimizations over but still relies on ctor injection in the strategies. Gives the benefit of no longer relying on settings during runtime but is not invasive. So no doco changes are required.