### PR TITLE
fix for operation cancelled exception triggering concurrent dispose

### DIFF
--- a/src/AcceptanceTests/Cleaner.cs
+++ b/src/AcceptanceTests/Cleaner.cs
@@ -1,0 +1,93 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.ServiceBus;
+    using Microsoft.ServiceBus.Messaging;
+    using NServiceBus.AcceptanceTests;
+    using Logging;
+    using NUnit.Framework;
+
+    public class Cleaner : NServiceBusAcceptanceTest
+    {
+        static ILog logger = LogManager.GetLogger<Cleaner>();
+
+        [Test, Explicit("Intended to be executed explicitly to delete all queues and topics.")]
+        [Category("Cleanup")]
+        public async Task DeleteEntities()
+        {
+            var namespaceManager = NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value);
+            await DeleteEntities(namespaceManager);
+
+            namespaceManager = NamespaceManager.CreateFromConnectionString(AzureServiceBusConnectionString.Value);
+            await DeleteEntities(namespaceManager);
+        }
+
+        static async Task DeleteEntities(NamespaceManager namespaceManager)
+        {
+            var queryQueues = namespaceManager.GetQueuesAsync();
+            var queryTopics = namespaceManager.GetTopicsAsync();
+            await Task.WhenAll(queryQueues, queryTopics)
+                .ConfigureAwait(false);
+
+            const int maxRetryAttempts = 5;
+            var deleteQueues = (await queryQueues).Select(queueDescription => TryWithRetries(queueDescription.Path, namespaceManager.DeleteQueueAsync(queueDescription.Path), maxRetryAttempts));
+
+            await Task.WhenAll(deleteQueues)
+                .ConfigureAwait(false);
+
+            var deleteTopics = (await queryTopics).Select(topicDescription => TryWithRetries(topicDescription.Path, namespaceManager.DeleteTopicAsync(topicDescription.Path), maxRetryAttempts));
+            await Task.WhenAll(deleteTopics)
+                .ConfigureAwait(false);
+        }
+
+        static async Task TryWithRetries(string entityPath, Task task, int maxRetryAttempts, int usedRetryAttempts = 0)
+        {
+            try
+            {
+                await task
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (usedRetryAttempts < maxRetryAttempts && (exception is TimeoutException || exception.IsTransientException()))
+            {
+                logger.Info($"Attempt to delete '{entityPath}' has failed. Retrying attempt {usedRetryAttempts + 1}/{maxRetryAttempts} in 5 seconds.");
+                await Task.Delay(5000)
+                    .ConfigureAwait(false);
+                await TryWithRetries(entityPath, task, maxRetryAttempts, usedRetryAttempts + 1)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                logger.Info($"Failed to delete '{entityPath}' after {usedRetryAttempts}. Last received exception:\n{exception.Message}");
+            }
+        }
+    }
+
+    static class AzureServiceBusConnectionString
+    {
+        public static string Value
+        {
+            get
+            {
+                var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus.ConnectionString");
+                if (connectionString != null)
+                {
+                    return connectionString;
+                }
+
+                throw new InvalidOperationException("Failed to get a value from `AzureServiceBus.ConnectionString`. Please add it to your environment variables to run tests.");
+            }
+        }
+    }
+
+    static class ExceptionExtensions
+    {
+        public static bool IsTransientException(this Exception exception)
+        {
+            var messagingException = exception as MessagingException;
+            return messagingException?.IsTransient ?? (exception is TimeoutException || exception is OperationCanceledException);
+        }
+    }
+}

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -50,9 +50,8 @@
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.2.0\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -263,6 +262,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.2.0\Tx\When_receiving_with_the_default_settings.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.2.0\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.2.0\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="Cleaner.cs" />
     <Compile Include="ConfigureEndpointAzureServiceBusTransport.cs" />
     <Compile Include="Infrastructure\TestIndependenceBehavior.cs" />
     <Compile Include="Issues\When_publisher_and_subscriber_bundles_are_misconfigured.cs" />

--- a/src/AcceptanceTests/packages.config
+++ b/src/AcceptanceTests/packages.config
@@ -4,6 +4,6 @@
   <package id="NServiceBus" version="6.2.0" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.2.0" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="6.2.0" targetFramework="net452" />
-  <package id="NUnit" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -77,9 +77,8 @@
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.2.0\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net452" />
   <package id="NServiceBus" version="6.2.0" targetFramework="net452" />
-  <package id="NUnit" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/src/Transport/Utils/ExceptionExtensions.cs
+++ b/src/Transport/Utils/ExceptionExtensions.cs
@@ -9,7 +9,7 @@
         public static bool IsTransientException(this Exception exception)
         {
             var messagingException = exception as MessagingException;
-            return messagingException?.IsTransient ?? exception is TimeoutException;
+            return messagingException?.IsTransient ?? (exception is TimeoutException || exception is OperationCanceledException);
         }
     }
 }

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -36,9 +36,8 @@
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.2.0\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TransportTests/packages.config
+++ b/src/TransportTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="NServiceBus" version="6.2.0" targetFramework="net452" />
   <package id="NServiceBus.TransportTests.Sources" version="6.2.0" targetFramework="net452" />
-  <package id="NUnit" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Connects to #659

Backport of https://github.com/Particular/NServiceBus.AzureServiceBus/pull/658

Connects to https://github.com/Particular/NServiceBus.Azure/issues/319

## Who's affected

Anyone using NServiceBus.Azure.Transports.WindowsAzureServiceBus transport version 7 and experiencing exceptions during endpoints shutdown.

## Symptoms 

The circuit breaker might be implemented to shutdown the appdomain, which will cause a garbage collection. Message in flight handles by the transport call into the infrastructure at that point may cause the underlying SDK to attempt cleanup using objects which have already been disposed. As a result of that, endpoint logs exceptions and doesn't end cleanly.

## Original issue description

When an endpoint is stopping and exception is thrown, we check if exception is transient or not. If exception is not transient, the error callback is invoked. That will lead to a circuit breaker invocation.

The circuit breaker might be implemented to shutdown the appdomain, which will cause a garbage collection. If other code calls into the infrastructure at that point, e.g. call Close on the pump, it may cause the underlying SDK to attempt cleanup using objects which have already been disposed.

If exception is a `OperationCancelledException`, it should be treated as transient as well to avoid false circuit breaker invocation.