### PR TITLE
Exceptions in recoverability policy do not trigger critical error

### DIFF
--- a/src/Transport/Receiving/INotifyIncomingMessages.cs
+++ b/src/Transport/Receiving/INotifyIncomingMessages.cs
@@ -15,4 +15,9 @@ namespace NServiceBus.Transport.AzureServiceBus
         void Start();
         Task Stop();
     }
+
+    interface INotifyIncomingMessagesWithCriticalError : INotifyIncomingMessages
+    {
+        CriticalError CriticalError { get; set; }
+    }
 }

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -67,8 +67,12 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             topologyOperator.OnError(exception => circuitBreaker.Failure(exception));
             topologyOperator.OnProcessingFailure(onError);
-            container.Register<CriticalError>(() => criticalError);
 
+            if (topologyOperator is IOperateTopology2)
+            {
+                ((IOperateTopology2)topologyOperator).Init(criticalError);
+            }
+       
             return TaskEx.Completed;
         }
 

--- a/src/Transport/Seam/MessagePump.cs
+++ b/src/Transport/Seam/MessagePump.cs
@@ -67,6 +67,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             topologyOperator.OnError(exception => circuitBreaker.Failure(exception));
             topologyOperator.OnProcessingFailure(onError);
+            container.Register<CriticalError>(() => criticalError);
 
             return TaskEx.Completed;
         }

--- a/src/Transport/Topology/IOperateTopology.cs
+++ b/src/Transport/Topology/IOperateTopology.cs
@@ -34,4 +34,9 @@
 
         void OnProcessingFailure(Func<ErrorContext, Task<ErrorHandleResult>> onError);
     }
+
+    interface IOperateTopology2 : IOperateTopology
+    {
+        void Init(CriticalError criticalError);
+    }
 }

--- a/src/Transport/Topology/TopologyOperator.cs
+++ b/src/Transport/Topology/TopologyOperator.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Threading.Tasks;
     using Logging;
 
-    class TopologyOperator : IOperateTopology, IDisposable
+    class TopologyOperator : IOperateTopology2, IDisposable
     {
         public TopologyOperator(ITransportPartsContainer container)
         {
@@ -16,6 +16,11 @@ namespace NServiceBus.Transport.AzureServiceBus
         public void Dispose()
         {
             // Injected
+        }
+
+        public void Init(CriticalError criticalError)
+        {
+            this.criticalError = criticalError;
         }
 
         public void Start(TopologySection topologySection, int maximumConcurrency)
@@ -74,8 +79,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         void StartNotifiersFor(IEnumerable<EntityInfo> entities)
         {
-            var criticalError = container.Resolve<CriticalError>();
-
             foreach (var entity in entities)
             {
                 if (!entity.ShouldBeListenedTo)
@@ -134,5 +137,6 @@ namespace NServiceBus.Transport.AzureServiceBus
         ILog logger = LogManager.GetLogger(typeof(TopologyOperator));
 
         int maxConcurrency;
+        CriticalError criticalError;
     }
 }

--- a/src/TransportTests/App_Packages/NSB.TransportTests.6.2.0/When_on_error_throws.cs
+++ b/src/TransportTests/App_Packages/NSB.TransportTests.6.2.0/When_on_error_throws.cs
@@ -1,7 +1,9 @@
 ﻿namespace NServiceBus.TransportTests
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using NUnit.Framework;
     using Transport;
 
@@ -13,15 +15,23 @@
         [TestCase(TransportTransactionMode.TransactionScope)]
         public async Task Should_reinvoke_on_error_with_original_exception(TransportTransactionMode transactionMode)
         {
+            var loggerFactory = new TransportTestLoggerFactory();
+            LogManager.UseFactory(loggerFactory);
+
             var onErrorCalled = new TaskCompletionSource<ErrorContext>();
+            var criticalErrorCalled = false;
+            string criticalErrorMessage = null;
 
             OnTestTimeout(() => onErrorCalled.SetCanceled());
 
             var firstInvocation = true;
+            string nativeMessageId = null;
 
             await StartPump(
                 context =>
                 {
+                    nativeMessageId = context.MessageId;
+
                     throw new Exception("Simulated exception");
                 },
                 context =>
@@ -37,13 +47,21 @@
 
                     return Task.FromResult(ErrorHandleResult.Handled);
                 },
-                transactionMode);
+                transactionMode,
+                (message, exception) =>
+                {
+                    criticalErrorCalled = true;
+                    criticalErrorMessage = message;
+                });
 
             await SendMessage(InputQueueName);
 
             var errorContext = await onErrorCalled.Task;
 
-            Assert.AreEqual("Simulated exception", errorContext.Exception.Message);
+            Assert.AreEqual("Simulated exception", errorContext.Exception.Message, "Should retry the message");
+            Assert.True(criticalErrorCalled, "Should invoke critical error");
+            Assert.AreEqual($"Failed to execute recoverability policy for message with native ID: `{nativeMessageId}`", criticalErrorMessage, "Incorrect critical error message.");
+            Assert.False(loggerFactory.LogItems.Any(item => item.Level > LogLevel.Info));
         }
     }
 }

--- a/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureServiceBus.TransportTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="App_Packages\NSB.TransportTests.6.2.0\When_using_non_durable_delivery.cs" />
     <Compile Include="ConfigureAzureServiceBusTransportInfrastructure.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TransportTestLoggerFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/TransportTests/TransportTestLoggerFactory.cs
+++ b/src/TransportTests/TransportTestLoggerFactory.cs
@@ -1,0 +1,134 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Logging;
+    using NUnit.Framework;
+
+    public class TransportTestLoggerFactory : ILoggerFactory
+    {
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new TransportTestLogger(name, LogItems);
+        }
+
+        public List<LogItem> LogItems { get; } = new List<LogItem>();
+
+        public class LogItem
+        {
+            // ReSharper disable NotAccessedField.Global
+            public LogLevel Level;
+            public string Message;
+            // ReSharper restore NotAccessedField.Global
+        }
+
+        class TransportTestLogger : ILog
+        {
+            public TransportTestLogger(string name, List<LogItem> logItems)
+            {
+                this.name = name;
+                this.logItems = logItems;
+            }
+
+            public bool IsDebugEnabled { get; } = true;
+            public bool IsInfoEnabled { get; } = true;
+            public bool IsWarnEnabled { get; } = true;
+            public bool IsErrorEnabled { get; } = true;
+            public bool IsFatalEnabled { get; } = true;
+
+            public void Debug(string message)
+            {
+                Log(LogLevel.Debug, message);
+            }
+
+            public void Debug(string message, Exception exception)
+            {
+                Log(LogLevel.Debug, $"{message} {exception}");
+            }
+
+            public void DebugFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Debug, string.Format(format, args));
+            }
+
+            public void Info(string message)
+            {
+                Log(LogLevel.Info, message);
+            }
+
+            public void Info(string message, Exception exception)
+            {
+                Log(LogLevel.Info, $"{message} {exception}");
+            }
+
+            public void InfoFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Info, string.Format(format, args));
+            }
+
+            public void Warn(string message)
+            {
+                Log(LogLevel.Warn, message);
+            }
+
+            public void Warn(string message, Exception exception)
+            {
+                Log(LogLevel.Warn, $"{message} {exception}");
+            }
+
+            public void WarnFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Warn, string.Format(format, args));
+            }
+
+            public void Error(string message)
+            {
+                Log(LogLevel.Error, message);
+            }
+
+            public void Error(string message, Exception exception)
+            {
+                Log(LogLevel.Error, $"{message} {exception}");
+            }
+
+            public void ErrorFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Error, string.Format(format, args));
+            }
+
+            public void Fatal(string message)
+            {
+                Log(LogLevel.Fatal, message);
+            }
+
+            public void Fatal(string message, Exception exception)
+            {
+                Log(LogLevel.Fatal, $"{message} {exception}");
+            }
+
+            public void FatalFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Fatal, string.Format(format, args));
+            }
+
+            void Log(LogLevel level, string message)
+            {
+                logItems.Add(new LogItem
+                {
+                    Level = level,
+                    Message = message
+                });
+
+                TestContext.WriteLine($"{DateTime.Now:T} {level} {name}: {message}");
+            }
+
+            string name;
+            List<LogItem> logItems;
+        }
+    }
+}


### PR DESCRIPTION
Backport of fix from #818

## Who's affected
Anyone using the transport.

## Symptoms
Exceptions thrown in recoverability policy are not propagated as critical error and hide the underlying infrastructure problems that user code could be responding to.

## Description
By not properly handling exceptions when the recoverability policy throws, and not raising a critical error, the transport does not allow taking an action when the underlying messaging infrastructure is partially failing.