### PR TITLE
AddressingLogic regression bug fix

### DIFF
--- a/src/AcceptanceTests/Addressing/When_sending_directly_with_hierarchy_composition_and_secure_connection.cs
+++ b/src/AcceptanceTests/Addressing/When_sending_directly_with_hierarchy_composition_and_secure_connection.cs
@@ -1,0 +1,93 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureServiceBus.AcceptanceTests.Addressing
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_directly_with_hierarchy_composition_and_secure_connection : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_send_and_receive_message()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<SourceEndpoint>(b =>
+                {
+                    b.When(async (bus, c) =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.SetDestination($"{Conventions.EndpointNamingConvention(typeof(TargetEndpoint))}@default");
+                        await bus.Send(new MyRequest(), sendOptions);
+                    });
+                })
+                .WithEndpoint<TargetEndpoint>()
+                .Done(c => c.RequestsReceived == 1)
+                .Run();
+        }
+
+
+        public class SourceEndpoint : EndpointConfigurationBuilder
+        {
+            public SourceEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    transport.Composition().UseStrategy<HierarchyComposition>().PathGenerator(path => "scadapter/");
+                    transport.UseNamespaceAliasesInsteadOfConnectionStrings();
+                });
+            }
+        }
+
+        public class TargetEndpoint : EndpointConfigurationBuilder
+        {
+            public TargetEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureAzureServiceBus();
+                    transport.Composition().UseStrategy<HierarchyComposition>().PathGenerator(path => "scadapter/");
+                    transport.UseNamespaceAliasesInsteadOfConnectionStrings();
+                });
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    Context.ReceivedRequest();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyRequestImpl : MyRequest
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            long receivedRequest;
+
+            public long RequestsReceived => Interlocked.Read(ref receivedRequest);
+
+            public void ReceivedRequest()
+            {
+                Interlocked.Increment(ref receivedRequest);
+            }
+        }
+    }
+}

--- a/src/Tests/Addressing/When_apply_addressing_logic.cs
+++ b/src/Tests/Addressing/When_apply_addressing_logic.cs
@@ -24,12 +24,12 @@
         [TestCase("validendpoint@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey")]
         [TestCase("endpoint$name@namespaceName")]
         [TestCase("endpoint$name@Endpoint=sb://namespaceName.servicebus.windows.net;SharedAccessKeyName=SharedAccessKeyName;SharedAccessKey=SharedAccessKey")]
-        public void Composition_and_sanitization_should_NOT_be_invoked_for_values_with_suffix(string endpointName)
+        public void Composition_and_sanitization_should_be_invoked_for_values_with_suffix(string endpointName)
         {
             addressingLogic.Apply(endpointName, EntityType.Queue);
 
-            Assert.IsFalse(compositionStrategy.WasInvoked);
-            Assert.IsFalse(sanitizationStrategy.WasInvoked);
+            Assert.IsTrue(compositionStrategy.WasInvoked);
+            Assert.IsTrue(sanitizationStrategy.WasInvoked);
         }
 
         class SanitizationStrategy : ISanitizationStrategy

--- a/src/Transport/Addressing/AddressingLogic.cs
+++ b/src/Transport/Addressing/AddressingLogic.cs
@@ -10,15 +10,12 @@
 
         public EntityAddress Apply(string value, EntityType entityType)
         {
-            var address = new EntityAddress(value);
-            if (address.HasSuffix)
-            {
-                return address;
-            }
+            var originalAddress = new EntityAddress(value);
 
-            var path = composition.GetEntityPath(address.Name, entityType);
+            var path = composition.GetEntityPath(originalAddress.Name, entityType);
             path = sanitizationStrategy.Sanitize(path, entityType);
-            return new EntityAddress(path, address.Suffix);
+
+            return new EntityAddress(path, originalAddress.Suffix);
         }
 
         readonly ICompositionStrategy composition;


### PR DESCRIPTION
As part of #696 and #697 fix, a regression bug was introduced.
Raised this question in https://github.com/Particular/NServiceBus.AzureServiceBus/pull/694#issuecomment-356512245, but looks like it was overlooked.

The issue is when a direct send is used while using secure connection strings and `HierarchyComposistion`  using a command such as `Send("endpoint@alias`, short-cutting in `AddressingLogic` would cause to return `endpoing@alias` w/o running the address through hierarchy composition. This would cause dispatch to a non-existent destination and result in failure.