### PR TITLE
Fix failing topology tests

### DIFF
--- a/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_EndpointOrientedTopology.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     using AzureServiceBus;
     using NUnit.Framework;
     using Settings;
+    using TestUtils;
     using Transport;
     using Transport.AzureServiceBus;
 
@@ -13,7 +14,7 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     [Category("AzureServiceBus")]
     public class When_computing_EndpointOrientedTopology
     {
-        static string Connectionstring = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
+        static string Connectionstring = AzureServiceBusConnectionString.Value;
         static string Name = "name";
 
         [Test]

--- a/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
+++ b/src/Tests/Topology/Computation/When_computing_ForwardingTopology.cs
@@ -6,13 +6,14 @@ namespace NServiceBus.Azure.WindowsAzureServiceBus.Tests.Topology.Computation
     using AzureServiceBus;
     using Transport.AzureServiceBus;
     using NUnit.Framework;
+    using TestUtils;
     using Transport;
 
     [TestFixture]
     [Category("AzureServiceBus")]
     public class When_computing_ForwardingTopology
     {
-        const string Connectionstring = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somesecretkey";
+        string Connectionstring = AzureServiceBusConnectionString.Value;
         const string Name = "name";
 
         [Test]


### PR DESCRIPTION
These tests seem to fail because for some reason, the fake connection string that was used no longer works as the underlying SDK implementation changed.

I changed it to use the actual connection string that is available anyway, with that, the tests seem to pass.