### PR TITLE
Don't discard unmarked messages in AcceptanceTests

### DIFF
--- a/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
+++ b/src/AcceptanceTests/Infrastructure/TestIndependenceBehavior.cs
@@ -5,6 +5,7 @@
     using AcceptanceTesting;
     using Pipeline;
     using MessageMutator;
+    using NUnit.Framework;
 
     class TestIndependenceMutator : IMutateOutgoingTransportMessages
     {
@@ -35,9 +36,9 @@
 
         public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
-            if (!context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) || runId != testRunId)
+            if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) && runId != testRunId)
             {
-                Console.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
+                TestContext.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
                 return Task.FromResult(0);
             }
 


### PR DESCRIPTION
only discard messages that have a `TestRunId` header AND where this id doesn't match with the current test run. This prevents raw messages or control messages from being discarded although those are part of this test.

Preliminary requirement to make the additional test added through #1008 pass, as it sends a control message that doesn't go through the mutator logic in the test infrastructure that adds the necessary header.