### PR TITLE
Make hierarchy composition idempotent

### DIFF
--- a/src/AcceptanceTests/Addressing/When_sending_message_with_hierarchy_composition_strategy.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_message_with_hierarchy_composition_strategy.cs
@@ -1,0 +1,129 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using AzureServiceBus;
+    using AzureServiceBus.AcceptanceTests.Infrastructure;
+    using Microsoft.ServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_message_with_hierarchy_composition_strategy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_send_to_one_namespace_only()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SourceEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        await bus.Send(new MyRequest());
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>()
+                .Done(c => c.RequestsReceived == 1 && c.ResponsesReceived == 1)
+                .Run();
+
+            var namespaceManager = NamespaceManager.CreateFromConnectionString(TestUtility.DefaultConnectionString);
+            var queueNames = context.ReplyToAddresses.Select(x => x.Replace("@default", "")).ToArray();
+
+            var results = await Task.WhenAll(namespaceManager.QueueExistsAsync(queueNames[0]), namespaceManager.QueueExistsAsync(queueNames[1]));
+
+            CollectionAssert.AreEquivalent(new[] { true, true }, results, "'{0}' and '{1}' queues were expected to exist, but were not found.", queueNames);
+        }
+
+
+        public class SourceEndpoint : EndpointConfigurationBuilder
+        {
+            public SourceEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    transport.Composition().UseStrategy<HierarchyComposition>().PathGenerator(path => "scadapter/");
+
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyRequest), typeof(TargetEndpoint));
+                });
+            }
+
+            class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.ReplyToAddresses.Push(context.ReplyToAddress);
+                    Context.ReceivedResponse();
+                    return TaskEx.Completed;
+                }
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    transport.Composition().UseStrategy<HierarchyComposition>().PathGenerator(path => "scadapter/");
+                });
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    Context.ReplyToAddresses.Push(context.ReplyToAddress);
+                    Context.ReceivedRequest();
+                    return context.Reply(new MyResponse());
+                }
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyRequestImpl : MyRequest
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            long receivedRequest;
+            long receivedResponse;
+
+            public Context()
+            {
+                ReplyToAddresses = new ConcurrentStack<string>();
+            }
+
+            public long RequestsReceived => Interlocked.Read(ref receivedRequest);
+            public long ResponsesReceived => Interlocked.Read(ref receivedResponse);
+
+            public ConcurrentStack<string> ReplyToAddresses { get; }
+
+            public void ReceivedRequest()
+            {
+                Interlocked.Increment(ref receivedRequest);
+            }
+            public void ReceivedResponse()
+            {
+                Interlocked.Increment(ref receivedResponse);
+            }
+        }
+    }
+}

--- a/src/Tests/Addressing/Composition/When_using_hierarchy_composition_strategy.cs
+++ b/src/Tests/Addressing/Composition/When_using_hierarchy_composition_strategy.cs
@@ -35,6 +35,18 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Addressing.Composition
             Assert.AreEqual(prefix + entityname, strategy.GetEntityPath(entityname, EntityType.Topic));
         }
 
+        [TestCase("my/path/", "my/path/myQueue", EntityType.Queue)]
+        [TestCase("my/path/", "my/path/myTopic", EntityType.Topic)]
+        public void Hierarchy_composition_will_NOT_prefix_entity_name_if_prefix_is_already_applied(string prefix, string entityPath, EntityType entityType)
+        {
+            var settings = new SettingsHolder();
+            settings.Set(WellKnownConfigurationKeys.Topology.Addressing.Composition.HierarchyCompositionPathGenerator, (Func<string, string>)(s => prefix));
+            var strategy = new HierarchyComposition(settings);
+
+            Assert.AreEqual(entityPath, strategy.GetEntityPath(entityPath, entityType));
+        }
+        
+
         [Test]
         public void Hierarchy_composition_will_not_prefix_entity_name_with_path_for_subscriptions()
         {

--- a/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
+++ b/src/Tests/Topology/MetaModel/When_parsing_string_to_connection_string.cs
@@ -229,9 +229,8 @@
         [Test]
         public void Should_equal_on_absence_of_sas_in_both()
         {
-            ConnectionStringInternal connectionString1, connectionString2;
-            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net", out connectionString1);
-            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net", out connectionString2);
+            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net", out var connectionString1);
+            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net", out var connectionString2);
 
             var areEqual = connectionString1.Equals(connectionString2);
             Assert.IsTrue(areEqual);
@@ -240,9 +239,8 @@
         [Test]
         public void Should_not_equal_on_absence_of_sas_in_one()
         {
-            ConnectionStringInternal connectionString1, connectionString2;
-            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net", out connectionString1);
-            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net;SharedAccessKeyName=name;SharedAccessKey=key", out connectionString2);
+            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net", out var connectionString1);
+            ConnectionStringInternal.TryParse("Endpoint=sb://namespacename.servicebus.windows.net;SharedAccessKeyName=name;SharedAccessKey=key", out var connectionString2);
 
             var areEqual = connectionString1.Equals(connectionString2);
             Assert.IsFalse(areEqual);

--- a/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
+++ b/src/Transport/Addressing/Composition/Strategies/HierarchyComposition.cs
@@ -25,10 +25,17 @@ namespace NServiceBus
             {
                 case EntityType.Queue:
                 case EntityType.Topic:
-                    return pathGenerator(entityName) + entityName;
+                    var prefix = pathGenerator(entityName);
+                    if (entityName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return entityName;
+                    }
+                    return prefix + entityName;
+
                 case EntityType.Subscription:
                 case EntityType.Rule:
                     return entityName;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null);
             }


### PR DESCRIPTION
Connects to #695 
Replaces #694 

Make `HierarchyComposition` idempotent by not applying path generator if entity path (queue or topic) is already prefixed with it.