### PR TITLE
Discard test

### DIFF
--- a/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -65,8 +65,8 @@ public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestE
 
             endpointOrientedTopology.RegisterPublisher(typeof(When_replying_to_saga_event.DidSomething), TestConventions.EndpointNamingConvention(typeof(When_replying_to_saga_event.SagaEndpoint)));
 
-            endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_base_event_from_other_saga.BaseEvent), TestConventions.EndpointNamingConvention(typeof(When_started_by_base_event_from_other_saga.Publisher)));
-            endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_event_from_another_saga.SomethingHappenedEvent), TestConventions.EndpointNamingConvention(typeof(When_started_by_event_from_another_saga.SagaThatPublishesAnEvent)));
+            endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_base_event_from_other_saga.IBaseEvent), TestConventions.EndpointNamingConvention(typeof(When_started_by_base_event_from_other_saga.Publisher)));
+            endpointOrientedTopology.RegisterPublisher(typeof(When_started_by_event_from_another_saga.ISomethingHappenedEvent), TestConventions.EndpointNamingConvention(typeof(When_started_by_event_from_another_saga.SagaThatPublishesAnEvent)));
 
             //When_two_sagas_subscribe_to_the_same_event
             endpointOrientedTopology.RegisterPublisher(typeof(When_two_sagas_subscribe_to_the_same_event.GroupPendingEvent), TestConventions.EndpointNamingConvention(typeof(When_two_sagas_subscribe_to_the_same_event.Publisher)));

--- a/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
+++ b/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
@@ -5,6 +5,7 @@
     using AcceptanceTesting;
     using Pipeline;
     using MessageMutator;
+    using NUnit.Framework;
 
     class TestIndependenceMutator : IMutateOutgoingTransportMessages
     {
@@ -35,9 +36,9 @@
 
         public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
-            if (!context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) || runId != testRunId)
+            if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) && runId != testRunId)
             {
-                Console.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
+                TestContext.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
                 return Task.FromResult(0);
             }
 

--- a/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureServiceBus.AcceptanceTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="WindowsAzure.ServiceBus" Version="6.1.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.4.4" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />


### PR DESCRIPTION
testing if the `TestIndependenceSkipBehavior` causes problems with the `When_retrying_message_from_error_queue` that is shipped with the 7.5 package because the control message won't get the test-run-id header.