### PR TITLE
Local address not available during tests

### DIFF
--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -40,7 +40,7 @@
                 return TaskEx.Completed;
             });
 
-            var pump = new MessagePump(fakeTopologyOperator, null, null, new FakeTopologyManager(), settings, TimeSpan.FromSeconds(1));
+            var pump = new MessagePump(fakeTopologyOperator, null, null, new FakeTopologyManager(), settings, "sales", TimeSpan.FromSeconds(1));
             await pump.Init(context => TaskEx.Completed, null, criticalError, new PushSettings("sales", "error", false, TransportTransactionMode.ReceiveOnly));
 
             pump.Start(new PushRuntimeSettings(1));

--- a/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
+++ b/src/Tests/Seam/When_purge_on_startup_is_enabled.cs
@@ -17,12 +17,12 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Seam
             settings.Set("NServiceBus.SharedQueue", "sales");
             DefaultConfigurationValues.Apply(settings);
 
-            var pump = new MessagePump(null, null, null, null, settings);
+            var pump = new MessagePump(null, null, null, null, settings, "sales");
             var criticalError = new CriticalError(ctx => TaskEx.Completed);
 
             const bool purgeOnStartup = true;
 
-            Assert.ThrowsAsync< InvalidOperationException> (async () => await pump.Init(context => TaskEx.Completed, null, criticalError, new PushSettings("sales", "error", purgeOnStartup, TransportTransactionMode.SendsAtomicWithReceive)));
+            Assert.ThrowsAsync<InvalidOperationException> (async () => await pump.Init(context => TaskEx.Completed, null, criticalError, new PushSettings("sales", "error", purgeOnStartup, TransportTransactionMode.SendsAtomicWithReceive)));
         }
     }
 }

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -55,11 +55,21 @@
 
             Guard.AgainstUnsetSerializerSetting(Settings);
 
+            var sendOnly = Settings.GetOrDefault<bool>("Endpoint.SendOnly");
+            var localAddressForSendOnlyEndpoint = ToTransportAddress(LogicalAddress.CreateLocalAddress(Settings.EndpointName(), new Dictionary<string, string>()));
+            try
+            {
+                localAddress = sendOnly ? localAddressForSendOnlyEndpoint : Settings.LocalAddress();
+            }
+            catch
+            {
+                // For tests other than Acceptance tests, LocalAddress() will throw
+                localAddress = localAddressForSendOnlyEndpoint;
+            }
+
             defaultNamespaceAlias = Settings.Get<string>(WellKnownConfigurationKeys.Topology.Addressing.DefaultNamespaceAlias);
             namespaceConfigurations = Settings.Get<NamespaceConfigurations>(WellKnownConfigurationKeys.Topology.Addressing.Namespaces);
             messageSizePaddingPercentage = Settings.Get<int>(WellKnownConfigurationKeys.Connectivity.MessageSenders.MessageSizePaddingPercentage);
-            var sendOnly = Settings.GetOrDefault<bool>("Endpoint.SendOnly");
-            localAddress = sendOnly ? ToTransportAddress(LogicalAddress.CreateLocalAddress(Settings.EndpointName(), new Dictionary<string, string>())) : Settings.LocalAddress();
 
             var partitioningStrategyType = (Type)Settings.Get(WellKnownConfigurationKeys.Topology.Addressing.Partitioning.Strategy);
             partitioningStrategy = partitioningStrategyType.CreateInstance<INamespacePartitioningStrategy>(Settings);

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -135,7 +135,7 @@
                 () =>
                 {
                     InitializeIfNecessary();
-                    return new MessagePump(topologyOperator, messageReceiverLifeCycleManager, new BrokeredMessagesToIncomingMessagesConverter(Settings, new DefaultConnectionStringToNamespaceAliasMapper(Settings)), topologyManager, Settings);
+                    return new MessagePump(topologyOperator, messageReceiverLifeCycleManager, new BrokeredMessagesToIncomingMessagesConverter(Settings, new DefaultConnectionStringToNamespaceAliasMapper(Settings)), topologyManager, Settings, localAddress);
                 },
                 () =>
                 {

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -10,18 +10,18 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class MessagePump : IPushMessages, IDisposable
     {
-        public MessagePump(IOperateTopologyInternal defaultOperator, MessageReceiverLifeCycleManager clientEntities, BrokeredMessagesToIncomingMessagesConverter brokeredMessageConverter, ITopologySectionManagerInternal topologySectionManager, ReadOnlySettings settings) : this(defaultOperator, clientEntities, brokeredMessageConverter, topologySectionManager, settings, TimeSpan.FromSeconds(30))
+        public MessagePump(IOperateTopologyInternal defaultOperator, MessageReceiverLifeCycleManager clientEntities, BrokeredMessagesToIncomingMessagesConverter brokeredMessageConverter, ITopologySectionManagerInternal topologySectionManager, ReadOnlySettings settings, string localAddress) : this(defaultOperator, clientEntities, brokeredMessageConverter, topologySectionManager, settings, localAddress, TimeSpan.FromSeconds(30))
         {
         }
 
-        internal MessagePump(IOperateTopologyInternal defaultOperator, MessageReceiverLifeCycleManager clientEntities, BrokeredMessagesToIncomingMessagesConverter brokeredMessageConverter, ITopologySectionManagerInternal topologySectionManager, ReadOnlySettings settings, TimeSpan timeToWaitBeforeTriggeringTheCircuitBreaker)
+        internal MessagePump(IOperateTopologyInternal defaultOperator, MessageReceiverLifeCycleManager clientEntities, BrokeredMessagesToIncomingMessagesConverter brokeredMessageConverter, ITopologySectionManagerInternal topologySectionManager, ReadOnlySettings settings, string localAddress, TimeSpan timeToWaitBeforeTriggeringTheCircuitBreaker)
         {
             this.defaultOperator = defaultOperator;
             this.clientEntities = clientEntities;
             this.brokeredMessageConverter = brokeredMessageConverter;
             this.topologySectionManager = topologySectionManager;
             this.settings = settings;
-            localAddress = settings.LocalAddress();
+            this.localAddress = localAddress;
             timeToWaitBeforeTriggering = timeToWaitBeforeTriggeringTheCircuitBreaker;
         }
 


### PR DESCRIPTION
Core has introduced a change in one of the latest beta builds.
The change was related to how `Setting.LocalAddress()` is working. The transport used to set directly settings value for the `SharedQueue`. The change in Core has introduced a concept of a "Receive Component" that cannot be manipulated by the transport directly, used by `Settings.LocalAddress()` logic, and is only instantiated when the receive infrastructure is created.

Tests that were executing w/o Core starting the receive infrastructure, would fail.
- Tests that exercise `MessagePump` directly
- Transport Tests
- Any other unit test that would run `AzureServiceBusTransportInfrastructure.Start()`

This change introduced the following:
1. MessagePump is no longer accessing `Settings.LocalAddress()` directly, and instead is injected with its value.
1. `AzureServiceBusTransportInfrastructure` introduced a [workaround](https://github.com/Particular/NServiceBus.AzureServiceBus/compare/local-address-not-available-during-tests?expand=1#diff-c6c4fbda098703835e5096381aa5bb8dR66) that would allow tests not to fail when `Settings.LocalAddress()` is not available (i.e. Core did not set up the "receive component").