### PR TITLE
Fix bundle prefix test

### DIFF
--- a/src/Tests/Topology/When_counting_existing_topics_in_bundle.cs
+++ b/src/Tests/Topology/When_counting_existing_topics_in_bundle.cs
@@ -39,7 +39,7 @@
             namespaceConfigurations.Add(namespaceAlias, AzureServiceBusConnectionString.Value, NamespacePurpose.Routing);
             settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Namespaces, namespaceConfigurations);
 
-            var result = await NumberOfTopicsInBundleCheck.Run(new NamespaceManagerLifeCycleManagerInternal(new NamespaceManagerCreator(settings)), namespaceConfigurations, "bundle-");
+            var result = await NumberOfTopicsInBundleCheck.Run(new NamespaceManagerLifeCycleManagerInternal(new NamespaceManagerCreator(settings)), namespaceConfigurations, bundlePrefix);
             Assert.AreEqual(0, result.GetNumberOfTopicInBundle(namespaceAlias));
         }
 


### PR DESCRIPTION
The bundle prefix test needs to use the artificial bundle prefix instead of bundle-1 to not count the existing bundles that remain from previous test runs