### PR TITLE
Hotfix 9.0.5

### DIFF
--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
@@ -43,7 +43,7 @@
         async Task<bool> SubscriptionIsReusedAcrossDifferentNamespaces(SubscriptionDescription subscriptionDescription, string sqlFilter, INamespaceManagerInternal namespaceManager)
         {
             var rules = await namespaceManager.GetRules(subscriptionDescription).ConfigureAwait(false);
-            if (rules.First().Filter is SqlFilter filter && filter.SqlExpression != sqlFilter)
+            if (rules.First().Filter is SqlFilter filter && !filter.SqlExpression.Contains(sqlFilter))
             {
                 logger.Debug("Looks like this subscription name is already taken as the sql filter does not match the subscribed event name.");
                 return true;

--- a/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
+++ b/src/Transport/Creation/AzureServiceBusSubscriptionCreatorV6.cs
@@ -42,11 +42,21 @@
 
         async Task<bool> SubscriptionIsReusedAcrossDifferentNamespaces(SubscriptionDescription subscriptionDescription, string sqlFilter, INamespaceManagerInternal namespaceManager)
         {
-            var rules = await namespaceManager.GetRules(subscriptionDescription).ConfigureAwait(false);
-            if (rules.First().Filter is SqlFilter filter && !filter.SqlExpression.Contains(sqlFilter))
+            var foundRules = await namespaceManager.GetRules(subscriptionDescription).ConfigureAwait(false);
+            var rules = foundRules as RuleDescription[] ?? foundRules.ToArray();
+
+            if (rules.First().Filter is SqlFilter filter)
             {
-                logger.Debug("Looks like this subscription name is already taken as the sql filter does not match the subscribed event name.");
-                return true;
+                if (!filter.SqlExpression.Contains(sqlFilter))
+                {
+                    logger.Debug("Looks like this subscription name is already taken as the sql filter does not match the subscribed event name.");
+                    return true;
+                }
+
+                if (sqlFilter.Length != filter.SqlExpression.Length && rules.Length == 1)
+                {
+                    logger.Info($"SQL filter of the existing subscription '{subscriptionDescription.Name}' should be optimized.\nUpdate Rule filter from \"{filter.SqlExpression}\" to \"{sqlFilter}\".");
+                }
             }
 
             return false;


### PR DESCRIPTION
## Who's affected

Anyone using endpoint-oriented topology with the legacy Azure Service Bus transport version 9 and above.

## Symptoms

When a subscribing endpoint creates its subscriptions, a duplicate subscription is created for each event. While subscriber is listening to only one of those, messages in the duplicate subscription are accumulated and could cause event overflow, impacting the entire namespace performance. Eventually, this can lead to degradation and interruption of the normal service operation.

## Workaround

A possible workaround is to manually modify the default rule for the original subscription to match the default rule of the duplicate subscription. After doing this, the duplicate subscription can be deleted. When the endpoint restarts it will no longer create the duplicate subscription. 
_Credit: @onesadjam_

## Will be there duplicate messages?

No. There will be no duplicated delivered to the subscribers as subscriber will only receive from a single subscription.

## Will be there duplicate messages in the migration mode?

No. There will be no duplicates delivered to the subscribers while the system is in the [migration mode](https://docs.particular.net/transports/azure-service-bus/legacy/migration).