### PR TITLE
Exceptions in recoverability policy do not trigger critical error

### DIFF
--- a/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
+++ b/src/Tests/Receiving/When_receiving_incomingmessages_from_queues.cs
@@ -192,7 +192,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Receiving
                     return TaskEx.Completed;
                 },
                 null,
-                exception =>
+                (message, exception) =>
                 {
                     ex = exception;
 

--- a/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
+++ b/src/Tests/Seam/When_message_pump_is_failing_to_receive_messages.cs
@@ -152,7 +152,7 @@
                 onError = func;
             }
 
-            public void OnCritical(Action<Exception> action)
+            public void SetCriticalError(CriticalError criticalError)
             {
             }
 

--- a/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/Config/AzureServiceBusTransportInfrastructure.cs
@@ -102,6 +102,11 @@
 
         public override Task Stop()
         {
+            if (messagingFactoryLifeCycleManager == null)
+            {
+                return Task.FromResult(0);
+            }
+
             return messagingFactoryLifeCycleManager.CloseAll();
         }
 

--- a/src/Transport/Receiving/INotifyIncomingMessages.cs
+++ b/src/Transport/Receiving/INotifyIncomingMessages.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     interface INotifyIncomingMessagesInternal
     {
-        void Initialize(EntityInfoInternal entity, Func<IncomingMessageDetailsInternal, ReceiveContextInternal, Task> callback, Func<Exception, Task> errorCallback, Action<Exception> onCritical, Func<ErrorContext, Task<ErrorHandleResult>> processingFailureCallback, int maximumConcurrency);
+        void Initialize(EntityInfoInternal entity, Func<IncomingMessageDetailsInternal, ReceiveContextInternal, Task> callback, Func<Exception, Task> errorCallback, Action<string, Exception> raiseCriticalErrorAction, Func<ErrorContext, Task<ErrorHandleResult>> processingFailureCallback, int maximumConcurrency);
 
         void Start();
         Task Stop();

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -75,7 +75,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             topologyOperator.OnError(exception => circuitBreaker?.Failure(exception));
             topologyOperator.OnProcessingFailure(onError);
-            topologyOperator.OnCritical(exception => criticalError.Raise("Failed to receive message from Azure Service Bus.", exception));
+            topologyOperator.SetCriticalError(criticalError);
 
             return TaskEx.Completed;
         }

--- a/src/Transport/Topology/IOperateTopology.cs
+++ b/src/Transport/Topology/IOperateTopology.cs
@@ -29,7 +29,7 @@
         void OnIncomingMessage(Func<IncomingMessageDetailsInternal, ReceiveContextInternal, Task> func);
 
         void OnError(Func<Exception, Task> func);
-        void OnCritical(Action<Exception> action);
+        void SetCriticalError(CriticalError criticalError);
 
         void OnProcessingFailure(Func<ErrorContext, Task<ErrorHandleResult>> onError);
     }

--- a/src/Transport/Topology/MetaModel/NamespaceInfo.cs
+++ b/src/Transport/Topology/MetaModel/NamespaceInfo.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
 
+    /// <summary></summary>
     public partial class NamespaceInfo : IEquatable<NamespaceInfo>
     {
         /// <summary></summary>

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -75,9 +75,9 @@ namespace NServiceBus.Transport.AzureServiceBus
             onError = func;
         }
 
-        public void OnCritical(Action<Exception> action)
+        public void SetCriticalError(CriticalError criticalError)
         {
-            onCriticalError = action;
+            this.criticalError = criticalError;
         }
 
         public void OnProcessingFailure(Func<ErrorContext, Task<ErrorHandleResult>> func)
@@ -97,7 +97,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 var notifier = notifiers.GetOrAdd(entity, e =>
                 {
                     var n = CreateNotifier(entity.Type);
-                    n.Initialize(e, onMessage, onError, onCriticalError, onProcessingFailure, maxConcurrency);
+                    n.Initialize(e, onMessage, onError, criticalError.Raise, onProcessingFailure, maxConcurrency);
                     return n;
                 });
 
@@ -146,6 +146,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         MessageReceiverCreator messageReceiverCreator;
         BrokeredMessagesToIncomingMessagesConverter brokeredMessageConverter;
         MessageReceiverNotifierSettings messageReceiverNotifierSettings;
-        Action<Exception> onCriticalError;
+        CriticalError criticalError;
     }
 }

--- a/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
+++ b/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
@@ -12,7 +12,7 @@ class ConfigureAzureServiceBusTransportInfrastructure : IConfigureTransportInfra
     {
         settings.Set("Transport.ConnectionString", Environment.GetEnvironmentVariable("AzureServiceBus.ConnectionString"));
         var connectionString = settings.Get<string>("Transport.ConnectionString");
-        settings.Set<Conventions>(new Conventions());
+        settings.Set(new Conventions());
         settings.Set(WellKnownConfigurationKeys.Core.MainSerializerSettingsKey, Tuple.Create<SerializationDefinition, SettingsHolder>(new XmlSerializer(), settings));
         settings.Set("NServiceBus.SharedQueue", settings.Get("NServiceBus.Routing.EndpointName"));
         var topologyName = Environment.GetEnvironmentVariable("AzureServiceBusTransport.Topology", EnvironmentVariableTarget.User);

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.2.0-beta0079" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />


### PR DESCRIPTION
Backport of fix from #818

## Who's affected
Anyone using the transport.

## Symptoms
Exceptions thrown in recoverability policy are not propagated as critical error and hide the underlying infrastructure problems that user code could be responding to.

## Description
By not properly handling exceptions when the recoverability policy throws, and not raising a critical error, the transport does not allow taking an action when the underlying messaging infrastructure is partially failing.