### PR TITLE
Hotfix 9.1.2

### DIFF
--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
@@ -43,7 +43,7 @@
         async Task<bool> SubscriptionIsReusedAcrossDifferentNamespaces(SubscriptionDescription subscriptionDescription, string sqlFilter, INamespaceManagerInternal namespaceManager)
         {
             var rules = await namespaceManager.GetRules(subscriptionDescription).ConfigureAwait(false);
-            if (rules.First().Filter is SqlFilter filter && filter.SqlExpression != sqlFilter)
+            if (rules.First().Filter is SqlFilter filter && !filter.SqlExpression.Contains(sqlFilter))
             {
                 logger.Debug("Looks like this subscription name is already taken as the sql filter does not match the subscribed event name.");
                 return true;

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
@@ -42,11 +42,21 @@
 
         async Task<bool> SubscriptionIsReusedAcrossDifferentNamespaces(SubscriptionDescription subscriptionDescription, string sqlFilter, INamespaceManagerInternal namespaceManager)
         {
-            var rules = await namespaceManager.GetRules(subscriptionDescription).ConfigureAwait(false);
-            if (rules.First().Filter is SqlFilter filter && !filter.SqlExpression.Contains(sqlFilter))
+            var foundRules = await namespaceManager.GetRules(subscriptionDescription).ConfigureAwait(false);
+            var rules = foundRules as RuleDescription[] ?? foundRules.ToArray();
+
+            if (rules.First().Filter is SqlFilter filter)
             {
-                logger.Debug("Looks like this subscription name is already taken as the sql filter does not match the subscribed event name.");
-                return true;
+                if (!filter.SqlExpression.Contains(sqlFilter))
+                {
+                    logger.Debug("Looks like this subscription name is already taken as the sql filter does not match the subscribed event name.");
+                    return true;
+                }
+
+                if (sqlFilter.Length != filter.SqlExpression.Length && rules.Length == 1)
+                {
+                    logger.Info($"SQL filter of the existing subscription '{subscriptionDescription.Name}' should be optimized.\nUpdate Rule filter from \"{filter.SqlExpression}\" to \"{sqlFilter}\".");
+                }
             }
 
             return false;


### PR DESCRIPTION
Fixes #811 

## In scope

- Do not create duplicate subscription.
- Log info message advising what subscriptions can be optimized by updating SQL Rule, providing an optimized filter SQL expression.
- Test to verify subscriptions are not duplicated when a previously created subscription with transport version 8 or earlier already exist.

## Out of scope

- Automated SQL Rule optimization