### PR TITLE
Obsoleting ICacheSendingNamespaces in v8

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureServiceBusTransport.approved.txt
@@ -360,6 +360,12 @@ namespace NServiceBus.Transport.AzureServiceBus
     public interface IBatcher { }
     [System.ObsoleteAttribute("Internal contract. Will be removed in version 9.0.0.", true)]
     public interface IBrokerSideSubscriptionFilter { }
+    [System.ObsoleteAttribute("Deprecated and no longer required. Will be removed in version 9.0.0.", true)]
+    public interface ICacheSendingNamespaces
+    {
+        [System.ObsoleteAttribute("Deprecated and no longer required. Will be removed in version 9.0.0.", true)]
+        bool SendingNamespacesCanBeCached { get; }
+    }
     [System.ObsoleteAttribute("Internal contract. Will be removed in version 9.0.0.", true)]
     public interface IClientEntity { }
     [System.ObsoleteAttribute("Internal unutilized contract that shouldn\'t be exposed. Will be removed in versio" +

--- a/src/Transport/obsoletes.cs
+++ b/src/Transport/obsoletes.cs
@@ -11,6 +11,7 @@ namespace NServiceBus
     {
         public const string InternalizedContract = "Internal contract.";
         public const string ReplaceWithNewAPI = "Replaced with new API.";
+        public const string DeprecatedAndNoLongerRequired = "Deprecated and no longer required.";
     }
 
     [ObsoleteEx(Message = ObsoleteMessages.InternalizedContract, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
@@ -404,6 +405,13 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             get { throw new NotImplementedException(); }
         }
+    }
+
+    [ObsoleteEx(Message = ObsoleteMessages.DeprecatedAndNoLongerRequired, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+    public interface ICacheSendingNamespaces
+    {
+        [ObsoleteEx(Message = ObsoleteMessages.DeprecatedAndNoLongerRequired, TreatAsErrorFromVersion = "8.0", RemoveInVersion = "9.0")]
+        bool SendingNamespacesCanBeCached { get; }
     }
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member


### PR DESCRIPTION
Related to #672
Related to #673

`ICacheSendingNamespaces` introduced in 7.2.10 should be obsoleted in v8.