### PR TITLE
Connection string should not check for a specific domain name

### DIFF
--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -117,7 +117,7 @@
         {
             var namespace1 = string.Format(Template, "namespace1", "RootManageSharedAccessKey", "YourSecret");
             var namespace2 = string.Format(Template, "namespace2", "RootManageSharedAccessKey", "YourSecret");
-            
+
             var connectionString1 = new ConnectionString(namespace1);
             var connectionString2 = new ConnectionString(namespace2);
 
@@ -220,6 +220,18 @@
             var hashCode2 = connectionString2.GetHashCode();
 
             Assert.AreEqual(hashCode1, hashCode2);
+        }
+
+        [Test]
+        [TestCase("Endpoint=sb://namespacename.servicebus.windows.net;SharedAccessKeyName=name;SharedAccessKey=key")]
+        [TestCase("Endpoint=sb://namespacename.usgovcloudapi.net;SharedAccessKeyName=name;SharedAccessKey=key")]
+        [TestCase("Endpoint=sb://namespacename.servicebus.cloudapi.de;SharedAccessKeyName=name;SharedAccessKey=key")]
+        public void Should_be_able_to_parse_various_domain_names(string connectionStringString)
+        {
+            ConnectionString connectionString;
+            ConnectionString.TryParse(connectionStringString, out connectionString);
+
+            Assert.AreEqual("namespacename", connectionString.NamespaceName);
         }
     }
 }

--- a/src/Transport/Topology/MetaModel/ConnectionString.cs
+++ b/src/Transport/Topology/MetaModel/ConnectionString.cs
@@ -8,7 +8,7 @@
     public class ConnectionString : IEquatable<ConnectionString>
     {
         static readonly string Sample = "Endpoint=sb://[namespace name].servicebus.windows.net;SharedAccessKeyName=[shared access key name];SharedAccessKey=[shared access key]";
-        static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9]).servicebus.windows.net/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
+        static string Pattern = "^Endpoint=sb://(?<namespaceName>[A-Za-z][A-Za-z0-9-]{4,48}[A-Za-z0-9])\\.(?<domain>[A-Za-z0-9-.]+)/?;SharedAccessKeyName=(?<sharedAccessPolicyName>[\\w\\W]+);SharedAccessKey=(?<sharedAccessPolicyValue>[\\w\\W]+)$";
 
         string value;
 


### PR DESCRIPTION
Related to #662 
Fixes #662

## Who's affected

Anyone using NServiceBus.Azure.Transports.WindowsAzureServiceBus transport version 7 and needs to connect to Azure Service Bus using domain other than `servicebus.windows.net`.

## Symptoms 

Exception is thrown.