### PR TITLE
Subscribe outside topology

### DIFF
--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -35,57 +35,57 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
         else
         {
             transportConfig.ConnectionString(connectionString);
-        }
 
-        if (topology == "ForwardingTopology")
-        {
-            transportConfig.UseForwardingTopology();
-        }
-        else
-        {
-            var endpointOrientedTopology = transportConfig.UseEndpointOrientedTopology();
-            foreach (var publisher in publisherMetadata.Publishers)
+            if (topology == "ForwardingTopology")
             {
-                foreach (var eventType in publisher.Events)
-                {
-                    endpointOrientedTopology.RegisterPublisher(eventType, publisher.PublisherName);
-                }
+                transportConfig.UseForwardingTopology();
             }
+            else
+            {
+                var endpointOrientedTopology = transportConfig.UseEndpointOrientedTopology();
+                foreach (var publisher in publisherMetadata.Publishers)
+                {
+                    foreach (var eventType in publisher.Events)
+                    {
+                        endpointOrientedTopology.RegisterPublisher(eventType, publisher.PublisherName);
+                    }
+                }
 
-            // ATTs that that require publishers to be explicitely registered for the EndpointOrientedTopology
-            endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher1)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher2)));
+                // ATTs that that require publishers to be explicitely registered for the EndpointOrientedTopology
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher1)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher2)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_to_scaled_out_subscribers.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_to_scaled_out_subscribers.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_to_scaled_out_subscribers.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_to_scaled_out_subscribers.Publisher)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_event.Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_event.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_event.Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_event.Publisher)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing.Endpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing.Endpoint)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V1Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V2Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V1Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V2Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_replies_to_message_published_by_a_saga.DidSomething), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_replies_to_message_published_by_a_saga.SagaEndpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_replies_to_message_published_by_a_saga.DidSomething), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_replies_to_message_published_by_a_saga.SagaEndpoint)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_base_event_from_other_saga.BaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_base_event_from_other_saga.Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_event_from_another_saga.SomethingHappenedEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_event_from_another_saga.SagaThatPublishesAnEvent)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_base_event_from_other_saga.BaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_base_event_from_other_saga.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_event_from_another_saga.SomethingHappenedEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_event_from_another_saga.SagaThatPublishesAnEvent)));
 
-            //When_two_sagas_subscribe_to_the_same_event
-            endpointOrientedTopology.RegisterPublisher(typeof(When_two_sagas_subscribe_to_the_same_event.GroupPendingEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_two_sagas_subscribe_to_the_same_event.Publisher)));
+                  //When_two_sagas_subscribe_to_the_same_event
+                endpointOrientedTopology.RegisterPublisher(typeof(When_two_sagas_subscribe_to_the_same_event.GroupPendingEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_two_sagas_subscribe_to_the_same_event.Publisher)));
 
-            // TODO: investigate why these tests that are intended for the ForwradingTopology only fail w/o publisher registration on EndpointOrientedTopology execution on build server
-            endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.BaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.DerivedEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
+                // TODO: investigate why these tests that are intended for the ForwradingTopology only fail w/o publisher registration on EndpointOrientedTopology execution on build server
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.BaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.DerivedEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_from_sendonly.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_from_sendonly.SendOnlyPublisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_base_event.IBaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_base_event.Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_derived_event.SpecificEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_derived_event.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_from_sendonly.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_from_sendonly.SendOnlyPublisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_base_event.IBaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_base_event.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_derived_event.SpecificEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_derived_event.Publisher)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_with_overridden_local_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_with_overridden_local_address.Publisher)));
-            // Both publisher and subscriber are the same endpoint with overridden endpoint name. We can't detect both from the message type.
-            endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.MyEvent), "myinputqueue");
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_with_overridden_local_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_with_overridden_local_address.Publisher)));
+				// Both publisher and subscriber are the same endpoint with overridden endpoint name. We can't detect both from the message type.
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.MyEvent), "myinputqueue");
+            }
         }
 
         transportConfig.Sanitization()

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -3,7 +3,7 @@ using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.AcceptanceTests.DelayedDelivery;
 using NServiceBus.AcceptanceTests.Routing;
-using TesingConventions = NServiceBus.AcceptanceTesting.Customization;
+using TestingConventions = NServiceBus.AcceptanceTesting.Customization;
 using NServiceBus.AcceptanceTests.Routing.NativePublishSubscribe;
 using NServiceBus.AcceptanceTests.Sagas;
 using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -51,38 +51,38 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
                     }
                 }
 
-                // ATTs that that require publishers to be explicitely registered for the EndpointOrientedTopology
-                endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher1)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher2)));
+                // ATTs that that require publishers to be explicitly registered for the EndpointOrientedTopology
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent1), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher1)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multi_subscribing_to_a_polymorphic_event.MyEvent2), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_multi_subscribing_to_a_polymorphic_event.Publisher2)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_to_scaled_out_subscribers.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_to_scaled_out_subscribers.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_to_scaled_out_subscribers.MyEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_to_scaled_out_subscribers.Publisher)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_event.Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_event.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_event.Event), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_event.Publisher)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing.Endpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing.MyEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing.Endpoint)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V1Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V2Event), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V1Event), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_multiple_versions_of_a_message_is_published.V2Event), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_replies_to_message_published_by_a_saga.DidSomething), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_replies_to_message_published_by_a_saga.SagaEndpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_replies_to_message_published_by_a_saga.DidSomething), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_replies_to_message_published_by_a_saga.SagaEndpoint)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_base_event_from_other_saga.BaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_base_event_from_other_saga.Publisher)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_event_from_another_saga.SomethingHappenedEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_event_from_another_saga.SagaThatPublishesAnEvent)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_base_event_from_other_saga.BaseEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_base_event_from_other_saga.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_event_from_another_saga.SomethingHappenedEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_started_by_event_from_another_saga.SagaThatPublishesAnEvent)));
 
-                  //When_two_sagas_subscribe_to_the_same_event
-                endpointOrientedTopology.RegisterPublisher(typeof(When_two_sagas_subscribe_to_the_same_event.GroupPendingEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_two_sagas_subscribe_to_the_same_event.Publisher)));
+                //When_two_sagas_subscribe_to_the_same_event
+                endpointOrientedTopology.RegisterPublisher(typeof(When_two_sagas_subscribe_to_the_same_event.GroupPendingEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_two_sagas_subscribe_to_the_same_event.Publisher)));
 
                 // TODO: investigate why these tests that are intended for the ForwradingTopology only fail w/o publisher registration on EndpointOrientedTopology execution on build server
-                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.BaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.DerivedEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.BaseEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.DerivedEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_base_and_derived_polymorphic_events_with_forwarding_topology.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.MyOtherEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.Endpoint)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_from_sendonly.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_from_sendonly.SendOnlyPublisher)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_base_event.IBaseEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_base_event.Publisher)));
-                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_derived_event.SpecificEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_derived_event.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_from_sendonly.MyEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_from_sendonly.SendOnlyPublisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_base_event.IBaseEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_base_event.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_subscribing_to_a_derived_event.SpecificEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_subscribing_to_a_derived_event.Publisher)));
 
-                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_with_overridden_local_address.MyEvent), TesingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_with_overridden_local_address.Publisher)));
+                endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_with_overridden_local_address.MyEvent), TestingConventions.Conventions.EndpointNamingConvention(typeof(When_publishing_with_overridden_local_address.Publisher)));
 				// Both publisher and subscriber are the same endpoint with overridden endpoint name. We can't detect both from the message type.
                 endpointOrientedTopology.RegisterPublisher(typeof(When_publishing_and_subscribing_to_self_with_overridden_address.MyEvent), "myinputqueue");
             }
@@ -105,8 +105,8 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
 
     void PreventInconclusiveTestsFromRunning(string endpointName)
     {
-        if (endpointName == TesingConventions.Conventions.EndpointNamingConvention(typeof(When_deferring_to_non_local.Endpoint))
-            || endpointName == TesingConventions.Conventions.EndpointNamingConvention(typeof(When_deferring_a_message.Endpoint)))
+        if (endpointName == TestingConventions.Conventions.EndpointNamingConvention(typeof(When_deferring_to_non_local.Endpoint))
+            || endpointName == TestingConventions.Conventions.EndpointNamingConvention(typeof(When_deferring_a_message.Endpoint)))
         {
             Assert.Inconclusive("Flaky test that relies on time and cannot be executed.");
         }

--- a/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
@@ -91,6 +91,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                     extensions.NamespacePartitioning().AddNamespace("source", connectionString);
                     extensions.NamespaceRouting().AddNamespace("target", targetConnectionString);
                 }
+
                 var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
                 if (topology == "ForwardingTopology")
                 {
@@ -144,6 +145,16 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                     extensions.NamespacePartitioning().AddNamespace("source", connectionString);
                     var targetNamespace = extensions.NamespaceRouting().AddNamespace("target", targetConnectionString);
                     targetNamespace.RegisteredEndpoints.Add(Conventions.EndpointNamingConvention(typeof(EndpointInTargetNamespace)));
+                }
+
+                var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
+                if (topology == "ForwardingTopology")
+                {
+                    extensions.UseForwardingTopology();
+                }
+                else
+                {
+                    extensions.UseEndpointOrientedTopology();
                 }
             };
 

--- a/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
@@ -36,6 +36,16 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                     extensions.NamespacePartitioning().AddNamespace("source", connectionString);
                     extensions.NamespaceRouting().AddNamespace("target", targetConnectionString);
                 }
+
+                var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
+                if (topology == "ForwardingTopology")
+                {
+                    extensions.UseForwardingTopology();
+                }
+                else
+                {
+                    extensions.UseEndpointOrientedTopology();
+                }
             };
 
             runSettings.Set("AzureServiceBus.AcceptanceTests.TransportConfigContext", ctx);
@@ -80,6 +90,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                 {
                     extensions.NamespacePartitioning().AddNamespace("source", connectionString);
                     extensions.NamespaceRouting().AddNamespace("target", targetConnectionString);
+                }
+                var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
+                if (topology == "ForwardingTopology")
+                {
+                    extensions.UseForwardingTopology();
+                }
+                else
+                {
+                    extensions.UseEndpointOrientedTopology();
                 }
             };
 

--- a/src/AcceptanceTests/Routing/When_subscribing_outside_the_endpoint_oriented_topology.cs
+++ b/src/AcceptanceTests/Routing/When_subscribing_outside_the_endpoint_oriented_topology.cs
@@ -4,12 +4,10 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Support;
-    using AzureServiceBus;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using Features;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
-    using Settings;
     using NUnit.Framework;
 
     public class When_subscribing_outside_the_endpoint_oriented_topology : NServiceBusAcceptanceTest
@@ -63,7 +61,7 @@
 
                     c.ReceiverSubscribedToEvents = true;
                 }))
-                .Done(ctx => ctx.SubscriberGotTheEvent || !ctx.IsEndpointOrientedTopology)
+                .Done(ctx => ctx.SubscriberGotTheEvent)
                 .Run(runSettings);
 
             Assert.That(context.SubscriberGotTheEvent, Is.True, "Should receive the event");
@@ -72,7 +70,6 @@
         public class Context : ScenarioContext
         {
             public bool SubscriberGotTheEvent { get; set; }
-            public bool IsEndpointOrientedTopology { get; set; }
             public bool ReceiverSubscribedToEvents { get; set; }
         }
 
@@ -82,41 +79,7 @@
 
             public Publisher()
             {
-                EndpointSetup<DefaultPublisher>(endpointConfiguration =>
-                {
-                    endpointConfiguration.EnableFeature<DetermineWhatTopologyIsUsed>();
-                });
-            }
-
-            class DetermineWhatTopologyIsUsed : Feature
-            {
-                protected override void Setup(FeatureConfigurationContext context)
-                {
-                    context.RegisterStartupTask(builder => new TaskToDetermineCurrentTopology(builder.Build<Context>(), builder.Build<ReadOnlySettings>()));
-                }
-            }
-
-            class TaskToDetermineCurrentTopology : FeatureStartupTask
-            {
-                Context context;
-                ReadOnlySettings settings;
-
-                public TaskToDetermineCurrentTopology(Context context, ReadOnlySettings settings)
-                {
-                    this.context = context;
-                    this.settings = settings;
-                }
-
-                protected override Task OnStart(IMessageSession session)
-                {
-                    context.IsEndpointOrientedTopology = settings.Get<string>("AzureServiceBus.AcceptanceTests.UsedTopology") == "EndpointOrientedTopology";
-                    return TaskEx.Completed;
-                }
-
-                protected override Task OnStop(IMessageSession session)
-                {
-                    return TaskEx.Completed;
-                }
+                EndpointSetup<DefaultPublisher>();
             }
         }
 

--- a/src/AcceptanceTests/Routing/When_subscribing_outside_the_endpoint_oriented_topology.cs
+++ b/src/AcceptanceTests/Routing/When_subscribing_outside_the_endpoint_oriented_topology.cs
@@ -1,0 +1,164 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Support;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using Features;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using Settings;
+    using NUnit.Framework;
+
+    public class When_subscribing_outside_the_endpoint_oriented_topology : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_event()
+        {
+            var runSettings = new RunSettings();
+            runSettings.TestExecutionTimeout = TimeSpan.FromMinutes(1);
+
+            var config = new AzureServiceBusTransportConfigContext();
+            config.Callback = (endpointName, extensions) =>
+            {
+                var publisherConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+                var subscriberConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+                if (endpointName == "SubscribingOutsideTheEndpointOrientedTopology.Subscriber")
+                {
+
+                    extensions.NamespacePartitioning().AddNamespace("subscriberNamespace", subscriberConnectionString);
+                    extensions.NamespaceRouting()
+                                    .AddNamespace("publisherNamespace", publisherConnectionString)
+                                    .RegisteredEndpoints.Add(AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
+                }
+                else
+                {
+                    extensions.NamespacePartitioning().AddNamespace("publisherNamespace", publisherConnectionString);
+                }
+
+                var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
+                if (topology == "ForwardingTopology")
+                {
+                    extensions.UseForwardingTopology();
+                }
+                else
+                {
+                    if (endpointName == "SubscribingOutsideTheEndpointOrientedTopology.Subscriber")
+                    {
+                        extensions.UseEndpointOrientedTopology()
+                            .RegisterPublisher(typeof(MyEvent), AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
+                    }
+                    else
+                    {
+                        extensions.UseEndpointOrientedTopology();
+                    }
+                }
+            };
+
+            runSettings.Set("AzureServiceBus.AcceptanceTests.TransportConfigContext", config);
+
+            var context = await Scenario.Define<Context>()
+                // Publish event only when it was signaled that events went out
+                .WithEndpoint<Publisher>(b => b.When(c => c.ReceiverSubscribedToEvents, async bus =>
+                {
+                    await bus.Publish<MyEvent>();
+                }))
+                .WithEndpoint<Subscriber>(b => b.When(async (session, c) =>
+                {
+                    await session.Subscribe<MyEvent>();
+
+                    c.ReceiverSubscribedToEvents = true;
+                }))
+                .Done(ctx => ctx.SubscriberGotTheEvent || !ctx.IsEndpointOrientedTopology)
+                .Run(runSettings);
+
+            if (!context.IsEndpointOrientedTopology)
+            {
+                Assert.Inconclusive("The test is designed for EndpointOrientedTopology only.");
+            }
+
+            Assert.That(context.SubscriberGotTheEvent, Is.True, "Should receive the event");
+         }
+
+        public class Context : ScenarioContext
+        {
+            public bool SubscriberGotTheEvent { get; set; }
+            public bool IsEndpointOrientedTopology { get; set; }
+            public bool ReceiverSubscribedToEvents { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Context Context { get; set; }
+
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(endpointConfiguration =>
+                {
+                    endpointConfiguration.EnableFeature<DetermineWhatTopologyIsUsed>();
+                });
+            }
+
+            class DetermineWhatTopologyIsUsed : Feature
+            {
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.RegisterStartupTask(builder => new TaskToDetermineCurrentTopology(builder.Build<Context>(), builder.Build<ReadOnlySettings>()));
+                }
+            }
+
+            class TaskToDetermineCurrentTopology : FeatureStartupTask
+            {
+                Context context;
+                ReadOnlySettings settings;
+
+                public TaskToDetermineCurrentTopology(Context context, ReadOnlySettings settings)
+                {
+                    this.context = context;
+                    this.settings = settings;
+                }
+
+                protected override Task OnStart(IMessageSession session)
+                {
+                    context.IsEndpointOrientedTopology = settings.Get<string>("AzureServiceBus.AcceptanceTests.UsedTopology") == "EndpointOrientedTopology";
+                    return TaskEx.Completed;
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(endpointConfiguration =>
+                {
+                    endpointConfiguration.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    Context.SubscriberGotTheEvent =  true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public interface MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/Routing/When_using_single_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_using_single_namespace.cs
@@ -25,6 +25,16 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
                 var connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
                 extensions.ConnectionString(connectionString);
                 extensions.UseNamespaceAliasesInsteadOfConnectionStrings();
+
+                var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
+                if (topology == "ForwardingTopology")
+                {
+                    extensions.UseForwardingTopology();
+                }
+                else
+                {
+                    extensions.UseEndpointOrientedTopology();
+                }
             };
 
             runSettings.Set("AzureServiceBus.AcceptanceTests.TransportConfigContext", ctx);

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -234,7 +234,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                             Path = subscriptionNameV6,
                             Metadata = new SubscriptionMetadataInternal
                             {
-                                Description = endpointName + " subscribed to " + eventType.FullName,
+                                Description = originalEndpointName + " subscribed to " + eventType.FullName,
                                 SubscriptionNameBasedOnEventWithNamespace = subscriptionName
                             },
                             BrokerSideFilter = new SqlSubscriptionFilter(eventType),

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -214,7 +214,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 var topicPath = publisher + ".events";
                 var path = addressingLogic.Apply(topicPath, EntityType.Topic).Name;
 
-                var destinationsOutsideTopology = namespaceConfigurations.Where(c => c.RegisteredEndpoints.Contains(publisher)).ToList();
+                var destinationsOutsideTopology = namespaceConfigurations.Where(c => c.RegisteredEndpoints.Contains(publisher, StringComparer.OrdinalIgnoreCase)).ToList();
                 if (destinationsOutsideTopology.Any())
                 {
                     topics.AddRange(destinationsOutsideTopology.Select(ns => new EntityInfoInternal


### PR DESCRIPTION
This PR fixes cross namespace subscriptions in the endpoint oriented topology, https://github.com/Particular/NServiceBus.AzureServiceBus/issues/584

It builds on the new api, https://github.com/Particular/NServiceBus.AzureServiceBus/pull/622, that allows to register an endpoint in a namespace outside the topology using

```
extensions.NamespaceRouting()
        .AddNamespace("publisherNamespace", publisherConnectionString)
        .RegisteredEndpoints.Add(AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
```

and takes this info into account when creating subscriptions.

A test, `When_subscribing_outside_the_endpoint_oriented_topology`, was added to proof that it works

I had to change the ATT's a little bit as the configure class did overwrite whatever topology was set in the configuration callback, that's why a few other tests have slightly changed as well

**TODO**
- [ ] documentation