### PR TITLE
Connection string should not check for a specific domain name

### DIFF
--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -214,5 +214,16 @@
 
             Assert.AreEqual(hashCode1, hashCode2);
         }
+
+        [Test]
+        [TestCase("Endpoint=sb://namespacename.servicebus.windows.net;SharedAccessKeyName=name;SharedAccessKey=key")]
+        [TestCase("Endpoint=sb://namespacename.usgovcloudapi.net;SharedAccessKeyName=name;SharedAccessKey=key")]
+        [TestCase("Endpoint=sb://namespacename.servicebus.cloudapi.de;SharedAccessKeyName=name;SharedAccessKey=key")]
+        public void Should_be_able_to_parse_various_domain_names(string connectionStringString)
+        {
+            ConnectionStringInternal.TryParse(connectionStringString, out var connectionString);
+
+            Assert.AreEqual("namespacename", connectionString.NamespaceName);
+        }
     }
 }

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -104,7 +104,7 @@
 
         string value;
         static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
-        static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
+        static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).(?<domain>[A-Za-z0-9-.]+)/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
 
         static ConcurrentDictionary<string, Tuple<bool, ConnectionStringInternal>> _parsingResults = new ConcurrentDictionary<string, Tuple<bool, ConnectionStringInternal>>();
     }

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -104,7 +104,7 @@
 
         string value;
         static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
-        static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).(?<domain>[A-Za-z0-9-.]+)/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
+        static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9])\\.(?<domain>[A-Za-z0-9-.]+)/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
 
         static ConcurrentDictionary<string, Tuple<bool, ConnectionStringInternal>> _parsingResults = new ConcurrentDictionary<string, Tuple<bool, ConnectionStringInternal>>();
     }


### PR DESCRIPTION
Fixes #662

Do not constrain to a specific domain name.