### PR TITLE
Namespace Partitioning Strategy can indicate whether caching of runtime namespaces is feasible

### DIFF
--- a/src/AcceptanceTests/Addressing/RoundRobinPartitioningFailoverStrategy.cs
+++ b/src/AcceptanceTests/Addressing/RoundRobinPartitioningFailoverStrategy.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Linq;
+    using Settings;
+    using Transport.AzureServiceBus;
+
+    public class RoundRobinPartitioningFailoverStrategy : INamespacePartitioningStrategy
+    {
+        public RoundRobinPartitioningFailoverStrategy(ReadOnlySettings settings)
+        {
+            if (!settings.TryGet("AzureServiceBus.Settings.Topology.Addressing.Namespaces",
+                out NamespaceConfigurations namespaces))
+            {
+                throw new ConfigurationErrorsException($"The '{nameof(RoundRobinPartitioningFailoverStrategy)}' strategy requires exactly two namespaces to be configured, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register the namespaces.");
+            }
+            var partitioningNamespaces = namespaces.Where(x => x.Purpose == NamespacePurpose.Partitioning).ToList();
+            if (partitioningNamespaces.Count != 2)
+            {
+                throw new ConfigurationErrorsException($"The '{nameof(RoundRobinPartitioningFailoverStrategy)}' strategy requires exactly two namespaces to be configured, please use {nameof(AzureServiceBusTransportExtensions.NamespacePartitioning)}().{nameof(AzureServiceBusNamespacePartitioningSettings.AddNamespace)}() to register the namespaces.");
+            }
+            this.namespaces = new CircularBuffer<RuntimeNamespaceInfo[]>(partitioningNamespaces.Count);
+            var first = namespaces.First();
+            var second = namespaces.Last();
+
+            this.namespaces.Put(new[]
+            {
+                new RuntimeNamespaceInfo(first.Alias, first.Connection, first.Purpose, NamespaceMode.Active),
+                new RuntimeNamespaceInfo(second.Alias, second.Connection, second.Purpose, NamespaceMode.Passive)
+            });
+            this.namespaces.Put(new[]
+            {
+                new RuntimeNamespaceInfo(first.Alias, first.Connection, first.Purpose, NamespaceMode.Passive),
+                new RuntimeNamespaceInfo(second.Alias, second.Connection, second.Purpose, NamespaceMode.Active)
+            });
+        }
+
+        public bool SendingNamespacesCanBeCached { get; } = false;
+
+        public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
+        {
+            return namespaces.Get();
+        }
+
+        readonly CircularBuffer<RuntimeNamespaceInfo[]> namespaces;
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
@@ -9,6 +9,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AzureServiceBus;
     using Configuration.AdvancedExtensibility;
     using Features;
+    using Microsoft.ServiceBus;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -32,8 +33,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
                         await bus.Publish(new MyEvent());
                         waitToSubscribe.SetResult(true);
                         await subscribed.Task;
-                        await bus.Publish(new MyEvent()); 
-                        await bus.Publish(new MyEvent()); 
+                        await bus.Publish(new MyEvent());
+                        await bus.Publish(new MyEvent());
                         await bus.Publish(new MyEvent());
                         await bus.Publish(new MyEvent());
                     });
@@ -70,6 +71,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             }, context.NamespaceNames);
         }
 
+        [TearDown]
+        public Task TearDown()
+        {
+            var namespaceManager1 = new NamespaceManagerAdapterInternal(NamespaceManager.CreateFromConnectionString(connectionString));
+            var namespaceManager2 = new NamespaceManagerAdapterInternal(NamespaceManager.CreateFromConnectionString(targetConnectionString));
+            var topic = $"{BundlePrefix}1";
+            return Task.WhenAll(namespaceManager1.DeleteTopic(topic), namespaceManager2.DeleteTopic(topic));
+        }
+        
         static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
         static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
         static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
@@ -1,0 +1,165 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using Configuration.AdvancedExtensibility;
+    using Features;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+    using Transport.AzureServiceBus;
+
+    public class When_publishing_message_with_custom_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_honor_strategy()
+        {
+            var waitToSubscribe = new TaskCompletionSource<bool>();
+            var subscribed = new TaskCompletionSource<bool>();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Publish(new MyEvent());
+                        waitToSubscribe.SetResult(true);
+                        await subscribed.Task;
+                        await bus.Publish(new MyEvent());
+                        await bus.Publish(new MyEvent());
+                        await bus.Publish(new MyEvent());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await waitToSubscribe.Task;
+                        await bus.Subscribe(typeof(MyEvent));
+                        subscribed.SetResult(true);
+                    });
+                    b.CustomConfig(c => { c.ConfigureAzureServiceBus().ConnectionString(connectionString); });
+                })
+                .WithEndpoint<TargetEndpoint>(b =>
+                {
+                    b.CustomConfig(c =>
+                    {
+                        c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString);
+                        c.EnableFeature<AutoSubscribe>();
+                    });
+                })
+                .Done(c => c.RequestsReceived == 4 && c.NamespaceNames.Count == 4)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1"
+            }, context.NamespaceNames);
+        }
+
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    if (TestSuiteConstraints.Current.IsForwardingTopology)
+                    {
+                        c.GetSettings().Set(WellKnownConfigurationKeys.Topology.Bundling.BundlePrefix, BundlePrefix);
+                    }
+
+                    transport.Topics().EnableFilteringMessagesBeforePublishing(true);
+
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<RoundRobinPartitioningFailoverStrategy>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                    partitioning.AddNamespace("namespace2", targetConnectionString);
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    if (TestSuiteConstraints.Current.IsForwardingTopology)
+                    {
+                        c.GetSettings().Set(WellKnownConfigurationKeys.Topology.Bundling.BundlePrefix, BundlePrefix);
+                    }
+
+                    transport.Topics().EnableFilteringMessagesBeforePublishing(true);
+                });
+            }
+
+            class MyRequestHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    await context.Reply(new MyResponse());
+                    Context.Received();
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+
+            long received;
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
@@ -40,6 +40,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
                 {
                     b.When(async (bus, c) =>
                     {
+                        await bus.Unsubscribe(typeof(MyEvent));
                         await waitToSubscribe.Task;
                         await bus.Subscribe(typeof(MyEvent));
                         subscribed.SetResult(true);

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
@@ -91,7 +91,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
         }
 
         static string connectionString = connectionString = TestUtility.DefaultConnectionString;
-        static string targetConnectionString = TestUtility.FallbackConnectionString; static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
+        static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
         static string TopicForwardingTopology = $"{BundlePrefix}1";
 
         public class Publisher : EndpointConfigurationBuilder

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using Configuration.AdvancedExtensibility;
     using Features;
     using Microsoft.ServiceBus;
+    using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -21,6 +22,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
         [Test]
         public async Task Should_honor_strategy()
         {
+            if (TestSuiteConstraints.Current.IsEndpointOrientedTopology)
+            {
+                var namespaceManager1 = NamespaceManager.CreateFromConnectionString(connectionString);
+                var namespaceManager2 = NamespaceManager.CreateFromConnectionString(targetConnectionString);
+
+                var topicEndpointOrientedTopology = $"{Conventions.EndpointNamingConvention(typeof(Publisher))}.events";
+                await Task.WhenAll(namespaceManager1.CreateTopicAsync(new TopicDescription(topicEndpointOrientedTopology)), namespaceManager2.CreateTopicAsync(new TopicDescription(topicEndpointOrientedTopology)));
+            }
+
             var waitToSubscribe = new TaskCompletionSource<bool>();
             var subscribed = new TaskCompletionSource<bool>();
 
@@ -74,15 +84,16 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
         [TearDown]
         public Task TearDown()
         {
-            var namespaceManager1 = new NamespaceManagerAdapterInternal(NamespaceManager.CreateFromConnectionString(connectionString));
-            var namespaceManager2 = new NamespaceManagerAdapterInternal(NamespaceManager.CreateFromConnectionString(targetConnectionString));
-            var topic = $"{BundlePrefix}1";
-            return Task.WhenAll(namespaceManager1.DeleteTopic(topic), namespaceManager2.DeleteTopic(topic));
+            var namespaceManager1 = NamespaceManager.CreateFromConnectionString(connectionString);
+            var namespaceManager2 = NamespaceManager.CreateFromConnectionString(targetConnectionString);
+            var topicEndpointOrientedTopology = $"{Conventions.EndpointNamingConvention(typeof(Publisher))}.events";
+            return Task.WhenAll(namespaceManager1.DeleteTopicAsync(TopicForwardingTopology), namespaceManager2.DeleteTopicAsync(TopicForwardingTopology), namespaceManager1.DeleteTopicAsync(topicEndpointOrientedTopology), namespaceManager2.DeleteTopicAsync(topicEndpointOrientedTopology));
         }
-        
+
         static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
         static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
         static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
+        static string TopicForwardingTopology = $"{BundlePrefix}1";
 
         public class Publisher : EndpointConfigurationBuilder
         {

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_custom_partitioning_strategy.cs
@@ -7,13 +7,13 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using Configuration.AdvancedExtensibility;
     using Features;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
     using Transport.AzureServiceBus;
 
@@ -90,9 +90,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             return Task.WhenAll(namespaceManager1.DeleteTopicAsync(TopicForwardingTopology), namespaceManager2.DeleteTopicAsync(TopicForwardingTopology), namespaceManager1.DeleteTopicAsync(topicEndpointOrientedTopology), namespaceManager2.DeleteTopicAsync(topicEndpointOrientedTopology));
         }
 
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
-        static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString; static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
         static string TopicForwardingTopology = $"{BundlePrefix}1";
 
         public class Publisher : EndpointConfigurationBuilder

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
-    using Configuration.AdvancedExtensibility;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -14,9 +13,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
 
     public class When_publishing_message_with_default_partitioning_strategy : NServiceBusAcceptanceTest
     {
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
-
         [Test]
         public async Task Should_send_to_one_namespace_only()
         {
@@ -39,9 +35,12 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             CollectionAssert.AreEquivalent(new[]
             {
                 $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
-                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1"
             }, context.NamespaceNames);
         }
+
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
 
 
         public class Publisher : EndpointConfigurationBuilder
@@ -74,7 +73,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             public TargetEndpoint()
             {
                 EndpointSetup<DefaultServer>(
-                    c => c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher)), 
+                    c => c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher)),
                     metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
@@ -100,7 +99,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
 
         class Context : ScenarioContext
         {
-            long received;
             public Context()
             {
                 NamespaceNames = new ConcurrentBag<string>();
@@ -114,6 +112,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             {
                 Interlocked.Increment(ref received);
             }
+
+            long received;
         }
     }
 }

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using Configuration.AdvancedExtensibility;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -19,6 +20,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
         [Test]
         public async Task Should_send_to_one_namespace_only()
         {
+            Requires.ForwardingTopology(); // for now until we find an option to conditionally register the publisher on just namespace1
+
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(b =>
                 {
@@ -70,7 +73,9 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
         {
             public TargetEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher)));
+                EndpointSetup<DefaultServer>(
+                    c => c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher)), 
+                    metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             class MyRequestHandler : IHandleMessages<MyEvent>

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
@@ -1,0 +1,114 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_publishing_message_with_default_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+        [Test]
+        public async Task Should_send_to_one_namespace_only()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Publish(new MyEvent());
+                        await bus.Publish(new MyEvent());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(connectionString)))
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString)))
+                .Done(c => c.RequestsReceived == 2 && c.NamespaceNames.Count == 2)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+            }, context.NamespaceNames);
+        }
+
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<SingleNamespacePartitioning>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher)));
+            }
+
+            class MyRequestHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    await context.Send(new MyResponse());
+                    Context.Received();
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class MyResponse : ICommand
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            long received;
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_default_partitioning_strategy.cs
@@ -6,11 +6,11 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_publishing_message_with_default_partitioning_strategy : NServiceBusAcceptanceTest
@@ -56,9 +56,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             return namespaceManager2.DeleteTopicAsync(topicEndpointOrientedTopology);
         }
 
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
-
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         public class Publisher : EndpointConfigurationBuilder
         {

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_failover_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_failover_partitioning_strategy.cs
@@ -1,0 +1,136 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using Configuration.AdvancedExtensibility;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+    using Transport.AzureServiceBus;
+
+    public class When_publishing_message_with_failover_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_failover_in_case_of_failure()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Publish(new MyEvent());
+                        await bus.Publish(new MyEvent());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString))) // target endpoint only available on failover namespace
+                .Done(c => c.RequestsReceived == 2 && c.NamespaceNames.Count == 2)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2"
+            }, context.NamespaceNames);
+        }
+
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    if (TestSuiteConstraints.Current.IsForwardingTopology)
+                    {
+                        c.GetSettings().Set(WellKnownConfigurationKeys.Topology.Bundling.BundlePrefix, BundlePrefix);
+                    }
+
+                    transport.Topics().EnableFilteringMessagesBeforePublishing(true);
+
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<FailOverNamespacePartitioning>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                    partitioning.AddNamespace("namespace2", targetConnectionString);
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    if (TestSuiteConstraints.Current.IsForwardingTopology)
+                    {
+                        c.GetSettings().Set(WellKnownConfigurationKeys.Topology.Bundling.BundlePrefix, BundlePrefix);
+                    }
+
+                    transport.Topics().EnableFilteringMessagesBeforePublishing(true);
+                });
+            }
+
+            class MyRequestHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    Context.Received();
+                    return context.Reply(new MyResponse());
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+
+            long received;
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_failover_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_failover_partitioning_strategy.cs
@@ -7,12 +7,12 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using Configuration.AdvancedExtensibility;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
     using Transport.AzureServiceBus;
 
@@ -59,8 +59,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             return Task.WhenAll(namespaceManager1.DeleteTopicAsync(TopicForwardingTopology), namespaceManager2.DeleteTopicAsync(TopicForwardingTopology), namespaceManager1.DeleteTopicAsync(topicEndpointOrientedTopology), namespaceManager2.DeleteTopicAsync(topicEndpointOrientedTopology));
         }
 
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
         static string BundlePrefix = $"bundle{DateTime.UtcNow.Ticks}-";
         static string TopicForwardingTopology = $"{BundlePrefix}1";
 

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_failover_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_failover_partitioning_strategy.cs
@@ -91,6 +91,10 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
                     }
 
                     transport.Topics().EnableFilteringMessagesBeforePublishing(true);
+
+                }, metadata =>
+                {
+                    metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher));
                 });
             }
 

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
@@ -6,11 +6,11 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_publishing_message_with_roundrobin_partitioning_strategy : NServiceBusAcceptanceTest
@@ -57,9 +57,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             return Task.WhenAll(namespaceManager1.DeleteTopicAsync(topicEndpointOrientedTopology), namespaceManager2.DeleteTopicAsync(topicEndpointOrientedTopology));
         }
 
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
-
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         public class Publisher : EndpointConfigurationBuilder
         {

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
@@ -75,6 +75,9 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher));
+                }, metadata =>
+                {
+                    metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher));
                 });
             }
 

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
@@ -13,9 +13,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
 
     public class When_publishing_message_with_roundrobin_partitioning_strategy : NServiceBusAcceptanceTest
     {
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
-
         [Test]
         public async Task Should_round_robin_between_active_namespaces()
         {
@@ -36,10 +33,13 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             CollectionAssert.AreEquivalent(new[]
             {
                 $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
-                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1"
             }, context.NamespaceNames);
         }
-      
+
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
 
         public class Publisher : EndpointConfigurationBuilder
         {
@@ -72,13 +72,7 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
         {
             public TargetEndpoint()
             {
-                EndpointSetup<DefaultServer>(c =>
-                {
-                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher));
-                }, metadata =>
-                {
-                    metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher));
-                });
+                EndpointSetup<DefaultServer>(c => { c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher)); }, metadata => { metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)); });
             }
 
             class MyRequestHandler : IHandleMessages<MyEvent>
@@ -103,7 +97,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
 
         class Context : ScenarioContext
         {
-            long received;
             public Context()
             {
                 NamespaceNames = new ConcurrentBag<string>();
@@ -117,6 +110,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             {
                 Interlocked.Increment(ref received);
             }
+
+            long received;
         }
     }
 }

--- a/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_publishing_message_with_roundrobin_partitioning_strategy.cs
@@ -1,0 +1,119 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_publishing_message_with_roundrobin_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+        [Test]
+        public async Task Should_round_robin_between_active_namespaces()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Publish(new MyEvent());
+                        await bus.Publish(new MyEvent());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(connectionString)))
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString)))
+                .Done(c => c.RequestsReceived == 2 && c.NamespaceNames.Count == 2)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+            }, context.NamespaceNames);
+        }
+      
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<RoundRobinNamespacePartitioning>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                    partitioning.AddNamespace("namespace2", targetConnectionString);
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyResponse), typeof(Publisher));
+                });
+            }
+
+            class MyRequestHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    await context.Send(new MyResponse());
+                    Context.Received();
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class MyResponse : ICommand
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            long received;
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_custom_partitioning_strategy.cs
@@ -1,0 +1,128 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_message_with_custom_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_honor_strategy()
+        {
+            // It is not possible to late start an endpoint therefore the switch over to namespace1 cannot be tested
+            // Testing that scenario is only possible with pub/sub because there it is possible to subscribe at a later point in time
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SourceEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Send(new MyRequest());
+                        await bus.Send(new MyRequest());
+                        await bus.Send(new MyRequest());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b =>
+                {
+                    b.CustomConfig(c =>
+                    {
+                        c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString);
+                    });
+                })
+                .Done(c => c.RequestsReceived == 3 && c.NamespaceNames.Count == 3)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+            }, context.NamespaceNames);
+        }
+
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+        public class SourceEndpoint : EndpointConfigurationBuilder
+        {
+            public SourceEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<RoundRobinPartitioningFailoverStrategy>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                    partitioning.AddNamespace("namespace2", targetConnectionString);
+
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyRequest), typeof(TargetEndpoint));
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    await context.Reply(new MyResponse());
+                    Context.Received();
+                }
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+
+            long received;
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_custom_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_custom_partitioning_strategy.cs
@@ -6,10 +6,10 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using Microsoft.ServiceBus;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
     using Transport.AzureServiceBus;
 
@@ -94,8 +94,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             }, context.NamespaceNames);
         }
 
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         public class SourceEndpoint : EndpointConfigurationBuilder
         {

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_default_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_default_partitioning_strategy.cs
@@ -1,0 +1,120 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_message_with_default_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+        [Test]
+        public async Task Should_send_to_one_namespace_only()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SourceEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Send(new MyRequest());
+                        await bus.Send(new MyRequest());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(connectionString)))
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString)))
+                .Done(c => c.RequestsReceived == 2 && c.NamespaceNames.Count == 2)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+            }, context.NamespaceNames);
+        }
+
+
+        public class SourceEndpoint : EndpointConfigurationBuilder
+        {
+            public SourceEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<SingleNamespacePartitioning>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyRequest), typeof(TargetEndpoint));
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    Context.Received();
+                    return context.Reply(new MyResponse());
+                }
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyRequestImpl : MyRequest
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            long received;
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_default_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_default_partitioning_strategy.cs
@@ -6,15 +6,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_sending_message_with_default_partitioning_strategy : NServiceBusAcceptanceTest
     {
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         [Test]
         public async Task Should_send_to_one_namespace_only()

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_failover_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_failover_partitioning_strategy.cs
@@ -6,9 +6,9 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_sending_message_with_failover_partitioning_strategy : NServiceBusAcceptanceTest
@@ -36,8 +36,8 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
             }, context.NamespaceNames);
         }
 
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         public class SourceEndpoint : EndpointConfigurationBuilder
         {

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_failover_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_failover_partitioning_strategy.cs
@@ -1,0 +1,120 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_message_with_failover_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_failover_in_case_of_failure()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SourceEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Send(new MyRequest());
+                        await bus.Send(new MyRequest());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString))) // target endpoint only available on failover namespace
+                .Done(c => c.RequestsReceived == 2 && c.NamespaceNames.Count == 2)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2"
+            }, context.NamespaceNames);
+        }
+
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+        public class SourceEndpoint : EndpointConfigurationBuilder
+        {
+            public SourceEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<FailOverNamespacePartitioning>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                    partitioning.AddNamespace("namespace2", targetConnectionString);
+
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyRequest), typeof(TargetEndpoint));
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    Context.Received();
+                    return context.Reply(new MyResponse());
+                }
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyRequestImpl : MyRequest
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+
+            long received;
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_roundrobin_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_roundrobin_partitioning_strategy.cs
@@ -1,0 +1,122 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_message_with_roundrobin_partitioning_strategy : NServiceBusAcceptanceTest
+    {
+        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+
+        [Test]
+        public async Task Should_round_robin_between_active_namespaces()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SourceEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Send(new MyRequest());
+                        await bus.Send(new MyRequest());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(connectionString)))
+                .WithEndpoint<TargetEndpoint>(b => b.CustomConfig(c => c.ConfigureAzureServiceBus().ConnectionString(targetConnectionString)))
+                .Done(c => c.RequestsReceived == 2 && c.NamespaceNames.Count == 2)
+                .Run();
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace2",
+                $"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@namespace1",
+            }, context.NamespaceNames);
+        }
+      
+
+        public class SourceEndpoint : EndpointConfigurationBuilder
+        {
+            public SourceEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+
+                    var partitioning = transport.NamespacePartitioning();
+                    partitioning.UseStrategy<RoundRobinNamespacePartitioning>();
+                    partitioning.AddNamespace("namespace1", connectionString);
+                    partitioning.AddNamespace("namespace2", targetConnectionString);
+
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyRequest), typeof(TargetEndpoint));
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.NamespaceNames.Add(context.ReplyToAddress);
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    Context.Received();
+                    return context.Reply(new MyResponse());
+                }
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyRequestImpl : MyRequest
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            long received;
+            public Context()
+            {
+                NamespaceNames = new ConcurrentBag<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref received);
+
+            public ConcurrentBag<string> NamespaceNames { get; }
+
+            public void Received()
+            {
+                Interlocked.Increment(ref received);
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/Addressing/When_sending_message_with_roundrobin_partitioning_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_roundrobin_partitioning_strategy.cs
@@ -6,15 +6,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ad
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_sending_message_with_roundrobin_partitioning_strategy : NServiceBusAcceptanceTest
     {
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         [Test]
         public async Task Should_round_robin_between_active_namespaces()

--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -21,7 +21,7 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
 
         configuration.UseSerialization<NewtonsoftSerializer>();
 
-        var connectionString = EnvironmentHelper.GetEnvironmentVariable($"{nameof(AzureServiceBusTransport)}.ConnectionString");
+        var connectionString = TestUtility.DefaultConnectionString;
         var topology = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.Topology");
 
         configuration.GetSettings().Set("AzureServiceBus.AcceptanceTests.UsedTopology", topology);

--- a/src/AcceptanceTests/Infrastructure/TestUtility.cs
+++ b/src/AcceptanceTests/Infrastructure/TestUtility.cs
@@ -31,7 +31,7 @@
             {
                 if (string.IsNullOrEmpty(fallbackConnectionString))
                 {
-                    var environmentVariableName = $"AzureServiceBus.ConnectionString.Fallback";
+                    var environmentVariableName = "AzureServiceBus.ConnectionString.Fallback";
                     fallbackConnectionString = EnvironmentHelper.GetEnvironmentVariable(environmentVariableName);
                     if (string.IsNullOrEmpty(fallbackConnectionString))
                     {

--- a/src/AcceptanceTests/Infrastructure/TestUtility.cs
+++ b/src/AcceptanceTests/Infrastructure/TestUtility.cs
@@ -31,7 +31,7 @@
             {
                 if (string.IsNullOrEmpty(fallbackConnectionString))
                 {
-                    var environmentVariableName = $"{nameof(AzureServiceBusTransport)}.ConnectionString";
+                    var environmentVariableName = $"AzureServiceBus.ConnectionString.Fallback";
                     fallbackConnectionString = EnvironmentHelper.GetEnvironmentVariable(environmentVariableName);
                     if (string.IsNullOrEmpty(fallbackConnectionString))
                     {

--- a/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
+++ b/src/AcceptanceTests/Routing/When_sending_to_specific_namespace.cs
@@ -4,15 +4,15 @@ namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Ro
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_using_multiple_namespaces : NServiceBusAcceptanceTest
     {
-        static string connectionString = connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string targetConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string connectionString = connectionString = TestUtility.DefaultConnectionString;
+        static string targetConnectionString = TestUtility.FallbackConnectionString;
 
         [Test]
         public async Task Should_support_request_reply_across_namespaces_using_aliases()

--- a/src/AcceptanceTests/Routing/When_subscribing_outside_the_endpoint_oriented_topology.cs
+++ b/src/AcceptanceTests/Routing/When_subscribing_outside_the_endpoint_oriented_topology.cs
@@ -2,17 +2,17 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using Conventions = AcceptanceTesting.Customization.Conventions;
     using Features;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_subscribing_outside_the_endpoint_oriented_topology : NServiceBusAcceptanceTest
     {
-        static string publisherConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
-        static string subscriberConnectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBus.ConnectionString.Fallback");
+        static string publisherConnectionString = TestUtility.DefaultConnectionString;
+        static string subscriberConnectionString = TestUtility.FallbackConnectionString;
 
         [Test]
         public async Task Should_receive_event()

--- a/src/AcceptanceTests/Routing/When_unsubscribing.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing.cs
@@ -6,8 +6,8 @@
     using NUnit.Framework;
     using NServiceBus.AcceptanceTests;
     using AcceptanceTesting.Customization;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
 
     public class When_unsubscribing : NServiceBusAcceptanceTest
     {
@@ -19,7 +19,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            var connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+            var connectionString = TestUtility.DefaultConnectionString;
             var namespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
             var endpointName = Conventions.EndpointNamingConvention(typeof(Endpoint));
 

--- a/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
+++ b/src/AcceptanceTests/Routing/When_unsubscribing_from_one_of_the_events_for_ForwardingTopology.cs
@@ -10,9 +10,9 @@
     using NUnit.Framework;
     using NServiceBus.AcceptanceTests;
     using AcceptanceTesting.Customization;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using Microsoft.ServiceBus.Messaging;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
 
     public class When_unsubscribing_from_one_of_the_events_for_ForwardingTopology : NServiceBusAcceptanceTest
     {
@@ -21,7 +21,7 @@
         {
             Requires.ForwardingTopology();
 
-            var connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+            var connectionString = TestUtility.DefaultConnectionString;
             var namespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
             var rawEndpointName = Conventions.EndpointNamingConvention(typeof(Endpoint));
             var endpointName = MD5HashBuilder.Build(rawEndpointName);

--- a/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
+++ b/src/AcceptanceTests/TransportEncoding/When_receiving_a_message_with_unknown_transport_encoding.cs
@@ -7,11 +7,11 @@
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using Transport.AzureServiceBus;
     using MessageMutator;
-    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
 
     public class When_receiving_a_message_with_unknown_transport_encoding : NServiceBusAcceptanceTest
@@ -42,7 +42,7 @@
                 // delay raw receive from the DLQ to allow endpoint (queue) creation
                 await Task.Delay(TimeSpan.FromSeconds(10));
 
-                var connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServiceBusTransport.ConnectionString");
+                var connectionString = TestUtility.DefaultConnectionString;
                 var namespaceManager = new NamespaceManagerAdapterInternal(NamespaceManager.CreateFromConnectionString(connectionString));
                 var factory = MessagingFactory.CreateAsync(namespaceManager.Address, namespaceManager.Settings.TokenProvider).GetAwaiter().GetResult();
                 var dlqPath = Conventions.EndpointNamingConvention(typeof(Receiver)) + "/$DeadLetterQueue";

--- a/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -272,6 +272,7 @@ namespace NServiceBus
     public class FailOverNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
         public NServiceBus.Transport.AzureServiceBus.FailOverMode Mode { get; set; }
+        public bool SendingCacheable { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class FlatComposition : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
@@ -290,10 +291,12 @@ namespace NServiceBus
     }
     public class RoundRobinNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
+        public bool SendingCacheable { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class SingleNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
+        public bool SendingCacheable { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class SizeInMegabytes
@@ -412,6 +415,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface INamespaceManager { }
     public interface INamespacePartitioningStrategy
     {
+        bool SendingCacheable { get; }
         System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent);
     }
     [System.ObsoleteAttribute("Internal contract. Will be removed in version 9.0.0.", true)]

--- a/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -272,7 +272,7 @@ namespace NServiceBus
     public class FailOverNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
         public NServiceBus.Transport.AzureServiceBus.FailOverMode Mode { get; set; }
-        public bool SendingCacheable { get; }
+        public bool SendingNamespacesCanBeCached { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class FlatComposition : NServiceBus.Transport.AzureServiceBus.ICompositionStrategy
@@ -291,12 +291,12 @@ namespace NServiceBus
     }
     public class RoundRobinNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
-        public bool SendingCacheable { get; }
+        public bool SendingNamespacesCanBeCached { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class SingleNamespacePartitioning : NServiceBus.Transport.AzureServiceBus.INamespacePartitioningStrategy
     {
-        public bool SendingCacheable { get; }
+        public bool SendingNamespacesCanBeCached { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent) { }
     }
     public class SizeInMegabytes
@@ -415,7 +415,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface INamespaceManager { }
     public interface INamespacePartitioningStrategy
     {
-        bool SendingCacheable { get; }
+        bool SendingNamespacesCanBeCached { get; }
         System.Collections.Generic.IEnumerable<NServiceBus.Transport.AzureServiceBus.RuntimeNamespaceInfo> GetNamespaces(NServiceBus.Transport.AzureServiceBus.PartitioningIntent partitioningIntent);
     }
     [System.ObsoleteAttribute("Internal contract. Will be removed in version 9.0.0.", true)]

--- a/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
+++ b/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
@@ -39,7 +39,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 
         class MyNamespacePartitioningStrategy : INamespacePartitioningStrategy
         {
-            public bool SendingCacheable { get; }
+            public bool SendingNamespacesCanBeCached { get; }
 
             public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
             {

--- a/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
+++ b/src/Tests/Configuration/When_configuring_namespace_partitioning.cs
@@ -39,6 +39,8 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Configuration
 
         class MyNamespacePartitioningStrategy : INamespacePartitioningStrategy
         {
+            public bool SendingCacheable { get; }
+
             public IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent)
             {
                 throw new NotImplementedException(); // not relevant for the test

--- a/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
+++ b/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
@@ -48,8 +48,6 @@
                 {SecondaryName, 1}
             };
 
-            // for publish destinations topics need to be created first
-            sectionManager.DetermineTopicsToCreate("sales");
             sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
             var publishDestination2 = sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
             Assert.AreEqual(SecondaryName, publishDestination2.Entities.First().Namespace.Alias, "Should have different namespace");
@@ -65,8 +63,6 @@
             var publishersConfiguration = new PublishersConfiguration(conventions, new SettingsHolder());
             var sectionManager = new EndpointOrientedTopologySectionManager(PrimaryName, namespaceConfigurations, "sales", publishersConfiguration, namespacePartitioningStrategy, addressingLogic);
 
-            // for publish destinations topics need to be created first
-            sectionManager.DetermineTopicsToCreate("sales");
             sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
             var publishDestination2 = sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
             Assert.AreEqual(SecondaryName, publishDestination2.Entities.First().Namespace.Alias, "Should have different namespace");

--- a/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
+++ b/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Topologies
+{
+    using System.Linq;
+    using AzureServiceBus.Topology.MetaModel;
+    using NUnit.Framework;
+    using Settings;
+    using Transport.AzureServiceBus;
+
+    [TestFixture]
+    [Category("AzureServiceBus")]
+    public class When_using_SectionManager_with_RoundRobinNamespacePartitioning
+    {
+        static string PrimaryConnectionString = "Endpoint=sb://namespace1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
+        static string SecondaryConnectionString = "Endpoint=sb://namespace2.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
+        static string PrimaryName = "namespace1";
+        static string SecondaryName = "namespace2";
+
+        RoundRobinNamespacePartitioning namespacePartitioningStrategy;
+        SettingsHolder settings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            settings = new SettingsHolder();
+            var extensions = new TransportExtensions<AzureServiceBusTransport>(settings);
+            extensions.NamespacePartitioning().AddNamespace(PrimaryName, PrimaryConnectionString);
+            extensions.NamespacePartitioning().AddNamespace(SecondaryName, SecondaryConnectionString);
+
+            namespacePartitioningStrategy = new RoundRobinNamespacePartitioning(settings);
+
+            // apply entity maximum lengths for addressing logic
+            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.QueuePathMaximumLength, 260);
+            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.TopicPathMaximumLength, 260);
+            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.SubscriptionNameMaximumLength, 50);
+            settings.SetDefault(WellKnownConfigurationKeys.Topology.Addressing.Sanitization.RuleNameMaximumLength, 50);
+        }
+
+        [Test]
+        public void Should_alternate_between_namespaces_for_ForwardingTopologySectionManager()
+        {
+            var namespaceConfigurations = new NamespaceConfigurations();
+            var addressingLogic = new AddressingLogic(new ThrowOnFailedValidation(settings), new FlatComposition());
+            var sectionManager = new ForwardingTopologySectionManager(PrimaryName, namespaceConfigurations, "sales", 1, "bundle", namespacePartitioningStrategy, addressingLogic);
+            sectionManager.BundleConfigurations = new NamespaceBundleConfigurations
+            {
+                {PrimaryName, 1},
+                {SecondaryName, 1}
+            };
+
+            // for publish destinations topics need to be created first
+            sectionManager.DetermineTopicsToCreate("sales");
+            sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
+            var publishDestination2 = sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
+            Assert.AreEqual(SecondaryName, publishDestination2.Entities.First().Namespace.Alias, "Should have different namespace");
+        }
+
+        [Test]
+        public void Should_alternate_between_namespaces_for_EndpointOrientedTopologySectionManager()
+        {
+            var namespaceConfigurations = new NamespaceConfigurations();
+            var addressingLogic = new AddressingLogic(new ThrowOnFailedValidation(settings), new FlatComposition());
+            var conventions = new Conventions();
+            conventions.AddSystemMessagesConventions(type => type != typeof(SomeEvent));
+            var publishersConfiguration = new PublishersConfiguration(conventions, new SettingsHolder());
+            var sectionManager = new EndpointOrientedTopologySectionManager(PrimaryName, namespaceConfigurations, "sales", publishersConfiguration, namespacePartitioningStrategy, addressingLogic);
+
+            // for publish destinations topics need to be created first
+            sectionManager.DetermineTopicsToCreate("sales");
+            sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
+            var publishDestination2 = sectionManager.DeterminePublishDestination(typeof(SomeEvent), "sales");
+            Assert.AreEqual(SecondaryName, publishDestination2.Entities.First().Namespace.Alias, "Should have different namespace");
+        }
+
+        class SomeEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
+++ b/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
@@ -4,14 +4,15 @@
     using AzureServiceBus.Topology.MetaModel;
     using NUnit.Framework;
     using Settings;
+    using TestUtils;
     using Transport.AzureServiceBus;
 
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_using_SectionManager_with_RoundRobinNamespacePartitioning
     {
-        static string PrimaryConnectionString = "Endpoint=sb://namespace1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
-        static string SecondaryConnectionString = "Endpoint=sb://namespace2.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
+        static string PrimaryConnectionString = AzureServiceBusConnectionString.Value;
+        static string SecondaryConnectionString = AzureServiceBusConnectionString.Fallback;
         static string PrimaryName = "namespace1";
         static string SecondaryName = "namespace2";
 

--- a/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
+++ b/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
@@ -4,15 +4,14 @@
     using AzureServiceBus.Topology.MetaModel;
     using NUnit.Framework;
     using Settings;
-    using TestUtils;
     using Transport.AzureServiceBus;
 
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_using_SectionManager_with_RoundRobinNamespacePartitioning
     {
-        static string PrimaryConnectionString = AzureServiceBusConnectionString.Value;
-        static string SecondaryConnectionString = AzureServiceBusConnectionString.Fallback;
+        static string PrimaryConnectionString = "Endpoint=sb://namespace1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
+        static string SecondaryConnectionString = "Endpoint=sb://namespace2.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
         static string PrimaryName = "namespace1";
         static string SecondaryName = "namespace2";
 

--- a/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
+++ b/src/Tests/Topology/Topologies/When_using_SectionManager_with_RoundRobinNamespacePartitioning.cs
@@ -99,8 +99,8 @@
             var sectionManager = new EndpointOrientedTopologySectionManager(PrimaryName, namespaceConfigurations, "sales", publishersConfiguration, namespacePartitioningStrategy, addressingLogic);
 
             sectionManager.DetermineSendDestination($"sales@{PrimaryName}");
-            var publishDestination2 = sectionManager.DetermineSendDestination($"sales@{PrimaryName}");
-            Assert.AreEqual(SecondaryName, publishDestination2.Entities.First().Namespace.Alias, "Should have different namespace");
+            var sendDestination2 = sectionManager.DetermineSendDestination($"sales@{PrimaryName}");
+            Assert.AreEqual(SecondaryName, sendDestination2.Entities.First().Namespace.Alias, "Should have different namespace");
         }
     }
 }

--- a/src/Transport/Addressing/Partitioning/INamespacePartitioningStrategy.cs
+++ b/src/Transport/Addressing/Partitioning/INamespacePartitioningStrategy.cs
@@ -8,7 +8,16 @@
     public interface INamespacePartitioningStrategy
     {
         /// <summary>
-        /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending" /> is cacheable.
+        /// The flag should be set to <c>false</c> if the partitioning strategy is intended to return a new runtime namespace for
+        /// every routing decision.
+        /// For static information that never changes the flag can be set to <c>true</c> thus the runtime namespaces will only ever
+        /// be acquired once during the lifetime of an endpoint per destination.
+        /// </summary>
+        bool SendingCacheable { get; }
+
+        /// <summary>
+        /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent" />.
         /// </summary>
         IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent);
     }

--- a/src/Transport/Addressing/Partitioning/INamespacePartitioningStrategy.cs
+++ b/src/Transport/Addressing/Partitioning/INamespacePartitioningStrategy.cs
@@ -8,16 +8,16 @@
     public interface INamespacePartitioningStrategy
     {
         /// <summary>
-        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending" /> is cacheable.
-        /// The flag should be set to <c>false</c> if the partitioning strategy is intended to return a new runtime namespace for
-        /// every routing decision.
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending" /> is cache-able.
+        /// The flag should be set to <c>false</c> if the partitioning strategy is intended to return a different runtime namespace for every routing decision.
         /// For static information that never changes the flag can be set to <c>true</c> thus the runtime namespaces will only ever
         /// be acquired once during the lifetime of an endpoint per destination.
         /// </summary>
-        bool SendingCacheable { get; }
+        bool SendingNamespacesCanBeCached { get; }
 
         /// <summary>
-        /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent" />.
+        /// Return a set of namespaces required by strategy for <paramref name="partitioningIntent"/>.
+        /// <param name="partitioningIntent"><see cref="PartitioningIntent"/> for namespaces to be returned by strategy.</param>
         /// </summary>
         IEnumerable<RuntimeNamespaceInfo> GetNamespaces(PartitioningIntent partitioningIntent);
     }

--- a/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
@@ -39,16 +39,16 @@
                 new RuntimeNamespaceInfo(secondary.Alias, secondary.Connection, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive)
             };
 
-            SendingCacheable = true;
+            SendingNamespacesCanBeCached = true;
         }
 
         /// <summary>Current mode.</summary>
         public FailOverMode Mode { get; set; }
 
         /// <summary>
-        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cacheable.
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cache-able.
         /// </summary>
-        public bool SendingCacheable { get; }
+        public bool SendingNamespacesCanBeCached { get; }
 
         /// <summary>
         /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.

--- a/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/FailOverNamespacePartitioning.cs
@@ -38,10 +38,17 @@
                 new RuntimeNamespaceInfo(primary.Alias, primary.Connection, primary.Purpose, Mode == FailOverMode.Primary ? NamespaceMode.Active : NamespaceMode.Passive),
                 new RuntimeNamespaceInfo(secondary.Alias, secondary.Connection, secondary.Purpose, Mode == FailOverMode.Secondary ? NamespaceMode.Active : NamespaceMode.Passive)
             };
+
+            SendingCacheable = true;
         }
 
         /// <summary>Current mode.</summary>
         public FailOverMode Mode { get; set; }
+
+        /// <summary>
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cacheable.
+        /// </summary>
+        public bool SendingCacheable { get; }
 
         /// <summary>
         /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.

--- a/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
@@ -29,7 +29,14 @@ namespace NServiceBus
 
             this.namespaces = new CircularBuffer<NamespaceInfo>(namespaces.Count);
             Array.ForEach(namespaces.ToArray(), x => this.namespaces.Put(x));
+
+            SendingCacheable = false;
         }
+
+        /// <summary>
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cacheable.
+        /// </summary>
+        public bool SendingCacheable { get; }
 
         /// <summary>
         /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.

--- a/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/RoundRobinNamespacePartitioning.cs
@@ -30,13 +30,13 @@ namespace NServiceBus
             this.namespaces = new CircularBuffer<NamespaceInfo>(namespaces.Count);
             Array.ForEach(namespaces.ToArray(), x => this.namespaces.Put(x));
 
-            SendingCacheable = false;
+            SendingNamespacesCanBeCached = false;
         }
 
         /// <summary>
-        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cacheable.
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cache-able.
         /// </summary>
-        public bool SendingCacheable { get; }
+        public bool SendingNamespacesCanBeCached { get; }
 
         /// <summary>
         /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.

--- a/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
@@ -30,7 +30,14 @@ namespace NServiceBus
             {
                 new RuntimeNamespaceInfo(@namespace.Alias, @namespace.Connection, @namespace.Purpose, NamespaceMode.Active)
             };
+
+            SendingCacheable = true;
         }
+
+        /// <summary>
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cacheable.
+        /// </summary>
+        public bool SendingCacheable { get; }
 
         /// <summary>
         /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.

--- a/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
+++ b/src/Transport/Addressing/Partitioning/Strategies/SingleNamespacePartitioning.cs
@@ -31,13 +31,13 @@ namespace NServiceBus
                 new RuntimeNamespaceInfo(@namespace.Alias, @namespace.Connection, @namespace.Purpose, NamespaceMode.Active)
             };
 
-            SendingCacheable = true;
+            SendingNamespacesCanBeCached = true;
         }
 
         /// <summary>
-        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cacheable.
+        /// Gets whether the information returned by the strategy for <see cref="PartitioningIntent.Sending"/> is cache-able.
         /// </summary>
-        public bool SendingCacheable { get; }
+        public bool SendingNamespacesCanBeCached { get; }
 
         /// <summary>
         /// Return a set of namespaces required by strategy for <see cref="PartitioningIntent"/>.

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -141,7 +141,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         TopologySectionInternal CreateSectionForPublish(string localAddress)
         {
-            var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
+            var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
 
             var topicPath = addressingLogic.Apply($"{localAddress}.events", EntityType.Topic).Name;
             var entities = new List<EntityInfoInternal>();

--- a/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/EndpointOrientedTopologySectionManager.cs
@@ -107,12 +107,12 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
-            return namespacePartitioningStrategy.SendingCacheable ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish(localAddress)) : CreateSectionForPublish(localAddress);
+            return namespacePartitioningStrategy.SendingNamespacesCanBeCached ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish(localAddress)) : CreateSectionForPublish(localAddress);
         }
 
         public TopologySectionInternal DetermineSendDestination(string destination)
         {
-            return namespacePartitioningStrategy.SendingCacheable ? sendDestinations.GetOrAdd(destination, d => CreateSectionForSend(d)) : CreateSectionForSend(destination);
+            return namespacePartitioningStrategy.SendingNamespacesCanBeCached ? sendDestinations.GetOrAdd(destination, d => CreateSectionForSend(d)) : CreateSectionForSend(destination);
         }
 
         public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -60,7 +60,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 {
                     entities.AddRange(namespaces.Select(n => new EntityInfoInternal
                     {
-                        Path = addressingLogic.Apply(bundlePrefix + i, EntityType.Topic).Name,
+                        Path = addressingLogic.Apply($"{bundlePrefix}{i}", EntityType.Topic).Name,
                         Type = EntityType.Topic,
                         Namespace = @namespace
                     }));
@@ -115,86 +115,12 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
-            return publishDestinations.GetOrAdd(eventType, t =>
-            {
-                // Filtering out passive namespaces since publishes should only be done to the active ones regardless what is being returned from the strategy
-                // i.ex. for the failover strategy a single publish destination should be used which is the currently active namespace.
-                var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
-
-                return new TopologySectionInternal
-                {
-                    Entities = new [] { topics[0] }, // first in bundle
-                    Namespaces = namespaces
-                };
-            });
+            return namespacePartitioningStrategy.SendingCacheable ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish()) : CreateSectionForPublish();
         }
 
         public TopologySectionInternal DetermineSendDestination(string destination)
         {
-            return sendDestinations.GetOrAdd(destination, d =>
-            {
-                var inputQueueAddress = addressingLogic.Apply(d, EntityType.Queue);
-
-                RuntimeNamespaceInfo[] namespaces = null;
-                if (inputQueueAddress.HasSuffix && inputQueueAddress.Suffix != defaultNameSpaceAlias) // sending to specific namespace
-                {
-                    if (inputQueueAddress.HasConnectionString)
-                    {
-                        namespaces = new[]
-                        {
-                            new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing)
-                        };
-                    }
-                    else
-                    {
-                        var configured = namespaceConfigurations.FirstOrDefault(n => n.Alias == inputQueueAddress.Suffix);
-                        if (configured != null)
-                        {
-                            namespaces = new[]
-                            {
-                                new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
-                            };
-                        }
-                    }
-                }
-                else
-                {
-                    var configured = namespaceConfigurations.FirstOrDefault(n => n.RegisteredEndpoints.Contains(d, StringComparer.OrdinalIgnoreCase));
-                    if (configured != null)
-                    {
-                        namespaces = new[]
-                        {
-                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose),
-                        };
-                    }
-                    else // sending to the partition
-                    {
-                        namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
-                    }
-                }
-
-                if (namespaces == null)
-                {
-                    throw new Exception($"Could not determine namespace for destination `{d}`.");
-                }
-
-                var entities = new List<EntityInfoInternal>();
-                foreach (var n in namespaces)
-                {
-                    entities.Add(new EntityInfoInternal
-                    {
-                        Path = inputQueueAddress.Name,
-                        Type = EntityType.Queue,
-                        Namespace = n
-                    });
-                }
-
-                return new TopologySectionInternal
-                {
-                    Namespaces = namespaces,
-                    Entities = entities
-                };
-            });
+            return namespacePartitioningStrategy.SendingCacheable ? sendDestinations.GetOrAdd(destination, d => CreateSectionForSend(d)) : CreateSectionForSend(destination);
         }
 
         public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)
@@ -219,6 +145,113 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
 
             return result;
+        }
+
+        TopologySectionInternal CreateSectionForPublish()
+        {
+            var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
+
+            var entities = new List<EntityInfoInternal>();
+            foreach (var @namespace in namespaces)
+            {
+                foreach (var topic in topics)
+                {
+                    if (topic.Namespace.Alias != @namespace.Alias)
+                    {
+                        continue;
+                    }
+
+                    // first in bundle
+                    entities.Add(topic);
+                    break;
+                }
+            }
+
+            return new TopologySectionInternal
+            {
+                Entities = entities,
+                Namespaces = namespaces
+            };
+        }
+
+        TopologySectionInternal CreateSectionForSend(string destination)
+        {
+            var inputQueueAddress = addressingLogic.Apply(destination, EntityType.Queue);
+
+            RuntimeNamespaceInfo[] namespaces = null;
+            if (inputQueueAddress.HasSuffix && inputQueueAddress.Suffix != defaultNameSpaceAlias) // sending to specific namespace
+            {
+                if (inputQueueAddress.HasConnectionString)
+                {
+                    namespaces = new[]
+                    {
+                        new RuntimeNamespaceInfo(inputQueueAddress.Suffix, inputQueueAddress.Suffix, NamespacePurpose.Routing)
+                    };
+                }
+                else
+                {
+                    NamespaceInfo configured = null;
+                    foreach (var namespaceConfiguration in namespaceConfigurations)
+                    {
+                        if (namespaceConfiguration.Alias == inputQueueAddress.Suffix)
+                        {
+                            configured = namespaceConfiguration;
+                        }
+                    }
+                    if (configured != null)
+                    {
+                        namespaces = new[]
+                        {
+                            new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
+                        };
+                    }
+                }
+            }
+            else
+            {
+                NamespaceInfo configured = null;
+                foreach (var namespaceConfiguration in namespaceConfigurations)
+                {
+                    if (namespaceConfiguration.RegisteredEndpoints.Contains(destination, StringComparer.OrdinalIgnoreCase))
+                    {
+                        configured = namespaceConfiguration;
+                    }
+                }
+
+                if (configured != null)
+                {
+                    namespaces = new[]
+                    {
+                        new RuntimeNamespaceInfo(configured.Alias, configured.Connection, configured.Purpose)
+                    };
+                }
+                else // sending to the partition
+                {
+                    namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).ToArray();
+                }
+            }
+
+            if (namespaces == null)
+            {
+                throw new Exception($"Could not determine namespace for destination `{destination}`.");
+            }
+
+            var entities = new List<EntityInfoInternal>(namespaces.Length);
+            foreach (var n in namespaces)
+            {
+                entities.Add(new EntityInfoInternal
+                {
+                    Path = inputQueueAddress.Name,
+                    Type = EntityType.Queue,
+                    Namespace = n
+                });
+            }
+
+            return new TopologySectionInternal
+            {
+                Namespaces = namespaces,
+                Entities = entities
+            };
         }
 
         TopologySectionInternal BuildSubscriptionHierarchy(Type eventType, string localAddress)

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -97,12 +97,12 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
-            return namespacePartitioningStrategy.SendingCacheable ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish()) : CreateSectionForPublish();
+            return namespacePartitioningStrategy.SendingNamespacesCanBeCached ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish()) : CreateSectionForPublish();
         }
 
         public TopologySectionInternal DetermineSendDestination(string destination)
         {
-            return namespacePartitioningStrategy.SendingCacheable ? sendDestinations.GetOrAdd(destination, d => CreateSectionForSend(d)) : CreateSectionForSend(destination);
+            return namespacePartitioningStrategy.SendingNamespacesCanBeCached ? sendDestinations.GetOrAdd(destination, d => CreateSectionForSend(d)) : CreateSectionForSend(destination);
         }
 
         public TopologySectionInternal DetermineResourcesToSubscribeTo(Type eventType, string localAddress)
@@ -152,7 +152,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         TopologySectionInternal CreateSectionForPublish()
         {
 			// Filtering out passive namespaces since publishes should only be done to the active ones regardless what is being returned from the strategy
-			// i.ex. for the failover strategy a single publish destination should be used which is the currently active namespace.
+			// i.ex. for the fail-over strategy a single publish destination should be used which is the currently active namespace.
             var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
 
             return new TopologySectionInternal

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -97,8 +97,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
-                // Filtering out passive namespaces since publishes should only be done to the active ones regardless what is being returned from the strategy
-                // i.ex. for the failover strategy a single publish destination should be used which is the currently active namespace.
             return namespacePartitioningStrategy.SendingCacheable ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish()) : CreateSectionForPublish();
         }
 

--- a/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
+++ b/src/Transport/Topology/Topologies/ForwardingTopologySectionManager.cs
@@ -97,6 +97,8 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         public TopologySectionInternal DeterminePublishDestination(Type eventType, string localAddress)
         {
+                // Filtering out passive namespaces since publishes should only be done to the active ones regardless what is being returned from the strategy
+                // i.ex. for the failover strategy a single publish destination should be used which is the currently active namespace.
             return namespacePartitioningStrategy.SendingCacheable ? publishDestinations.GetOrAdd(eventType, t => CreateSectionForPublish()) : CreateSectionForPublish();
         }
 
@@ -151,6 +153,8 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         TopologySectionInternal CreateSectionForPublish()
         {
+			// Filtering out passive namespaces since publishes should only be done to the active ones regardless what is being returned from the strategy
+			// i.ex. for the failover strategy a single publish destination should be used which is the currently active namespace.
             var namespaces = namespacePartitioningStrategy.GetNamespaces(PartitioningIntent.Sending).Where(n => n.Mode == NamespaceMode.Active).ToArray();
 
             return new TopologySectionInternal


### PR DESCRIPTION
Fixes #672
Fixes #678
Fixes #679

This PR introduces the possibility to indicate on a namespace partitioning strategy whether the result of `GetNamespaces` can be cached for sending. The flag was named `SendingCachaeble` in order to clearly show that currently only call for `PartitioningIntent.Sending` are cached by the infrastructure. 

Verification tests to demonstrate caching issue with RoundRobin strategy in v8 #672.