### PR TITLE
Make TestApprover immune to shadow copying

### DIFF
--- a/src/Tests/TestApprover.cs
+++ b/src/Tests/TestApprover.cs
@@ -3,6 +3,7 @@
     using System.IO;
     using ApprovalTests;
     using ApprovalTests.Namers;
+    using NUnit.Framework;
 
     static class TestApprover
     {
@@ -15,15 +16,7 @@
 
         class ApprovalNamer : UnitTestFrameworkNamer
         {
-            public ApprovalNamer()
-            {
-                var assemblyPath = GetType().Assembly.Location;
-                var assemblyDir = Path.GetDirectoryName(assemblyPath);
-
-                SourcePath = Path.Combine(assemblyDir, "..", "..", "..", "ApprovalFiles");
-            }
-
-            public override string SourcePath { get; }
+            public override string SourcePath { get; } = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
         }
     }
 }


### PR DESCRIPTION
Simplifies the testing and makes `TestApprover` immune to shadow copying.