### PR TITLE
RegisteredEndpoints can be added to the namespace info

### DIFF
--- a/src/Tests/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -94,7 +94,7 @@ namespace NServiceBus
     }
     public class AzureServiceBusNamespaceRoutingSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
-        public void AddNamespace(string name, string connectionString) { }
+        public NServiceBus.Transport.AzureServiceBus.NamespaceInfo AddNamespace(string name, string connectionString) { }
     }
     public class AzureServiceBusQueueSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
@@ -439,7 +439,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         public NamespaceConfigurations() { }
         public int Count { get; }
-        public void Add(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose) { }
+        public NServiceBus.Transport.AzureServiceBus.NamespaceInfo Add(string alias, string connectionString, NServiceBus.Transport.AzureServiceBus.NamespacePurpose purpose) { }
         public string GetConnectionString(string name) { }
         public System.Collections.Generic.IEnumerator<NServiceBus.Transport.AzureServiceBus.NamespaceInfo> GetEnumerator() { }
     }
@@ -452,6 +452,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             " removed in version 9.0.0.", true)]
         public NServiceBus.Transport.AzureServiceBus.ConnectionString ConnectionString { get; }
         public NServiceBus.Transport.AzureServiceBus.NamespacePurpose Purpose { get; }
+        public System.Collections.Generic.HashSet<string> RegisteredEndpoints { get; }
         public bool Equals(NServiceBus.Transport.AzureServiceBus.NamespaceInfo other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
+++ b/src/Transport/Config/ExtensionPoints/AzureServiceBusNamespaceRoutingSettings.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
         /// <summary>
         /// Adds a namespace for routing.
         /// </summary>
-        public void AddNamespace(string name, string connectionString)
+        public NamespaceInfo AddNamespace(string name, string connectionString)
         {
             NamespaceConfigurations namespaces;
             if (!settings.TryGet(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, out namespaces))
@@ -23,7 +23,7 @@ namespace NServiceBus
                 settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaces);
             }
 
-            namespaces.Add(name, connectionString, NamespacePurpose.Routing);
+            return namespaces.Add(name, connectionString, NamespacePurpose.Routing);
         }
 
         SettingsHolder settings;

--- a/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceConfigurations.cs
@@ -30,24 +30,25 @@
             return GetEnumerator();
         }
 
-        public void Add(string alias, string connectionString, NamespacePurpose purpose)
+        public NamespaceInfo Add(string alias, string connectionString, NamespacePurpose purpose)
         {
             var definition = new NamespaceInfo(alias, connectionString, purpose);
-
             var namespaceInfo = inner.SingleOrDefault(x => x.Connection == definition.Connection);
             if (namespaceInfo != null)
             {
                 Log.Info($"Duplicated connection string for namespace `{namespaceInfo.Alias}` and alias `{alias}.`  + {Environment.NewLine} + `{alias}` namespace alias was not registered.");
-                return;
+                return namespaceInfo;
             }
 
-            if (inner.Any(x => string.Equals(x.Alias, alias, StringComparison.OrdinalIgnoreCase)))
+            namespaceInfo = inner.SingleOrDefault(x => string.Equals(x.Alias, alias, StringComparison.OrdinalIgnoreCase));
+            if (namespaceInfo != null)
             {
                 Log.Info($"Duplicated namespace alias `{alias}` configuration detected. Registered only once");
-                return;
+                return namespaceInfo;
             }
 
             inner.Add(definition);
+            return definition;
         }
 
         public string GetConnectionString(string name)

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
+    using System.Collections.Generic;
 
     public partial class NamespaceInfo : IEquatable<NamespaceInfo>
     {
@@ -19,6 +20,7 @@
             Alias = alias;
             this.connectionString = new ConnectionStringInternal(connectionString);
             Purpose = purpose;
+            RegisteredEndpoints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public string Alias { get; }
@@ -26,6 +28,8 @@
         public NamespacePurpose Purpose { get; }
 
         public string Connection => connectionString;
+
+        public HashSet<string> RegisteredEndpoints { get; }
 
         public bool Equals(NamespaceInfo other)
         {


### PR DESCRIPTION
API draft to solve #585 and #584 

- `AddNamespace `on routing will return a `NamespaceInfo  `since that class is already public
- `NamespaceInfo `has been extended to have a property called `RegisteredEndpoints `which allows indicating that an endpoint belongs to the specific namespace
- Uses a HashSet with ordinal ignore case comparison to avoid having duplicate entries in the set