### PR TITLE
MessageReceiverNotifier non-blocking start

### DIFF
--- a/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
+++ b/src/Tests/Receiving/When_comparing_performance_for_prefetch.cs
@@ -86,7 +86,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                         completed.Set();
                     }
                     return TaskEx.Completed;
-                }, null, null, 32);
+                }, null, null, null, 32);
 
 
             var sw = new Stopwatch();

--- a/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
+++ b/src/Tests/Receiving/When_incoming_message_processing_takes_longer_than_LockDuration.cs
@@ -79,7 +79,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                         await Task.Delay(TimeSpan.FromSeconds(5), cts.Token);
                         completed.Set();
                     }
-                }, null, null, 1);
+                }, null, null, null, 1);
 
 
             var sw = new Stopwatch();

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -146,9 +146,12 @@
                 onError = func;
             }
 
+            public void OnCritical(Action<Exception> action)
+            {
+            }
+
             public void OnProcessingFailure(Func<ErrorContext, Task<ErrorHandleResult>> func)
             {
-
             }
 
             public Func<Exception, Task> onError;

--- a/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
+++ b/src/Tests/Sending/When_comparing_performance_between_built_in_batching_and_manual.cs
@@ -56,7 +56,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
             {
                 for (var i = 0; i < 1000; i++)
                 {
-                    var sender = entityLifecycleManager.Get("myqueue", null, "namespace");
+                    var sender = await entityLifecycleManager.Get("myqueue", null, "namespace");
                     tasks.Add(sender.RetryOnThrottleAsync(s => s.Send(new BrokeredMessage()), s => s.Send(new BrokeredMessage()), TimeSpan.FromSeconds(10), 5));
 
                     counter++;
@@ -123,7 +123,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Sending
                     batch.Add(new BrokeredMessage());
                     counter++;
                 }
-                var sender = entityLifecycleManager.Get("myqueue", null, "namespace");
+                var sender = await entityLifecycleManager.Get("myqueue", null, "namespace");
                 tasks.Add(sender.RetryOnThrottleAsync(s => s.SendBatch(batch), s => s.SendBatch(batch.Select(x => x.Clone())), TimeSpan.FromSeconds(10), 5));
             }
             await Task.WhenAll(tasks);

--- a/src/Transport/Connectivity/MessageReceiverLifeCycleManager.cs
+++ b/src/Transport/Connectivity/MessageReceiverLifeCycleManager.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Settings;
 
     class MessageReceiverLifeCycleManager
@@ -11,43 +13,55 @@ namespace NServiceBus.Transport.AzureServiceBus
             numberOfReceiversPerEntity = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.NumberOfClientsPerEntity);
         }
 
-        public IMessageReceiverInternal Get(string entityPath, string namespaceAlias)
+        public async Task<IMessageReceiverInternal> Get(string entityPath, string namespaceAlias)
         {
-            var buffer = MessageReceivers.GetOrAdd(entityPath + namespaceAlias, s =>
+            var buffer = await MessageReceivers.GetOrAdd(entityPath + namespaceAlias, async s =>
             {
                 var b = new CircularBuffer<EntityClientEntry>(numberOfReceiversPerEntity);
                 for (var i = 0; i < numberOfReceiversPerEntity; i++)
                 {
-                    var e = new EntityClientEntry();
-                    e.ClientEntity = receiveFactory.Create(entityPath, namespaceAlias).GetAwaiter().GetResult();
+                    var e = new EntityClientEntry
+                    {
+                        ClientEntity = await receiveFactory.Create(entityPath, namespaceAlias)
+                            .ConfigureAwait(false)
+                    };
                     b.Put(e);
                 }
                 return b;
-            });
+            }).ConfigureAwait(false);
 
             var entry = buffer.Get();
 
-            if (entry.ClientEntity.IsClosed)
+            if (!entry.ClientEntity.IsClosed)
             {
-                lock (entry.Mutex)
-                {
-                    if (entry.ClientEntity.IsClosed)
-                    {
-                        entry.ClientEntity = receiveFactory.Create(entityPath, namespaceAlias).GetAwaiter().GetResult();
-                    }
-                }
+                return entry.ClientEntity;
             }
-
-            return entry.ClientEntity;
+            
+            try
+            {
+                await entry.Semaphore.WaitAsync()
+                    .ConfigureAwait(false);
+                
+                if (entry.ClientEntity.IsClosed)
+                {
+                    entry.ClientEntity = await receiveFactory.Create(entityPath, namespaceAlias)
+                        .ConfigureAwait(false);
+                }
+                return entry.ClientEntity;
+            }
+            finally
+            {
+                entry.Semaphore.Release();
+            }
         }
 
         ICreateMessageReceiversInternal receiveFactory;
         int numberOfReceiversPerEntity;
-        ConcurrentDictionary<string, CircularBuffer<EntityClientEntry>> MessageReceivers = new ConcurrentDictionary<string, CircularBuffer<EntityClientEntry>>();
+        ConcurrentDictionary<string, Task<CircularBuffer<EntityClientEntry>>> MessageReceivers = new ConcurrentDictionary<string, Task<CircularBuffer<EntityClientEntry>>>();
 
         class EntityClientEntry
         {
-            internal object Mutex = new object();
+            internal SemaphoreSlim Semaphore = new SemaphoreSlim(1);
             internal IMessageReceiverInternal ClientEntity;
         }
     }

--- a/src/Transport/Receiving/INotifyIncomingMessages.cs
+++ b/src/Transport/Receiving/INotifyIncomingMessages.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         bool IsRunning { get; }
         int RefCount { get; set; }
 
-        void Initialize(EntityInfoInternal entity, Func<IncomingMessageDetailsInternal, ReceiveContextInternal, Task> callback, Func<Exception, Task> errorCallback, Func<ErrorContext, Task<ErrorHandleResult>> processingFailureCallback, int maximumConcurrency);
+        void Initialize(EntityInfoInternal entity, Func<IncomingMessageDetailsInternal, ReceiveContextInternal, Task> callback, Func<Exception, Task> errorCallback, Action<Exception> onCritical, Func<ErrorContext, Task<ErrorHandleResult>> processingFailureCallback, int maximumConcurrency);
 
         void Start();
         Task Stop();

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -70,6 +70,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             topologyOperator.OnError(exception => circuitBreaker.Failure(exception));
             topologyOperator.OnProcessingFailure(onError);
+            topologyOperator.OnCritical(exception => criticalError.Raise("Failed to receive message from Azure Service Bus.", exception));
 
             return TaskEx.Completed;
         }

--- a/src/Transport/Topology/IOperateTopology.cs
+++ b/src/Transport/Topology/IOperateTopology.cs
@@ -29,6 +29,7 @@
         void OnIncomingMessage(Func<IncomingMessageDetailsInternal, ReceiveContextInternal, Task> func);
 
         void OnError(Func<Exception, Task> func);
+        void OnCritical(Action<Exception> action);
 
         void OnProcessingFailure(Func<ErrorContext, Task<ErrorHandleResult>> onError);
     }

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -76,6 +76,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             onError = func;
         }
 
+        public void OnCritical(Action<Exception> action)
+        {
+            onCriticalError = action;
+        }
+
         public void OnProcessingFailure(Func<ErrorContext, Task<ErrorHandleResult>> func)
         {
             onProcessingFailure = func;
@@ -93,7 +98,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 var notifier = notifiers.GetOrAdd(entity, e =>
                 {
                     var n = CreateNotifier(entity.Type);
-                    n.Initialize(e, onMessage, onError, onProcessingFailure, maxConcurrency);
+                    n.Initialize(e, onMessage, onError, onCriticalError, onProcessingFailure, maxConcurrency);
                     return n;
                 });
 
@@ -154,5 +159,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         MessageReceiverLifeCycleManager messageReceiverLifeCycle;
         BrokeredMessagesToIncomingMessagesConverter brokeredMessageConverter;
         MessageReceiverNotifierSettings messageReceiverNotifierSettings;
+        Action<Exception> onCriticalError;
     }
 }


### PR DESCRIPTION
- MessageReceiverNotifier no longer used a blocking start
- Concurrent acquire of entities
- Asynchronous Message[Sender|Receiver]LifeCycleManager

### Manual test results

#### (NumberOfEntities): Endpoint 1 / Endpoint 2 (ms)

Before :
- (Default 5): 3542 / 3549
- (10): 2935 / 2974
- (20): 3079 / 3195
- (50): 3516 / 3212

After:
- (Default 5): 2678 / 2667
- (10): 2501 / 2384
- (20): 2512 / 2355
- (50): 2560/ 2558

### Micro Benchmarks

``` ini

BenchmarkDotNet=v0.10.1, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4980HQ CPU 2.80GHz, ProcessorCount=8
Frequency=2728072 Hz, Resolution=366.5592 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 32bit LegacyJIT-v4.7.2102.0
  DefaultJob : Clr 4.0.30319.42000, 32bit LegacyJIT-v4.7.2102.0


```
Method | IsClosed |        Mean |    StdErr |     StdDev |         Min |          Q1 |      Median |          Q3 |         Max |     Op/s |  Gen 0 | Allocated |
------------------ |--------- |------------ |---------- |----------- |------------ |------------ |------------ |------------ |------------ |--------- |------- |---------- |
 **Before_Sequential** |    **False** | **143.8103 us** | **1.3201 us** |  **4.7596 us** | **138.5223 us** | **139.9606 us** | **143.6854 us** | **146.8417 us** | **155.4937 us** |   **6953.6** | **2.0213** |  **16.89 kB** |
  After_Sequential |    False | 209.3963 us | 2.0883 us | 18.9107 us | 178.3369 us | 191.4350 us | 210.5530 us | 222.2242 us | 243.9872 us |  4775.63 | 0.8138 |     22 kB |
 Before_Concurrent |    False |  75.7541 us | 0.8089 us |  7.0052 us |  65.8006 us |  70.4486 us |  73.9723 us |  79.8793 us | 100.5178 us | 13200.61 | 1.0742 |  18.21 kB |
  After_Concurrent |    False |  74.2022 us | 0.7254 us |  2.9909 us |  71.1783 us |  71.3837 us |  72.3651 us |  77.5372 us |  77.8978 us | 13476.69 | 2.0888 |  22.24 kB |
 **Before_Sequential** |     **True** | **222.8536 us** | **0.4446 us** |  **1.6032 us** | **218.9874 us** | **222.2791 us** | **223.0299 us** | **223.8304 us** | **225.3614 us** |  **4487.25** |      **-** |  **18.19 kB** |
  After_Sequential |     True | 251.6912 us | 2.1933 us |  8.4946 us | 244.5247 us | 245.1053 us | 249.2620 us | 257.5447 us | 270.0482 us |  3973.12 |      - |  23.32 kB |
 Before_Concurrent |     True |  86.3425 us | 0.8550 us |  5.3392 us |  79.8688 us |  81.1973 us |  86.8259 us |  89.5799 us |  99.1518 us | 11581.79 | 1.3184 |  19.52 kB |
  After_Concurrent |     True |  86.7504 us | 0.3468 us |  1.2505 us |  83.8152 us |  85.9906 us |  87.0104 us |  87.8217 us |  88.2744 us | 11527.32 | 3.2290 |  23.55 kB |
