### PR TITLE
Using core LocalAddress abstraction

### DIFF
--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -84,6 +84,7 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
             endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_derived_event.SpecificEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_derived_event.Publisher)));
 
             endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_with_overridden_local_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_with_overridden_local_address.Publisher)));
+            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.PublisherAndSubscriber)));
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -28,8 +28,7 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
 
         var transportConfig = configuration.UseTransport<AzureServiceBusTransport>();
 
-        AzureServiceBusTransportConfigContext azureServiceBusTransportConfigContext;
-        if(settings.TryGet("AzureServiceBus.AcceptanceTests.TransportConfigContext", out azureServiceBusTransportConfigContext))
+        if(settings.TryGet<AzureServiceBusTransportConfigContext>("AzureServiceBus.AcceptanceTests.TransportConfigContext", out var azureServiceBusTransportConfigContext))
         {
             azureServiceBusTransportConfigContext.Callback?.Invoke(endpointName, transportConfig);
         }

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -84,7 +84,8 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
             endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_derived_event.SpecificEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_derived_event.Publisher)));
 
             endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_with_overridden_local_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_with_overridden_local_address.Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.PublisherAndSubscriber)));
+            // Both publisher and subscriber are the same endpoint with overridden endpoint name. We can't detect both from the message type.
+            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.MyEvent), "myinputqueue");
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
+++ b/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
@@ -33,8 +33,7 @@
 
         public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
-            string runId;
-            if (!context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out runId) || runId != testRunId)
+            if (!context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) || runId != testRunId)
             {
                 Console.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
                 return Task.FromResult(0);

--- a/src/AcceptanceTests/Receiving/When_receive_operation_is_aborted.cs
+++ b/src/AcceptanceTests/Receiving/When_receive_operation_is_aborted.cs
@@ -71,8 +71,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                 {
                     await next(context);
 
-                    string runId;
-                    if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out runId) && runId == testRunId)
+                    if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) && runId == testRunId)
                     {
                         context.AbortReceiveOperation();
                     }

--- a/src/AcceptanceTests/Routing/When_publishing_and_subscribing_to_self_with_overridden_address.cs
+++ b/src/AcceptanceTests/Routing/When_publishing_and_subscribing_to_self_with_overridden_address.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_publishing_and_subscribing_to_self_with_overridden_address : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_be_delivered_to_self()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<PublisherAndSubscriber>(builder => 
+                    builder.When(session => session.Publish(new MyEvent()))) 
+                .Done(c => c.GotTheEvent)
+                .Run();
+
+            Assert.True(context.GotTheEvent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEvent { get; set; }
+            public bool IsSubscribed { get; set; }
+        }
+
+        public class PublisherAndSubscriber : EndpointConfigurationBuilder
+        {
+            public PublisherAndSubscriber()
+            {
+                EndpointSetup<DefaultPublisher>(builder =>
+                {
+                    builder.OverrideLocalAddress("myinputqueue");                    
+                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(PublisherAndSubscriber)));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent messageThatIsEnlisted, IMessageHandlerContext context)
+                {
+                    Context.GotTheEvent = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/Routing/When_publishing_and_subscribing_to_self_with_overridden_address.cs
+++ b/src/AcceptanceTests/Routing/When_publishing_and_subscribing_to_self_with_overridden_address.cs
@@ -33,7 +33,7 @@
                 EndpointSetup<DefaultPublisher>(builder =>
                 {
                     builder.OverrideLocalAddress("myinputqueue");                    
-                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(PublisherAndSubscriber)));
+                });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
+++ b/src/Tests/Seam/When_dispatching_messages_in_receive_context.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
                 namespaceLifecycleManager, settings);
 
             var topologySectionManager = endpointOrientedTopology.TopologySectionManager;
-            await topologyCreator.Create(topologySectionManager.DetermineResourcesToCreate(new QueueBindings())).ConfigureAwait(false);
+            await topologyCreator.Create(topologySectionManager.DetermineResourcesToCreate(new QueueBindings(), SourceQueueName)).ConfigureAwait(false);
 
             // create the destination queue
             var creator = new AzureServiceBusQueueCreator(endpointOrientedTopology.Settings.QueueSettings, settings);

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -104,7 +104,7 @@
                 return new TopologySectionInternal();
             }
 
-            public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType)
+            public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)
             {
                 return new TopologySectionInternal();
             }

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -89,7 +89,7 @@
                 };
             }
 
-            public TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings)
+            public TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress)
             {
                 return new TopologySectionInternal();
             }

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -94,7 +94,7 @@
                 return new TopologySectionInternal();
             }
 
-            public TopologySectionInternal DeterminePublishDestination(Type eventType)
+            public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
             {
                 return new TopologySectionInternal();
             }

--- a/src/Tests/Seam/When_receiving_messages.cs
+++ b/src/Tests/Seam/When_receiving_messages.cs
@@ -44,7 +44,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
                 namespaceLifecycleManager, settings);
 
             var topologySectionManager = topology.TopologySectionManager;
-            await topologyCreator.Create(topologySectionManager.DetermineResourcesToCreate(new QueueBindings()));
+            await topologyCreator.Create(topologySectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales"));
 
             // setup the operator
             var messageFactoryCreator = new MessagingFactoryCreator(namespaceLifecycleManager, settings);

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -10,11 +10,19 @@
     using Routing;
     using Transport;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_batching_TransportOperations
     {
+        static SettingsHolder BuildSettingsWithDefaultConfigurationValuesApplied()
+        {
+            var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
+            settings.Set("NServiceBus.SharedQueue", "dummy");
+            return settings;
+        }
+
         [Test]
         public void Should_not_batch_different_types_of_transport_operations_together()
         {
@@ -27,7 +35,7 @@
 
             var transportOperations = new TransportOperations(operation1, operation2);
 
-            var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
+            var settings = BuildSettingsWithDefaultConfigurationValuesApplied();
 
             var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
@@ -51,7 +59,7 @@
 
             var transportOperations = new TransportOperations(operation1, operation2, operation3, operation4);
 
-            var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
+            var settings = BuildSettingsWithDefaultConfigurationValuesApplied();
 
             var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
@@ -75,7 +83,7 @@
 
             var transportOperations = new TransportOperations(operation1, operation2, operation3, operation4);
 
-            var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
+            var settings = BuildSettingsWithDefaultConfigurationValuesApplied();
 
             var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
@@ -99,7 +107,7 @@
 
             var transportOperations = new TransportOperations(operation1, operation2);
 
-            var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
+            var settings = BuildSettingsWithDefaultConfigurationValuesApplied();
 
             var batcher = new Batcher(new FakeTopolySectionManager(), settings);
             var batches = batcher.ToBatches(transportOperations);
@@ -130,7 +138,7 @@
             throw new NotImplementedException();
         }
 
-        public TopologySectionInternal DeterminePublishDestination(Type eventType)
+        public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
             return new TopologySectionInternal
             {

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -149,7 +149,7 @@
 
         }
 
-        public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType)
+        public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)
         {
             return new TopologySectionInternal
             {

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -125,7 +125,7 @@
             throw new NotImplementedException();
         }
 
-        public TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings)
+        public TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
@@ -62,7 +62,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings()), "Was expected to fail: " + reasonToFail);
+            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings(), endpointName), "Was expected to fail: " + reasonToFail);
         }
 
 
@@ -89,7 +89,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
 
             var sectionManager = topology.TopologySectionManager;
 
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
             return definition;
         }
     }

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -110,7 +110,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var sectionManager = topology.TopologySectionManager;
             sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
-            var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent));
+            var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
             Assert.That(section.Entities.Count(), Is.EqualTo(1));
         }
@@ -131,7 +131,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var sectionManager = topology.TopologySectionManager;
             sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
-            var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent));
+            var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
             Assert.IsTrue(section.Entities.All(e => e.Path == "sales"), "Subscription name should be matching subscribing endpoint name, but it wasn't.");
         }
@@ -151,7 +151,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             var sectionManager = topology.TopologySectionManager;
             sectionManager.DetermineResourcesToCreate(new QueueBindings());
 
-            var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent));
+            var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
             Assert.IsFalse(section.Entities.Any(x => x.ShouldBeListenedTo));
         }

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
 
             // ReSharper disable once RedundantArgumentDefaultValue
             var namespaceInfo = new RuntimeNamespaceInfo(Name, Connectionstring);
@@ -49,7 +49,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
 
             Assert.AreEqual(1, definition.Entities.Count(ei => ei.Path == "sales" && ei.Type == EntityType.Queue && ei.Namespace.ConnectionString == Connectionstring));
         }
@@ -69,7 +69,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings()), "Was expected to fail: " + reasonToFail);
+            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings(), endpointName), "Was expected to fail: " + reasonToFail);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
 
             var result = definition.Entities.Where(ei => ei.Type == EntityType.Topic && ei.Namespace.ConnectionString == Connectionstring && ei.Path.StartsWith("bundle-"));
 
@@ -108,7 +108,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
@@ -129,7 +129,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
@@ -149,7 +149,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
             topology.Initialize(settings);
 
             var sectionManager = topology.TopologySectionManager;
-            sectionManager.DetermineResourcesToCreate(new QueueBindings());
+            sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 

--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -16,8 +16,7 @@
         {
             var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
-            ConnectionStringInternal connectionString;
-            var isValid = ConnectionStringInternal.TryParse(@namespace, out connectionString);
+            var isValid = ConnectionStringInternal.TryParse(@namespace, out var connectionString);
 
             Assert.IsFalse(isValid);
             Assert.Null(connectionString);
@@ -30,8 +29,7 @@
         {
             var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
-            ConnectionStringInternal connectionString;
-            var isValid = ConnectionStringInternal.TryParse(@namespace, out connectionString);
+            var isValid = ConnectionStringInternal.TryParse(@namespace, out var connectionString);
 
             Assert.IsFalse(isValid);
             Assert.Null(connectionString);
@@ -44,8 +42,7 @@
         {
             var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
-            ConnectionStringInternal connectionString;
-            var isValid = ConnectionStringInternal.TryParse(@namespace, out connectionString);
+            var isValid = ConnectionStringInternal.TryParse(@namespace, out var connectionString);
 
             Assert.IsFalse(isValid);
             Assert.Null(connectionString);
@@ -56,8 +53,7 @@
         {
             var @namespace = string.Format(Template, "abcdef-", "RootManageSharedAccessKey", "YourSecret");
 
-            ConnectionStringInternal connectionString;
-            var isValid = ConnectionStringInternal.TryParse(@namespace, out connectionString);
+            var isValid = ConnectionStringInternal.TryParse(@namespace, out var connectionString);
 
             Assert.IsFalse(isValid);
             Assert.Null(connectionString);
@@ -74,8 +70,7 @@
         {
             var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
-            ConnectionStringInternal connectionString;
-            var isValid = ConnectionStringInternal.TryParse(@namespace, out connectionString);
+            var isValid = ConnectionStringInternal.TryParse(@namespace, out var connectionString);
 
             Assert.IsFalse(isValid);
             Assert.Null(connectionString);
@@ -92,8 +87,7 @@
         {
             var @namespace = string.Format(Template, value, "RootManageSharedAccessKey", "YourSecret");
 
-            ConnectionStringInternal connectionString;
-            var isValid = ConnectionStringInternal.TryParse(@namespace, out connectionString);
+            var isValid = ConnectionStringInternal.TryParse(@namespace, out var connectionString);
 
             Assert.True(isValid);
             Assert.NotNull(connectionString);

--- a/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Operation/When_operating_EndpointOrientedTopology.cs
@@ -269,7 +269,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Operation
                 settings);
 
             var sectionManager = topology.TopologySectionManager;
-            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate(new QueueBindings()));
+            await topologyCreator.Create(sectionManager.DetermineResourcesToCreate(new QueueBindings(), endpointName));
             return topology;
         }
     }

--- a/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_EndpointOrientedTopology.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
         {
             var topology = SetupEndpointOrientedTopology("sales");
 
-            var destination = topology.DeterminePublishDestination(typeof(SomeMessageType));
+            var destination = topology.DeterminePublishDestination(typeof(SomeMessageType), "sales");
 
             Assert.IsTrue(destination.Entities.Single().Type == EntityType.Topic);
             Assert.IsTrue(destination.Entities.Single().Path == "sales.events");

--- a/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
+++ b/src/Tests/Topology/Sending/When_sending_through_ForwardingTopology.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Sending
         {
             var topology = SetupForwardingTopology("sales");
 
-            var destination = topology.DeterminePublishDestination(typeof(SomeMessageType));
+            var destination = topology.DeterminePublishDestination(typeof(SomeMessageType), "sales");
 
             Assert.IsTrue(destination.Entities.Single().Type == EntityType.Topic);
             Assert.IsTrue(destination.Entities.Single().Path.StartsWith("bundle"));

--- a/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
@@ -11,8 +11,7 @@ namespace NServiceBus
     {
         internal RoundRobinNamespacePartitioning(ReadOnlySettings settings)
         {
-            NamespaceConfigurations namespaces;
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
+            if (!settings.TryGet<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out var namespaces))
             {
                 throw new ConfigurationErrorsException($"The '{nameof(RoundRobinNamespacePartitioning)}' strategy requires more than one namespace, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register multiple namespaces");
             }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusEndpointOrientedTopologySettingsExtensions.cs
@@ -23,9 +23,7 @@
 
         static void AddScannerForPublisher(SettingsHolder settings, string publisherName, ITypesScanner scanner)
         {
-            Dictionary<string, List<ITypesScanner>> map;
-
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Publishers, out map))
+            if (!settings.TryGet<Dictionary<string, List<ITypesScanner>>>(WellKnownConfigurationKeys.Topology.Publishers, out var map))
             {
                 map = new Dictionary<string, List<ITypesScanner>>();
                 settings.Set(WellKnownConfigurationKeys.Topology.Publishers, map);

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespacePartitioningSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespacePartitioningSettings.cs
@@ -31,8 +31,7 @@
         /// </summary>
         public void AddNamespace(string name, string connectionString)
         {
-            NamespaceConfigurations namespaces;
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
+            if (!settings.TryGet<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out var namespaces))
             {
                 namespaces = new NamespaceConfigurations();
                 settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaces);

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
@@ -16,8 +16,7 @@ namespace NServiceBus
         /// </summary>
         public NamespaceInfo AddNamespace(string name, string connectionString)
         {
-            NamespaceConfigurations namespaces;
-            if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
+            if (!settings.TryGet<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out var namespaces))
             {
                 namespaces = new NamespaceConfigurations();
                 settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaces);

--- a/src/Transport/Creation/ReadOnlySettingsExtensions.cs
+++ b/src/Transport/Creation/ReadOnlySettingsExtensions.cs
@@ -26,10 +26,9 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         static T GetDefault<T>(this ReadOnlySettings settings, string key)
         {
-            object result;
             var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
             var defaults = (ConcurrentDictionary<string, object>)typeof(SettingsHolder).GetField("Defaults", bindingFlags).GetValue(settings);
-            if (defaults.TryGetValue(key, out result))
+            if (defaults.TryGetValue(key, out var result))
             {
                 return (T)result;
             }

--- a/src/Transport/Receiving/MultiProducerConcurrentCompletion.cs
+++ b/src/Transport/Receiving/MultiProducerConcurrentCompletion.cs
@@ -197,8 +197,7 @@
                 List<TItem> items = null;
                 for (var i = 0; i < batchSize; i++)
                 {
-                    TItem item;
-                    if (!queue.TryDequeue(out item))
+                    if (!queue.TryDequeue(out var item))
                     {
                         break;
                     }

--- a/src/Transport/Seam/Dispatcher.cs
+++ b/src/Transport/Seam/Dispatcher.cs
@@ -18,8 +18,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             var outgoingBatches = batcher.ToBatches(operations);
 
-            ReceiveContextInternal receiveContext;
-            if (!TryGetReceiveContext(transportTransaction, out receiveContext)) // not in a receive context, so send out immediately
+            if (!TryGetReceiveContext(transportTransaction, out var receiveContext)) // not in a receive context, so send out immediately
             {
                 return routeOutgoingBatches.RouteBatches(outgoingBatches, null, DispatchConsistency.Default);
             }

--- a/src/Transport/Seam/SubscriptionManager.cs
+++ b/src/Transport/Seam/SubscriptionManager.cs
@@ -6,16 +6,17 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class SubscriptionManager : IManageSubscriptions
     {
-        public SubscriptionManager(ITopologySectionManagerInternal topologySectionManager, IOperateTopologyInternal topologyOperator, TopologyCreator topologyCreator)
+        public SubscriptionManager(ITopologySectionManagerInternal topologySectionManager, IOperateTopologyInternal topologyOperator, TopologyCreator topologyCreator, string localAddress)
         {
             this.topologySectionManager = topologySectionManager;
             this.topologyOperator = topologyOperator;
             this.topologyCreator = topologyCreator;
+            this.localAddress = localAddress;
         }
 
         public async Task Subscribe(Type eventType, ContextBag context)
         {
-            var section = topologySectionManager.DetermineResourcesToSubscribeTo(eventType);
+            var section = topologySectionManager.DetermineResourcesToSubscribeTo(eventType, localAddress);
             await topologyCreator.Create(section).ConfigureAwait(false);
             topologyOperator.Start(section.Entities);
         }
@@ -30,5 +31,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         ITopologySectionManagerInternal topologySectionManager; // responsible for providing the metadata about the subscription (what in case of EH?)
         IOperateTopologyInternal topologyOperator; // responsible for operating the subscription (creating if needed & receiving from)
         TopologyCreator topologyCreator;
+        readonly string localAddress;
     }
 }

--- a/src/Transport/Seam/TransportResourcesCreator.cs
+++ b/src/Transport/Seam/TransportResourcesCreator.cs
@@ -4,10 +4,11 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class TransportResourcesCreator : ICreateQueues
     {
-        public TransportResourcesCreator(TopologyCreator topologyCreator, ITopologySectionManagerInternal sections)
+        public TransportResourcesCreator(TopologyCreator topologyCreator, ITopologySectionManagerInternal sections, string localAddress)
         {
             this.topologyCreator = topologyCreator;
             this.sections = sections;
+            this.localAddress = localAddress;
         }
 
         public async Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
@@ -19,13 +20,14 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             await topologyCreator.AssertManagedRights().ConfigureAwait(false);
 
-            var receiveResources = sections.DetermineResourcesToCreate(queueBindings);
+            var receiveResources = sections.DetermineResourcesToCreate(queueBindings, localAddress);
             await topologyCreator.Create(receiveResources).ConfigureAwait(false);
 
             resourcesCreated = true;
         }
 
         ITopologySectionManagerInternal sections;
+        readonly string localAddress;
         TopologyCreator topologyCreator;
         bool resourcesCreated;
     }

--- a/src/Transport/Sending/Batcher.cs
+++ b/src/Transport/Sending/Batcher.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Settings;
@@ -10,6 +11,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             this.topologySectionManager = topologySectionManager;
             messageSizePaddingPercentage = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.MessageSenders.MessageSizePaddingPercentage);
+            localAddress = new Lazy<string>(() => settings.LocalAddress());
         }
 
         public IList<BatchInternal> ToBatches(TransportOperations operations)
@@ -51,7 +53,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     batch = new BatchInternal();
                     indexedBatches[key] = batch;
 
-                    batch.Destinations = topologySectionManager.DeterminePublishDestination(multicastOperation.MessageType);
+                    batch.Destinations = topologySectionManager.DeterminePublishDestination(multicastOperation.MessageType, localAddress.Value);
                     batch.RequiredDispatchConsistency = multicastOperation.RequiredDispatchConsistency;
                 }
                 batch.Operations.Add(new BatchedOperationInternal(messageSizePaddingPercentage)
@@ -64,5 +66,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         ITopologySectionManagerInternal topologySectionManager;
         int messageSizePaddingPercentage;
+        Lazy<string> localAddress;
     }
 }

--- a/src/Transport/Sending/Batcher.cs
+++ b/src/Transport/Sending/Batcher.cs
@@ -25,8 +25,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             foreach (var unicastOperation in operations.UnicastTransportOperations)
             {
                 var key = $"unicast-{unicastOperation.Destination}-consistency-{unicastOperation.RequiredDispatchConsistency}";
-                BatchInternal batch;
-                if (!indexedBatches.TryGetValue(key, out batch))
+                if (!indexedBatches.TryGetValue(key, out var batch))
                 {
                     batch = new BatchInternal();
                     indexedBatches[key] = batch;
@@ -47,8 +46,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             foreach (var multicastOperation in operations.MulticastTransportOperations)
             {
                 var key = $"multicast-{multicastOperation.MessageType}-consistency-{multicastOperation.RequiredDispatchConsistency}";
-                BatchInternal batch;
-                if (!indexedBatches.TryGetValue(key, out batch))
+                if (!indexedBatches.TryGetValue(key, out var batch))
                 {
                     batch = new BatchInternal();
                     indexedBatches[key] = batch;

--- a/src/Transport/Sending/Batcher.cs
+++ b/src/Transport/Sending/Batcher.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Transport.AzureServiceBus
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Settings;
@@ -11,7 +10,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             this.topologySectionManager = topologySectionManager;
             messageSizePaddingPercentage = settings.Get<int>(WellKnownConfigurationKeys.Connectivity.MessageSenders.MessageSizePaddingPercentage);
-            localAddress = new Lazy<string>(() => settings.LocalAddress());
+            localAddress = settings.LocalAddress();
         }
 
         public IList<BatchInternal> ToBatches(TransportOperations operations)
@@ -53,7 +52,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     batch = new BatchInternal();
                     indexedBatches[key] = batch;
 
-                    batch.Destinations = topologySectionManager.DeterminePublishDestination(multicastOperation.MessageType, localAddress.Value);
+                    batch.Destinations = topologySectionManager.DeterminePublishDestination(multicastOperation.MessageType, localAddress);
                     batch.RequiredDispatchConsistency = multicastOperation.RequiredDispatchConsistency;
                 }
                 batch.Operations.Add(new BatchedOperationInternal(messageSizePaddingPercentage)
@@ -66,6 +65,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         ITopologySectionManagerInternal topologySectionManager;
         int messageSizePaddingPercentage;
-        Lazy<string> localAddress;
+        string localAddress;
     }
 }

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -7,7 +7,7 @@
         TopologySectionInternal DetermineReceiveResources(string inputQueue);
         TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress);
 
-        TopologySectionInternal DeterminePublishDestination(Type eventType);
+        TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress);
         TopologySectionInternal DetermineSendDestination(string destination);
 
         TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress);

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -5,7 +5,7 @@
     interface ITopologySectionManagerInternal
     {
         TopologySectionInternal DetermineReceiveResources(string inputQueue);
-        TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings);
+        TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress);
 
         TopologySectionInternal DeterminePublishDestination(Type eventType);
         TopologySectionInternal DetermineSendDestination(string destination);

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -10,7 +10,7 @@
         TopologySectionInternal DeterminePublishDestination(Type eventType);
         TopologySectionInternal DetermineSendDestination(string destination);
 
-        TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType);
+        TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress);
         TopologySectionInternal DetermineResourcesToUnsubscribeFrom(Type eventtype);
     }
 }

--- a/src/Transport/Topology/PublishersConfiguration.cs
+++ b/src/Transport/Topology/PublishersConfiguration.cs
@@ -63,8 +63,7 @@
 
         void AddPublisherForType(string publisherName, Type type)
         {
-            List<string> publisherNames;
-            if (!publishers.TryGetValue(type, out publisherNames))
+            if (!publishers.TryGetValue(type, out var publisherNames))
             {
                 publisherNames = new List<string>();
                 publishers.Add(type, publisherNames);

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -11,9 +11,7 @@ namespace NServiceBus
     class EndpointOrientedTopologyInternal : ITopologyInternal
     {
         public ITopologySectionManagerInternal TopologySectionManager { get; set; }
-
         public IOperateTopologyInternal Operator { get; set; }
-
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
         public TopologySettings Settings { get; } = new TopologySettings();
@@ -63,7 +61,6 @@ namespace NServiceBus
             var oversizedMessageHandler = (IHandleOversizedBrokeredMessages)this.settings.Get(WellKnownConfigurationKeys.Connectivity.MessageSenders.OversizedBrokeredMessageHandlerInstance);
 
             outgoingBatchRouter = new OutgoingBatchRouter(new BatchedOperationsToBrokeredMessagesConverter(this.settings), senderLifeCycleManager, this.settings, oversizedMessageHandler);
-            batcher = new Batcher(TopologySectionManager, this.settings);
 
             Operator = new TopologyOperator(messageReceiverLifeCycleManager, new BrokeredMessagesToIncomingMessagesConverter(this.settings, new DefaultConnectionStringToNamespaceAliasMapper(this.settings)), this.settings);
         }
@@ -86,7 +83,7 @@ namespace NServiceBus
 
         public Func<IDispatchMessages> GetDispatcherFactory()
         {
-            return () => new Dispatcher(outgoingBatchRouter, batcher);
+            return () => new Dispatcher(outgoingBatchRouter, new Batcher(TopologySectionManager, settings));
         }
 
         public Func<IManageSubscriptions> GetSubscriptionManagerFactory()
@@ -126,7 +123,6 @@ namespace NServiceBus
         TopologyCreator topologyCreator;
         SettingsHolder settings;
         OutgoingBatchRouter outgoingBatchRouter;
-        Batcher batcher;
         IIndividualizationStrategy individualization;
     }
 }

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -44,7 +44,7 @@ namespace NServiceBus
 
             var addressingLogic = new AddressingLogic(sanitizationStrategy, compositionStrategy);
 
-            var endpointName = this.settings.GetOrDefault<string>("BaseInputQueueName") ?? this.settings.EndpointName();
+            var endpointName = this.settings.LocalAddress();
             TopologySectionManager = new EndpointOrientedTopologySectionManager(defaultName, namespaceConfigurations, endpointName, publishersConfiguration, partitioningStrategy, addressingLogic);
 
             namespaceManagerCreator = new NamespaceManagerCreator(this.settings);

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -44,7 +44,7 @@ namespace NServiceBus
 
             var addressingLogic = new AddressingLogic(sanitizationStrategy, compositionStrategy);
 
-            var endpointName = this.settings.LocalAddress();
+            var endpointName = this.settings.EndpointName();
             TopologySectionManager = new EndpointOrientedTopologySectionManager(defaultName, namespaceConfigurations, endpointName, publishersConfiguration, partitioningStrategy, addressingLogic);
 
             namespaceManagerCreator = new NamespaceManagerCreator(this.settings);
@@ -90,7 +90,8 @@ namespace NServiceBus
 
         public Func<IManageSubscriptions> GetSubscriptionManagerFactory()
         {
-            return () => new SubscriptionManager(TopologySectionManager, Operator, topologyCreator);
+            // Have to provide endpoint name by accessing the settings and not using the cached version for an endpoint name that is overridden.
+            return () => new SubscriptionManager(TopologySectionManager, Operator, topologyCreator, settings.LocalAddress());
         }
 
         public Task<StartupCheckResult> RunPreStartupChecks()

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopology.cs
@@ -75,7 +75,8 @@ namespace NServiceBus
 
         public Func<ICreateQueues> GetQueueCreatorFactory()
         {
-            return () => new TransportResourcesCreator(topologyCreator, TopologySectionManager);
+            // Have to provide endpoint name by accessing the settings and not using the cached version for an endpoint name that is overridden. 
+            return () => new TransportResourcesCreator(topologyCreator, TopologySectionManager, settings.LocalAddress());
         }
 
         public Func<IPushMessages> GetMessagePumpFactory()

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -170,11 +170,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             });
         }
 
-        public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType)
+        public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)
         {
             if (!subscriptions.ContainsKey(eventType))
             {
-                subscriptions[eventType] = BuildSubscriptionHierarchy(eventType);
+                subscriptions[eventType] = BuildSubscriptionHierarchy(eventType, localAddress);
             }
 
             return subscriptions[eventType];
@@ -196,15 +196,17 @@ namespace NServiceBus.Transport.AzureServiceBus
             return result;
         }
 
-        TopologySectionInternal BuildSubscriptionHierarchy(Type eventType)
+        TopologySectionInternal BuildSubscriptionHierarchy(Type eventType, string localAddress)
         {
             var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Creating).ToArray();
 
             var topicPaths = DetermineTopicsFor(eventType);
 
-            var subscriptionNameCandidateV6 = endpointName + "." + eventType.Name;
+            // Using localAddress that will be provided by SubscriptionManager instead of the endpoint name.
+            // Reason: endpoint name can be overridden. If the endpoint name is overridden, "endpointName" will not have the override value.
+            var subscriptionNameCandidateV6 = localAddress + "." + eventType.Name;
             var subscriptionNameV6 = addressingLogic.Apply(subscriptionNameCandidateV6, EntityType.Subscription).Name;
-            var subscriptionNameCandidate = endpointName + "." + eventType.FullName;
+            var subscriptionNameCandidate = localAddress + "." + eventType.FullName;
             var subscriptionName = addressingLogic.Apply(subscriptionNameCandidate, EntityType.Subscription).Name;
 
             var topics = new List<EntityInfoInternal>();

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -85,13 +85,12 @@ namespace NServiceBus.Transport.AzureServiceBus
             };
         }
 
-        public TopologySectionInternal DeterminePublishDestination(Type eventType)
+        public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
             return publishDestinations.GetOrAdd(eventType, t =>
             {
                 var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
-            // TODO: does this need to be localAddress and not endpointOriginalName?
-            	var topicPath = addressingLogic.Apply(originalEndpointName + ".events", EntityType.Topic).Name;
+            	var topicPath = addressingLogic.Apply(localAddress + ".events", EntityType.Topic).Name;
                 var topics = namespaces.Select(n => new EntityInfoInternal
                 {
                     Path = topicPath,

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -183,9 +183,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DetermineResourcesToUnsubscribeFrom(Type eventtype)
         {
-            TopologySectionInternal result;
-
-            if (!subscriptions.TryRemove(eventtype, out result))
+            if (!subscriptions.TryRemove(eventtype, out var result))
             {
                 result = new TopologySectionInternal
                 {

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -90,6 +90,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             return publishDestinations.GetOrAdd(eventType, t =>
             {
                 var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
+            // TODO: does this need to be localAddress and not endpointOriginalName?
             	var topicPath = addressingLogic.Apply(originalEndpointName + ".events", EntityType.Topic).Name;
                 var topics = namespaces.Select(n => new EntityInfoInternal
                 {

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -11,9 +11,7 @@ namespace NServiceBus
     class ForwardingTopologyInternal : ITopologyInternal
     {
         public ITopologySectionManagerInternal TopologySectionManager { get; set; }
-
         public IOperateTopologyInternal Operator { get; set; }
-
         public bool HasNativePubSubSupport => true;
         public bool HasSupportForCentralizedPubSub => true;
         public TopologySettings Settings { get; } = new TopologySettings();
@@ -68,7 +66,6 @@ namespace NServiceBus
             var oversizedMessageHandler = (IHandleOversizedBrokeredMessages)this.settings.Get(WellKnownConfigurationKeys.Connectivity.MessageSenders.OversizedBrokeredMessageHandlerInstance);
 
             outgoingBatchRouter = new OutgoingBatchRouter(new BatchedOperationsToBrokeredMessagesConverter(this.settings), senderLifeCycleManager, this.settings, oversizedMessageHandler);
-            batcher = new Batcher(TopologySectionManager, this.settings);
 
             Operator = new TopologyOperator(messageReceiverLifeCycleManager, new BrokeredMessagesToIncomingMessagesConverter(this.settings, new DefaultConnectionStringToNamespaceAliasMapper(this.settings)), this.settings);
         }
@@ -91,7 +88,7 @@ namespace NServiceBus
 
         public Func<IDispatchMessages> GetDispatcherFactory()
         {
-            return () => new Dispatcher(outgoingBatchRouter, batcher);
+            return () => new Dispatcher(outgoingBatchRouter, new Batcher(TopologySectionManager, this.settings));
         }
 
         public Func<IManageSubscriptions> GetSubscriptionManagerFactory()
@@ -131,7 +128,6 @@ namespace NServiceBus
         TopologyCreator topologyCreator;
         SettingsHolder settings;
         OutgoingBatchRouter outgoingBatchRouter;
-        Batcher batcher;
         IIndividualizationStrategy individualization;
     }
 }

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -51,7 +51,7 @@ namespace NServiceBus
             namespaceManagerCreator = new NamespaceManagerCreator(this.settings);
             namespaceManagerLifeCycleManagerInternal = new NamespaceManagerLifeCycleManagerInternal(namespaceManagerCreator);
 
-            var endpointName = this.settings.LocalAddress();
+            var endpointName = this.settings.EndpointName();
             TopologySectionManager = new ForwardingTopologySectionManager(defaultName, namespaceConfigurations, endpointName, numberOfEntitiesInBundle, bundlePrefix, partitioningStrategy, addressingLogic, namespaceManagerLifeCycleManagerInternal);
 
             messagingFactoryAdapterCreator = new MessagingFactoryCreator(namespaceManagerLifeCycleManagerInternal, this.settings);
@@ -95,7 +95,8 @@ namespace NServiceBus
 
         public Func<IManageSubscriptions> GetSubscriptionManagerFactory()
         {
-            return () => new SubscriptionManager(TopologySectionManager, Operator, topologyCreator);
+            // Have to provide endpoint name by accessing the settings and not using the cached version for an endpoint name that is overridden. 
+            return () => new SubscriptionManager(TopologySectionManager, Operator, topologyCreator, settings.LocalAddress());
         }
 
         public Task<StartupCheckResult> RunPreStartupChecks()

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -51,7 +51,7 @@ namespace NServiceBus
             namespaceManagerCreator = new NamespaceManagerCreator(this.settings);
             namespaceManagerLifeCycleManagerInternal = new NamespaceManagerLifeCycleManagerInternal(namespaceManagerCreator);
 
-            var endpointName = this.settings.GetOrDefault<string>("BaseInputQueueName") ?? this.settings.EndpointName();
+            var endpointName = this.settings.LocalAddress();
             TopologySectionManager = new ForwardingTopologySectionManager(defaultName, namespaceConfigurations, endpointName, numberOfEntitiesInBundle, bundlePrefix, partitioningStrategy, addressingLogic, namespaceManagerLifeCycleManagerInternal);
 
             messagingFactoryAdapterCreator = new MessagingFactoryCreator(namespaceManagerLifeCycleManagerInternal, this.settings);

--- a/src/Transport/Topology/Topologies/ForwardingTopology.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopology.cs
@@ -80,7 +80,8 @@ namespace NServiceBus
 
         public Func<ICreateQueues> GetQueueCreatorFactory()
         {
-            return () => new TransportResourcesCreator(topologyCreator, TopologySectionManager);
+            // Have to provide endpoint name by accessing the settings and not using the cached version for an endpoint name that is overridden. 
+            return () => new TransportResourcesCreator(topologyCreator, TopologySectionManager, settings.LocalAddress());
         }
 
         public Func<IPushMessages> GetMessagePumpFactory()

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -170,11 +170,11 @@ namespace NServiceBus.Transport.AzureServiceBus
             });
         }
 
-        public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType)
+        public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)
         {
             if (!subscriptions.ContainsKey(eventType))
             {
-                subscriptions[eventType] = BuildSubscriptionHierarchy(eventType);
+                subscriptions[eventType] = BuildSubscriptionHierarchy(eventType, localAddress);
             }
 
             return subscriptions[eventType];
@@ -194,12 +194,15 @@ namespace NServiceBus.Transport.AzureServiceBus
             return result;
         }
 
-        TopologySectionInternal BuildSubscriptionHierarchy(Type eventType)
+        TopologySectionInternal BuildSubscriptionHierarchy(Type eventType, string localAddress)
         {
             var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Creating).ToArray();
 
-            var sanitizedInputQueuePath = addressingLogic.Apply(endpointName, EntityType.Queue).Name;
-            var sanitizedSubscriptionPath = addressingLogic.Apply(endpointName, EntityType.Subscription).Name;
+            // Using localAddress that will be provided by SubscriptionManager instead of the endpoint name.
+            // Reason: endpoint name can be overridden. If the endpoint name is overridden, "endpointName" will not have the override value.
+            var sanitizedInputQueuePath = addressingLogic.Apply(localAddress, EntityType.Queue).Name;
+            var sanitizedSubscriptionPath = addressingLogic.Apply(localAddress, EntityType.Subscription).Name;
+
             // rule name needs to be 1) based on event full name 2) unique 3) deterministic
             var ruleName = addressingLogic.Apply(eventType.FullName, EntityType.Rule).Name;
 

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -89,7 +89,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             };
         }
 
-        public TopologySectionInternal DeterminePublishDestination(Type eventType)
+        public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
             return publishDestinations.GetOrAdd(eventType, t =>
             {

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -127,8 +127,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             foreach (var entity in entities)
             {
-                INotifyIncomingMessagesInternal notifier;
-                notifiers.TryGetValue(entity, out notifier);
+                notifiers.TryGetValue(entity, out var notifier);
 
                 if (notifier == null || !notifier.IsRunning)
                 {

--- a/src/Transport/Utils/BrokeredMessageExtensions.cs
+++ b/src/Transport/Utils/BrokeredMessageExtensions.cs
@@ -91,8 +91,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public static long EstimatedSize(this BrokeredMessage message)
         {
-            object size;
-            message.Properties.TryGetValue(BrokeredMessageHeaders.EstimatedMessageSize, out size);
+            message.Properties.TryGetValue(BrokeredMessageHeaders.EstimatedMessageSize, out var size);
             return Convert.ToInt64(size);
         }
 


### PR DESCRIPTION
Connects to #619 
Fixes #619

When an endpoint name is overridden, endpoint's original input queue shouldn't be used.
Instead, the override name should.

For example, with 2 endpoints, `Publisher` and `Subscriber` where `Subscriber` overrides endpoint name to be `myInputQueue` and subscribes to the publisher's event `MyEvent`. The following _should_ happen:

1.  Subscriber endpoint to create `myInputQueue` queue as its input queue.
1. `MyEvent` events published by Publisher to be received by Subscriber via `myInputQueue`.
1. `Subscriber` queue to **not** exist

Subscriber's endpoint name should be available via `settings.LocalAddress`. Problem with this extension method is that the transport upon Initialization constructs topology that _caches_ endpoint name that is **not finalized by the core yet**.  Therefore, endpoint name should not be cached, but instead `settings.LocalAddress` be used when 
- `SubscriptionManager` needs to create a subscription  ==> `ITopologyInternal.GetSubscriptionManagerFactory()`
- or `TransportResourcesCreator` needs to create an input queue ==> `ITopologyInternal.GetQueueCreatorFactory()`