### PR TITLE
Hotifx 8.0.3

### DIFF
--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -6,6 +6,8 @@
     using System.Threading;
     using System.Threading.Tasks;
     using DelayedDelivery;
+    using Features;
+    using NServiceBus.AzureServiceBus;
     using Performance.TimeToBeReceived;
     using Routing;
     using Settings;
@@ -28,6 +30,8 @@
             var sanitizationStrategy = sanitizationStrategyType.CreateInstance<ISanitizationStrategy>(Settings);
 
             addressingLogic = new AddressingLogic(sanitizationStrategy, compositionStrategy);
+
+            settings.EnableFeatureByDefault<TransactionScopeSuppressFeature>();
         }
 
         protected TopologySettings TopologySettings { get; }

--- a/src/Transport/Receiving/TransactionScopeSuppressFeature.cs
+++ b/src/Transport/Receiving/TransactionScopeSuppressFeature.cs
@@ -4,11 +4,6 @@ namespace NServiceBus.AzureServiceBus
 
     class TransactionScopeSuppressFeature : Feature
     {
-        public TransactionScopeSuppressFeature()
-        {
-            EnableByDefault();
-        }
-
         protected override void Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent(b => new TransactionScopeSuppressBehavior(), DependencyLifecycle.InstancePerCall);


### PR DESCRIPTION
Fixes #743 

Azure Service Bus suppresses transaction scope for all transports for all transports in a multi-endpoint hosted scenario. The feature should only be enabled for ASB transport.

@Particular/azure-maintainers please review/merge (commit, no squash).