### PR TITLE
Clear separation of queues and topic creation

### DIFF
--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -91,7 +91,12 @@
                 };
             }
 
-            public TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress)
+            public TopologySectionInternal DetermineTopicsToCreate(string localAddress)
+            {
+                return new TopologySectionInternal();
+            }
+
+            public TopologySectionInternal DetermineQueuesToCreate(QueueBindings queueBindings, string localAddress)
             {
                 return new TopologySectionInternal();
             }

--- a/src/Tests/Sending/When_batching_TransportOperations.cs
+++ b/src/Tests/Sending/When_batching_TransportOperations.cs
@@ -136,7 +136,12 @@
             throw new NotImplementedException();
         }
 
-        public TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress)
+        public TopologySectionInternal DetermineTopicsToCreate(string localAddress)
+        {
+            throw new NotImplementedException();
+        }
+
+        public TopologySectionInternal DetermineQueuesToCreate(QueueBindings queueBindings, string localAddress)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -20,15 +20,16 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
+
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
+            var definition = sectionManager.DetermineQueuesToCreate(new QueueBindings(), "sales");
 
             // ReSharper disable once RedundantArgumentDefaultValue
             var namespaceInfo = new RuntimeNamespaceInfo(Name, Connectionstring);
@@ -40,15 +41,16 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
+
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
+            var definition = sectionManager.DetermineQueuesToCreate(new QueueBindings(), "sales");
 
             Assert.AreEqual(1, definition.Entities.Count(ei => ei.Path == "sales" && ei.Type == EntityType.Queue && ei.Namespace.ConnectionString == Connectionstring));
         }
@@ -59,15 +61,16 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+            settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
 
-            settings.SetDefault("NServiceBus.Routing.EndpointName", endpointName);
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            Assert.Throws<Exception>(() => sectionManager.DetermineResourcesToCreate(new QueueBindings(), endpointName), "Was expected to fail: " + reasonToFail);
+            Assert.Throws<Exception>(() => sectionManager.DetermineQueuesToCreate(new QueueBindings(), endpointName), "Was expected to fail: " + reasonToFail);
         }
 
         [Test]
@@ -75,15 +78,17 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
+
             extensions.NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            var definition = sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineQueuesToCreate(new QueueBindings(), "sales");
+            var definition = sectionManager.DetermineTopicsToCreate("sales");
 
             var result = definition.Entities.Where(ei => ei.Type == EntityType.Topic && ei.Namespace.ConnectionString == Connectionstring && ei.Path.StartsWith("bundle-"));
 
@@ -96,15 +101,17 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
+
             extensions.UseForwardingTopology().NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineQueuesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineTopicsToCreate("sales");
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
@@ -116,15 +123,17 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
+
             extensions.UseForwardingTopology().NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineQueuesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineTopicsToCreate("sales");
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 
@@ -136,15 +145,17 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
         {
             var settings = DefaultConfigurationValues.Apply(SettingsHolderFactory.BuildWithSerializer());
             var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
-
             settings.SetDefault("NServiceBus.Routing.EndpointName", "sales");
+            settings.SetDefault("NServiceBus.SharedQueue", "sales");
+
             extensions.UseForwardingTopology().NamespacePartitioning().AddNamespace(Name, Connectionstring);
 
             var topology = new ForwardingTransportInfrastructure(settings);
             await topology.Start();
 
             var sectionManager = topology.topologyManager;
-            sectionManager.DetermineResourcesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineQueuesToCreate(new QueueBindings(), "sales");
+            sectionManager.DetermineTopicsToCreate("sales");
 
             var section = sectionManager.DetermineResourcesToSubscribeTo(typeof(SomeTestEvent), "sales");
 

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -72,10 +72,13 @@
             topologyOperator = new TopologyOperator(messageReceiverLifeCycleManager, new BrokeredMessagesToIncomingMessagesConverter(Settings, new DefaultConnectionStringToNamespaceAliasMapper(Settings)), Settings);
         }
 
-        public override Task Start()
+        public override async Task Start()
         {
             InitializeIfNecessary();
-            return topologyManager.Initialize();
+
+            await topologyManager.Initialize().ConfigureAwait(false);
+            var topicsToCreate = topologyManager.DetermineTopicsToCreate(Settings.LocalAddress());
+            await topologyCreator.Create(topicsToCreate).ConfigureAwait(false);
         }
 
         public override Task Stop()

--- a/src/Transport/Seam/TransportResourcesCreator.cs
+++ b/src/Transport/Seam/TransportResourcesCreator.cs
@@ -21,8 +21,8 @@ namespace NServiceBus.Transport.AzureServiceBus
             await topologyCreator.AssertManagedRights().ConfigureAwait(false);
 
             await sections.Initialize().ConfigureAwait(false);
-            var receiveResources = sections.DetermineResourcesToCreate(queueBindings, localAddress);
-            await topologyCreator.Create(receiveResources).ConfigureAwait(false);
+            var queuesToCreate = sections.DetermineQueuesToCreate(queueBindings, localAddress);
+            await topologyCreator.Create(queuesToCreate).ConfigureAwait(false);
 
             resourcesCreated = true;
         }

--- a/src/Transport/Topology/ITopologySectionManager.cs
+++ b/src/Transport/Topology/ITopologySectionManager.cs
@@ -8,7 +8,10 @@
         Func<Task> Initialize { get; set; } 
 
         TopologySectionInternal DetermineReceiveResources(string inputQueue);
-        TopologySectionInternal DetermineResourcesToCreate(QueueBindings queueBindings, string localAddress);
+
+        TopologySectionInternal DetermineTopicsToCreate(string localAddress);
+
+        TopologySectionInternal DetermineQueuesToCreate(QueueBindings queueBindings, string localAddress);
 
         TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress);
         TopologySectionInternal DetermineSendDestination(string destination);

--- a/src/Transport/Topology/Topologies/EndpointOrientedTransportInfrastructure.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTransportInfrastructure.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         {
             var conventions = Settings.Get<Conventions>();
             var publishersConfiguration = new PublishersConfiguration(conventions, Settings);
-            var endpointName = SettingsExtensions.EndpointName(Settings);
+            var endpointName = Settings.EndpointName();
 
             return new EndpointOrientedTopologySectionManager(defaultAlias, @namespaces, endpointName, publishersConfiguration, partitioning, addressing);
         }


### PR DESCRIPTION
Closes #625

Fixes SendOnly endpoint publish

Assuming manage rights:
- Queue creation happens during ressource creation phase
- Topic creation happens when the transport is started