### PR TITLE
Remove readonly settings from topology related code

### DIFF
--- a/src/Tests/PreStartupChecks/When_execute_manage_rights_startup_check.cs
+++ b/src/Tests/PreStartupChecks/When_execute_manage_rights_startup_check.cs
@@ -5,7 +5,6 @@
     using FakeItEasy;
     using Tests;
     using Transport.AzureServiceBus;
-    using Settings;
     using NUnit.Framework;
 
 #pragma warning disable 618
@@ -16,21 +15,18 @@
         [Test]
         public async Task Should_return_no_namespaces_when_all_namespaces_have_manage_rights()
         {
-            var settings = new SettingsHolder();
-
-            var namespaces = new NamespaceConfigurations
+            var namespaceConfigurations = new NamespaceConfigurations
             {
                 {"name1", ConnectionStringValue.Build("namespace1"), NamespacePurpose.Partitioning},
                 {"name2", ConnectionStringValue.Build("namespace2"), NamespacePurpose.Partitioning}
             };
-            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaces);
 
             var namespaceManager = A.Fake<INamespaceManagerInternal>();
             A.CallTo(() => namespaceManager.CanManageEntities()).Returns(Task.FromResult(true));
             var manageNamespaceLifeCycle = A.Fake<IManageNamespaceManagerLifeCycleInternal>();
             A.CallTo(() => manageNamespaceLifeCycle.Get(A<string>.Ignored)).Returns(namespaceManager);
 
-            var result = await ManageRightsCheck.Run(manageNamespaceLifeCycle, settings);
+            var result = await ManageRightsCheck.Run(manageNamespaceLifeCycle, namespaceConfigurations);
 
             CollectionAssert.IsEmpty(result);
         }
@@ -38,14 +34,11 @@
         [Test]
         public async Task Should_namespaces_that_dont_have_manage_rights()
         {
-            var settings = new SettingsHolder();
-
-            var namespaces = new NamespaceConfigurations
+            var namespaceConfigurations = new NamespaceConfigurations
             {
                 {"name1", ConnectionStringValue.Build("namespace1"), NamespacePurpose.Partitioning},
                 {"name2", ConnectionStringValue.Build("namespace2"), NamespacePurpose.Partitioning}
             };
-            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaces);
 
             var trueNamespaceManager = A.Fake<INamespaceManagerInternal>();
             A.CallTo(() => trueNamespaceManager.CanManageEntities()).Returns(Task.FromResult(true));
@@ -55,7 +48,7 @@
             A.CallTo(() => manageNamespaceLifeCycle.Get("name1")).Returns(trueNamespaceManager);
             A.CallTo(() => manageNamespaceLifeCycle.Get("name2")).Returns(falseNamespaceManager);
 
-            var result = await ManageRightsCheck.Run(manageNamespaceLifeCycle, settings);
+            var result = await ManageRightsCheck.Run(manageNamespaceLifeCycle, namespaceConfigurations);
 
             CollectionAssert.Contains(result, "name2");
             CollectionAssert.DoesNotContain(result, "name1");

--- a/src/Transport/Receiving/MessageReceiverNotifierSettings.cs
+++ b/src/Transport/Receiving/MessageReceiverNotifierSettings.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.Transport.AzureServiceBus
+{
+    using System;
+    using Microsoft.ServiceBus.Messaging;
+
+    class MessageReceiverNotifierSettings
+    {
+        public MessageReceiverNotifierSettings(ReceiveMode receiveMode, TransportTransactionMode transportTransactionMode, TimeSpan autoRenewTimeout, int numberOfClients)
+        {
+            ReceiveMode = receiveMode;
+            TransportTransactionMode = transportTransactionMode;
+            AutoRenewTimeout = autoRenewTimeout;
+            NumberOfClients = numberOfClients;
+        }
+
+        public ReceiveMode ReceiveMode { get; }
+        public TransportTransactionMode TransportTransactionMode { get; }
+        public TimeSpan AutoRenewTimeout { get; }
+        public int NumberOfClients { get; }
+    }
+}

--- a/src/Transport/Topology/MetaModel/DefaultConnectionStringToNamespaceAliasMapper.cs
+++ b/src/Transport/Topology/MetaModel/DefaultConnectionStringToNamespaceAliasMapper.cs
@@ -9,7 +9,7 @@
     {
         public DefaultConnectionStringToNamespaceAliasMapper(ReadOnlySettings settings)
         {
-            this.settings = settings;
+            namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
         }
 
         public virtual EntityAddress Map(EntityAddress value)
@@ -19,8 +19,6 @@
                 return value;
             }
 
-            var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-
             var namespaceInfo = namespaces.SingleOrDefault(x => x.Connection == value.Suffix);
             if (namespaceInfo != null)
             {
@@ -28,12 +26,12 @@
             }
 
             var namespaceName = new ConnectionStringInternal(value.Suffix).NamespaceName;
-            Logger.Warn($"Connection string for for namespace name '{namespaceName}' hasn't been configured. {Environment.NewLine}, replying may not work properly" +
+            logger.Warn($"Connection string for for namespace name '{namespaceName}' hasn't been configured. {Environment.NewLine}, replying may not work properly" +
                         "Use `AddNamespace` configuration API to map connection string to namespace alias.");
             return value;
         }
 
-        ReadOnlySettings settings;
-        static ILog Logger = LogManager.GetLogger<DefaultConnectionStringToNamespaceAliasMapper>();
+        static ILog logger = LogManager.GetLogger<DefaultConnectionStringToNamespaceAliasMapper>();
+        NamespaceConfigurations namespaces;
     }
 }

--- a/src/Transport/Topology/MetaModel/ManageRightsCheck.cs
+++ b/src/Transport/Topology/MetaModel/ManageRightsCheck.cs
@@ -2,17 +2,15 @@ namespace NServiceBus.AzureServiceBus.Topology.MetaModel
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Settings;
     using Transport.AzureServiceBus;
 
     static class ManageRightsCheck
     {
-        public static async Task<List<string>> Run(IManageNamespaceManagerLifeCycleInternal manageNamespaceManagerLifeCycle, ReadOnlySettings settings)
+        public static async Task<List<string>> Run(IManageNamespaceManagerLifeCycleInternal manageNamespaceManagerLifeCycle, NamespaceConfigurations namespaceConfigurations)
         {
             var namespacesWithoutManageRights = new List<string>();
 
-            var namespaces = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
-            foreach (var @namespace in namespaces)
+            foreach (var @namespace in namespaceConfigurations)
             {
                 var namespaceManager = manageNamespaceManagerLifeCycle.Get(@namespace.Alias);
                 var canManageEntities = await namespaceManager.CanManageEntities().ConfigureAwait(false);

--- a/src/Transport/Topology/TopologyCreator.cs
+++ b/src/Transport/Topology/TopologyCreator.cs
@@ -19,10 +19,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             this.queuesCreator = queuesCreator;
             this.subscriptionsCreator = subscriptionsCreator;
             this.namespaces = namespaces;
+            var namespaceConfigurations = settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
 
             hasManageRights = new AsyncLazy<bool>(async () =>
             {
-                var namespacesWithoutManageRights = await ManageRightsCheck.Run(namespaces, settings)
+                var namespacesWithoutManageRights = await ManageRightsCheck.Run(namespaces, namespaceConfigurations)
                     .ConfigureAwait(false);
                 namespacesWithoutManageRightsJoined = string.Join(", ", namespacesWithoutManageRights.Select(alias => $"`{alias}`"));
                 return namespacesWithoutManageRights.Count == 0;
@@ -33,7 +34,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             if (!await hasManageRights.Value.ConfigureAwait(false))
             {
-                Logger.Info($"Configured to create topology, but have no manage rights for the following namespace(s): {namespacesWithoutManageRightsJoined}. Execution will continue and assume the topology is already created.");
+                logger.Info($"Configured to create topology, but have no manage rights for the following namespace(s): {namespacesWithoutManageRightsJoined}. Execution will continue and assume the topology is already created.");
                 return;
             }
 
@@ -107,6 +108,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         AzureServiceBusTopicCreator topicsCreator;
         AsyncLazy<bool> hasManageRights;
         string namespacesWithoutManageRightsJoined;
-        static ILog Logger = LogManager.GetLogger<TopologyCreator>();
+        static ILog logger = LogManager.GetLogger<TopologyCreator>();
     }
 }


### PR DESCRIPTION
Connects to #282 

- No longer relying on `ReadOnlySettings` during runtime for topology related code.
- Modified `MessageReceiveNotifier` not to need `ReadOnlySettings` (replaced with `MessageReceiveNotifierSettings`).