### PR TITLE
Guard.AgainstUnsetSerializerSetting() should not be invoked during defaults setup

### DIFF
--- a/src/Tests/Configuration/When_using_default_configuration.cs
+++ b/src/Tests/Configuration/When_using_default_configuration.cs
@@ -1,10 +1,8 @@
 ﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 {
-    using System;
     using AzureServiceBus;
     using Transport.AzureServiceBus;
     using NUnit.Framework;
-    using Settings;
 
     [TestFixture]
     [Category("AzureServiceBus")]
@@ -29,16 +27,6 @@
             DefaultConfigurationValues.Apply(settings);
 
             Assert.That(settings.Get<TopologySettings>().QueueSettings.MaxDeliveryCount, Is.EqualTo(10));
-        }
-
-        [Test]
-        public void Should_throw_exception_when_no_serializer_was_set()
-        {
-            var settings = new SettingsHolder();
-
-            var exception = Assert.Throws<Exception>(() => DefaultConfigurationValues.Apply(settings));
-
-            Assert.IsTrue(exception.Message.StartsWith("Use 'endpointConfiguration.UseSerialization<T>();'"), $"Incorrect exception message: {exception.Message}");
         }
     }
 }

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -52,7 +52,9 @@
             {
                 return;
             }
-            
+
+            Guard.AgainstUnsetSerializerSetting(Settings);
+
             defaultNamespaceAlias = Settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias);
             namespaceConfigurations = Settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
 

--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -10,8 +10,6 @@
     {
         public static SettingsHolder Apply(SettingsHolder settings)
         {
-            Guard.AgainstUnsetSerializerSetting(settings);
-
             settings.SetDefault<TopologySettings>(new TopologySettings());
 
             ApplyDefaultsForExtensibility(settings);


### PR DESCRIPTION
Connect to #654 
Fixes #654 

Don't check serializer when setting default values, defer at a later stage of the transport Start