### PR TITLE
Update development tooling

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0" />
-    <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureServiceBus.Tests.csproj
@@ -16,10 +16,9 @@
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="PublicApiGenerator" Version="6.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0" />
-    <PackageReference Include="NUnit" Version="3.*" />
-    <!-- TODO: replace with "3.*" when NUnit bug is fixed -->
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Transport/NServiceBus.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.AzureServiceBus.csproj
@@ -19,12 +19,7 @@
     <PackageReference Include="Janitor.Fody" Version="1.5.2" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
+    <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0" />
-    <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This updates development tooling on the `support-8.0` branch.

Note: It is okay for this to be squashed.