### PR TITLE
Send over namespaces

### DIFF
--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -136,12 +136,12 @@ namespace NServiceBus.Transport.AzureServiceBus
                 }
                 else
                 {
-                    var configured = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(d, StringComparer.OrdinalIgnoreCase));
-                    if (configured != null)
+                    var namespaceToRouteTo = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(d, StringComparer.OrdinalIgnoreCase));
+                    if (namespaceToRouteTo != null)
                     {
                         namespaces = new[]
                         {
-                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose),
+                            new RuntimeNamespaceInfo(namespaceToRouteTo.Alias, namespaceToRouteTo.Connection, namespaceToRouteTo.Purpose),
                         };
                     }
                     else // sending to the partition
@@ -152,7 +152,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
                 if (namespaces == null)
                 {
-                    throw new Exception($"Could not determine namespace for destination {d}");
+                    throw new Exception($"Could not determine namespace for destination '{d}'");
                 }
 
                 var inputQueues = namespaces.Select(n => new EntityInfoInternal

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -115,7 +115,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 {
                     namespaces = new[]
                     {
-                        new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing, NamespaceMode.Active)
+                        new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing)
                     };
                 }
                 else
@@ -125,14 +125,25 @@ namespace NServiceBus.Transport.AzureServiceBus
                     {
                         namespaces = new[]
                         {
-                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose, NamespaceMode.Active)
+                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
                         };
                     }
                 }
             }
-            else // sending to the partition
+            else
             {
-                namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                var configured = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(destination, StringComparer.OrdinalIgnoreCase));
+                if (configured != null)
+                {
+                    namespaces = new[]
+                    {
+                        new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose),
+                    };
+                }
+                else // sending to the partition
+                {
+                    namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                }
             }
 
             if (namespaces == null)

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -87,82 +87,87 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DeterminePublishDestination(Type eventType)
         {
-            var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
-
-            var topicPath = addressingLogic.Apply(endpointName + ".events", EntityType.Topic).Name;
-            var topics = namespaces.Select(n => new EntityInfoInternal
+            return publishDestinations.GetOrAdd(eventType, t =>
             {
-                Path = topicPath,
-                Type = EntityType.Topic,
-                Namespace = n
-            }).ToArray();
+                var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
+                var topicPath = addressingLogic.Apply(endpointName + ".events", EntityType.Topic).Name;
+                var topics = namespaces.Select(n => new EntityInfoInternal
+                {
+                    Path = topicPath,
+                    Type = EntityType.Topic,
+                    Namespace = n
+                }).ToArray();
 
-            return new TopologySectionInternal
-            {
-                Namespaces = namespaces,
-                Entities = topics
-            };
+                return new TopologySectionInternal
+                {
+                    Namespaces = namespaces,
+                    Entities = topics
+                };
+            });
         }
 
         public TopologySectionInternal DetermineSendDestination(string destination)
         {
-            var inputQueueAddress = addressingLogic.Apply(destination, EntityType.Queue);
-
-            RuntimeNamespaceInfo[] namespaces = null;
-            if (inputQueueAddress.HasSuffix && inputQueueAddress.Suffix != defaultNameSpaceAlias) // sending to specific namespace
+            return sendDestinations.GetOrAdd(destination, d =>
             {
-                if (inputQueueAddress.HasConnectionString)
+                var inputQueueAddress = addressingLogic.Apply(d, EntityType.Queue);
+
+                RuntimeNamespaceInfo[] namespaces = null;
+                if (inputQueueAddress.HasSuffix && inputQueueAddress.Suffix != defaultNameSpaceAlias) // sending to specific namespace
                 {
-                    namespaces = new[]
+                    if (inputQueueAddress.HasConnectionString)
                     {
-                        new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing)
-                    };
+                        namespaces = new[]
+                        {
+                            new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing)
+                        };
+                    }
+                    else
+                    {
+                        var configured = namespaceConfigurations.FirstOrDefault(n => n.Alias == inputQueueAddress.Suffix);
+                        if (configured != null)
+                        {
+                            namespaces = new[]
+                            {
+                                new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
+                            };
+                        }
+                    }
                 }
                 else
                 {
-                    var configured = namespaceConfigurations.FirstOrDefault(n => n.Alias == inputQueueAddress.Suffix);
+                    var configured = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(d, StringComparer.OrdinalIgnoreCase));
                     if (configured != null)
                     {
                         namespaces = new[]
                         {
-                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
+                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose),
                         };
                     }
-                }
-            }
-            else
-            {
-                var configured = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(destination, StringComparer.OrdinalIgnoreCase));
-                if (configured != null)
-                {
-                    namespaces = new[]
+                    else // sending to the partition
                     {
-                        new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose),
-                    };
+                        namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                    }
                 }
-                else // sending to the partition
+
+                if (namespaces == null)
                 {
-                    namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                    throw new Exception($"Could not determine namespace for destination {d}");
                 }
-            }
 
-            if (namespaces == null)
-            {
-                throw new Exception($"Could not determine namespace for destination {destination}");
-            }
+                var inputQueues = namespaces.Select(n => new EntityInfoInternal
+                {
+                    Path = inputQueueAddress.Name,
+                    Type = EntityType.Queue,
+                    Namespace = n
+                }).ToArray();
 
-            var inputQueues = namespaces.Select(n => new EntityInfoInternal
-            {
-                Path = inputQueueAddress.Name,
-                Type = EntityType.Queue,
-                Namespace = n
-            }).ToArray();
-
-            return new TopologySectionInternal
-            {
-                Namespaces = namespaces,
-                Entities = inputQueues
-            };
+                return new TopologySectionInternal
+                {
+                    Namespaces = namespaces,
+                    Entities = inputQueues
+                };
+            });
         }
 
         public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType)
@@ -254,6 +259,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         }
 
         ConcurrentDictionary<Type, TopologySectionInternal> subscriptions = new ConcurrentDictionary<Type, TopologySectionInternal>();
+        ConcurrentDictionary<string, TopologySectionInternal> sendDestinations = new ConcurrentDictionary<string, TopologySectionInternal>();
+        ConcurrentDictionary<Type, TopologySectionInternal> publishDestinations = new ConcurrentDictionary<Type, TopologySectionInternal>();
         INamespacePartitioningStrategy namespacePartitioningStrategy;
         AddressingLogic addressingLogic;
         PublishersConfiguration publishersConfiguration;

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -101,7 +101,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
                 return new TopologySectionInternal
                 {
-                    Entities = SelectFirstTopicFromBundle(topics),
+                    Entities = new [] { topics[0] }, // first in bundle
                     Namespaces = namespaces
                 };
             });
@@ -192,12 +192,6 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
 
             return result;
-        }
-
-        IEnumerable<EntityInfoInternal> SelectFirstTopicFromBundle(List<EntityInfoInternal> entityInfos)
-        {
-            const int index = 0;
-            yield return entityInfos[index];
         }
 
         TopologySectionInternal BuildSubscriptionHierarchy(Type eventType)

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -120,7 +120,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     {
                         namespaces = new[]
                         {
-                            new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing, NamespaceMode.Active)
+                            new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing)
                         };
                     }
                     else
@@ -130,14 +130,25 @@ namespace NServiceBus.Transport.AzureServiceBus
                         {
                             namespaces = new[]
                             {
-                                new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose, NamespaceMode.Active)
+                                new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
                             };
                         }
                     }
                 }
-                else // sending to the partition
+                else
                 {
-                    namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                    var configured = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(d, StringComparer.OrdinalIgnoreCase));
+                    if (configured != null)
+                    {
+                        namespaces = new[]
+                        {
+                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose),
+                        };
+                    }
+                    else // sending to the partition
+                    {
+                        namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                    }
                 }
 
                 if (namespaces == null)


### PR DESCRIPTION
Based on #622 
Closes #585 
Doco https://github.com/Particular/docs.particular.net/pull/3276

`DetermineSendDestination` is the central location where either explicit destinations with alias or connection string or endpoint names will go through. The routing has been extended to look up whether a registered endpoint is available and then use that as a destination. If no registered endpoint is available the normal partitioning strategy approach will be used. 

The assumptions are that if a destination contains `@alias` or `@connectionstring` the `inputQueueAddress` will have the properties set as usual and this takes precedence. For all other destinations without `@` the else part is responsible. 