### PR TITLE
Cleanup test to remove all queues and topics

### DIFF
--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -4,9 +4,9 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus;
-    using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NUnit.Framework;
+    using Utils;
 
     public class Cleaner : NServiceBusAcceptanceTest
     {
@@ -37,9 +37,9 @@
                     .ConfigureAwait(false);
             }
             catch (Exception exception)
-                when (usedRetryAttempts < maxRetryAttempts && (exception is TimeoutException || exception is MessagingCommunicationException || exception is ServerBusyException))
+                when (usedRetryAttempts < maxRetryAttempts && (exception is TimeoutException || exception.IsTransientException()))
             {
-                TestContext.WriteLine($"Attempt to delete '{entityPath}' has failed. Trying attempt {usedRetryAttempts + 2}/{maxRetryAttempts} in 5 seconds.");
+                TestContext.WriteLine($"Attempt to delete '{entityPath}' has failed. Retrying attempt {usedRetryAttempts + 1}/{maxRetryAttempts} in 5 seconds.");
                 await Task.Delay(5000)
                     .ConfigureAwait(false);
                 await TryWithRetries(entityPath, task, maxRetryAttempts, usedRetryAttempts + 1)

--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -23,8 +23,8 @@
                 .ConfigureAwait(false);
 
             const int maxRetryAttempts = 5;
-            var deleteQueues = queryQueues.Result.Select(queueDescription => TryWithRetries(queueDescription.Path, namespaceManager.DeleteQueueAsync(queueDescription.Path), maxRetryAttempts));
-            var deleteTopics = queryTopics.Result.Select(topicDescription => TryWithRetries(topicDescription.Path, namespaceManager.DeleteTopicAsync(topicDescription.Path), maxRetryAttempts));
+            var deleteQueues = (await queryQueues).Select(queueDescription => TryWithRetries(queueDescription.Path, namespaceManager.DeleteQueueAsync(queueDescription.Path), maxRetryAttempts));
+            var deleteTopics = (await queryTopics).Select(topicDescription => TryWithRetries(topicDescription.Path, namespaceManager.DeleteTopicAsync(topicDescription.Path), maxRetryAttempts));
 
             await Task.WhenAll(deleteQueues.Concat(deleteTopics))
                 .ConfigureAwait(false);

--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using Logging;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
@@ -40,7 +39,7 @@
             catch (Exception exception)
                 when (usedRetryAttempts < maxRetryAttempts && (exception is TimeoutException || exception is MessagingCommunicationException || exception is ServerBusyException))
             {
-                logger.Info($"Attempt to delete '{entityPath}' has failed. Trying attempt {usedRetryAttempts + 2}/{maxRetryAttempts} in 5 seconds.");
+                TestContext.WriteLine($"Attempt to delete '{entityPath}' has failed. Trying attempt {usedRetryAttempts + 2}/{maxRetryAttempts} in 5 seconds.");
                 await Task.Delay(5000)
                     .ConfigureAwait(false);
                 await TryWithRetries(entityPath, task, maxRetryAttempts, usedRetryAttempts + 1)
@@ -48,10 +47,8 @@
             }
             catch (Exception exception)
             {
-                logger.Info($"Failed to delete '{entityPath}' after {usedRetryAttempts}. Last received exception:\n{exception.Message}");
+                TestContext.WriteLine($"Failed to delete '{entityPath}' after {usedRetryAttempts}. Last received exception:\n{exception.Message}");
             }
         }
-
-        static ILog logger = LogManager.GetLogger(typeof(Cleaner));
     }
 }

--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -1,0 +1,28 @@
+﻿namespace NServiceBus.AzureServiceBus.AcceptanceTests.Infrastructure
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.ServiceBus;
+    using NUnit.Framework;
+
+    public class Cleaner
+    {
+        [Test, Explicit("Intended to be executed explicitly to delete all queues and topics.")]
+        [Category("Cleanup")]
+        public async Task DeleteEntities()
+        {
+            var namespaceManager = NamespaceManager.CreateFromConnectionString(TestUtility.GetDefaultConnectionString());
+
+            var queryQueues = namespaceManager.GetQueuesAsync();
+            var queryTopics = namespaceManager.GetTopicsAsync();
+            await Task.WhenAll(queryQueues, queryTopics)
+                .ConfigureAwait(false);
+
+            var deleteQueues = queryQueues.Result.Select(queueDescription => namespaceManager.DeleteQueueAsync(queueDescription.Path));
+            var deleteTopics = queryTopics.Result.Select(topicDescription => namespaceManager.DeleteTopicAsync(topicDescription.Path));
+
+            await Task.WhenAll(deleteQueues.Concat(deleteTopics))
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -1,8 +1,11 @@
 ﻿namespace NServiceBus.AzureServiceBus.AcceptanceTests.Infrastructure
 {
+    using System;
     using System.Linq;
     using System.Threading.Tasks;
+    using Logging;
     using Microsoft.ServiceBus;
+    using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NUnit.Framework;
 
@@ -22,8 +25,32 @@
             var deleteQueues = queryQueues.Result.Select(queueDescription => namespaceManager.DeleteQueueAsync(queueDescription.Path));
             var deleteTopics = queryTopics.Result.Select(topicDescription => namespaceManager.DeleteTopicAsync(topicDescription.Path));
 
-            await Task.WhenAll(deleteQueues.Concat(deleteTopics))
+            await TryWithRetries(Task.WhenAll(deleteQueues.Concat(deleteTopics)), 5)
                 .ConfigureAwait(false);
         }
+
+        static async Task TryWithRetries(Task task, int maxRetryAttempts, int usedRetryAttempts = 0)
+        {
+            try
+            {
+                await task
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (usedRetryAttempts < maxRetryAttempts && (exception is TimeoutException || exception is MessagingCommunicationException || exception is ServerBusyException))
+            {
+                logger.InfoFormat("Attempt to delete all queues and topics has failed. Trying attempt {0}/{1} in 5 seconds.", usedRetryAttempts + 2, maxRetryAttempts);
+                await Task.Delay(5000)
+                    .ConfigureAwait(false);
+                await TryWithRetries(task, maxRetryAttempts, usedRetryAttempts + 1)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                logger.InfoFormat($"Failed to delete all queues and topics after {0}. Last received exception:\n{1}", usedRetryAttempts, exception.Message);
+            }
+        }
+
+        static ILog logger = LogManager.GetLogger(typeof(Cleaner));
     }
 }

--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -3,9 +3,10 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.ServiceBus;
+    using NServiceBus.AcceptanceTests;
     using NUnit.Framework;
 
-    public class Cleaner
+    public class Cleaner : NServiceBusAcceptanceTest
     {
         [Test, Explicit("Intended to be executed explicitly to delete all queues and topics.")]
         [Category("Cleanup")]

--- a/src/AcceptanceTests/Infrastructure/Cleaner.cs
+++ b/src/AcceptanceTests/Infrastructure/Cleaner.cs
@@ -25,7 +25,10 @@
             var deleteQueues = (await queryQueues).Select(queueDescription => TryWithRetries(queueDescription.Path, namespaceManager.DeleteQueueAsync(queueDescription.Path), maxRetryAttempts));
             var deleteTopics = (await queryTopics).Select(topicDescription => TryWithRetries(topicDescription.Path, namespaceManager.DeleteTopicAsync(topicDescription.Path), maxRetryAttempts));
 
-            await Task.WhenAll(deleteQueues.Concat(deleteTopics))
+            await Task.WhenAll(deleteQueues)
+                .ConfigureAwait(false);
+            
+            await Task.WhenAll(deleteTopics)
                 .ConfigureAwait(false);
         }
 

--- a/src/AcceptanceTests/Infrastructure/TestUtility.cs
+++ b/src/AcceptanceTests/Infrastructure/TestUtility.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.AzureServiceBus.AcceptanceTests.Infrastructure
+{
+    using System;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+
+    static class TestUtility
+    {
+        public static string GetDefaultConnectionString()
+        {
+            var environmentVariableName = $"{nameof(AzureServiceBusTransport)}.ConnectionString";
+            var connectionString = EnvironmentHelper.GetEnvironmentVariable(environmentVariableName);
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new Exception($"Oh no! Could not find an environment variable '{environmentVariableName}'.");
+            }
+            return connectionString;
+        }
+    }
+}

--- a/src/AcceptanceTests/Infrastructure/TestUtility.cs
+++ b/src/AcceptanceTests/Infrastructure/TestUtility.cs
@@ -5,15 +5,41 @@
 
     static class TestUtility
     {
-        public static string GetDefaultConnectionString()
+        static string connectionString;
+        static string fallbackConnectionString;
+
+        public static string DefaultConnectionString
         {
-            var environmentVariableName = $"{nameof(AzureServiceBusTransport)}.ConnectionString";
-            var connectionString = EnvironmentHelper.GetEnvironmentVariable(environmentVariableName);
-            if (string.IsNullOrEmpty(connectionString))
+            get
             {
-                throw new Exception($"Oh no! Could not find an environment variable '{environmentVariableName}'.");
+                if (string.IsNullOrEmpty(connectionString))
+                {
+                    var environmentVariableName = $"{nameof(AzureServiceBusTransport)}.ConnectionString";
+                    connectionString = EnvironmentHelper.GetEnvironmentVariable(environmentVariableName);
+                    if (string.IsNullOrEmpty(connectionString))
+                    {
+                        throw new Exception($"Oh no! Could not find an environment variable '{environmentVariableName}'.");
+                    }
+                }
+                return connectionString;
             }
-            return connectionString;
+        }
+
+        public static string FallbackConnectionString
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(fallbackConnectionString))
+                {
+                    var environmentVariableName = $"{nameof(AzureServiceBusTransport)}.ConnectionString";
+                    fallbackConnectionString = EnvironmentHelper.GetEnvironmentVariable(environmentVariableName);
+                    if (string.IsNullOrEmpty(fallbackConnectionString))
+                    {
+                        throw new Exception($"Oh no! Could not find an environment variable '{environmentVariableName}'.");
+                    }
+                }
+                return fallbackConnectionString;
+            }
         }
     }
 }


### PR DESCRIPTION
Connects to #634 
Fixes #634 

Adding a single `explicit` test that should be triggered from TC build configuration step at the **after** ATTs step is done, to remove all queues and topics.

## Current setup

### ATT project

An explicit test called `DeleteEntities()` that asynchronously deletes all queues and topics on the main namespace with up to 5 retries per each entity.

### TC

![image](https://user-images.githubusercontent.com/1309622/31104085-06391b2c-a798-11e7-87cc-353d6f58b37a.png)

1 - Additional (last) build step for EndpointOriented and Forwarding topology.
2 - Step is set to always execute .
3 - Cleaner is explicitly executed by selecting it using a filter ` --where "name==DeleteEntities && cat==Cleanup"`
4 - Assembly for Cleaner test is always `AcceptanceTests.dll`